### PR TITLE
ENH: Make FindNumpy.cmake Python3-compatible

### DIFF
--- a/src/cmake/FindNumpy.cmake
+++ b/src/cmake/FindNumpy.cmake
@@ -29,7 +29,7 @@ set(_python ${PYTHON_EXECUTABLE})
 #endif()
 
 execute_process (
-  COMMAND ${_python} -c "import os; os.environ['DISTUTILS_USE_SDK']='1'; import numpy.distutils; print numpy.distutils.misc_util.get_numpy_include_dirs()[0]"
+  COMMAND ${_python} -c "from __future__ import print_function; import os; os.environ['DISTUTILS_USE_SDK']='1'; import numpy.distutils; print(numpy.distutils.misc_util.get_numpy_include_dirs()[0])"
   OUTPUT_VARIABLE output
   OUTPUT_STRIP_TRAILING_WHITESPACE
   )


### PR DESCRIPTION
Your Python command to find out the Numpy version only works in Python 2 due to the usage of `print` as a statement (deprecated) rather than a function. With `from __future__ import print_function` (which is anyway recommended for future-proof code), the print function works in both Py2 and Py3.

That's what this PR does to fix the issue.