### PR TITLE
Functions to get the reconstructed image from the Reconstruction object.

### DIFF
--- a/src/include/stir/recon_buildblock/Reconstruction.h
+++ b/src/include/stir/recon_buildblock/Reconstruction.h
@@ -149,6 +149,13 @@ public:
   //! \details The counterpart of set_disable_output().
   void set_enable_output(bool _val);
 
+  //!
+  //! \brief get_reconstructed_image
+  //! \author Nikos Efthimiou
+  //! \return
+  //!
+  shared_ptr<TargetT > get_target_image();
+
   // parameters
  protected:
 
@@ -194,6 +201,11 @@ protected:
     \c set_post_processor_sptr() ).
   */
   virtual bool post_processing();
+
+  //!
+  //! \brief target_data_sptr
+  //!
+  shared_ptr<TargetT > target_data_sptr;
 
   //!
   //! \brief _disable_output

--- a/src/recon_buildblock/IterativeReconstruction.cxx
+++ b/src/recon_buildblock/IterativeReconstruction.cxx
@@ -396,8 +396,8 @@ reconstruct()
 {
   this->start_timers();
 
-  shared_ptr<TargetT > target_data_sptr(this->get_initial_data_ptr());
-  if (this->set_up(target_data_sptr) == Succeeded::no)
+  this->target_data_sptr.reset(this->get_initial_data_ptr());
+  if (this->set_up(this->target_data_sptr) == Succeeded::no)
     {
       this->stop_timers();
       return Succeeded::no;
@@ -405,7 +405,7 @@ reconstruct()
 
   this->stop_timers();
 
-  return this->reconstruct(target_data_sptr);
+  return this->reconstruct(this->target_data_sptr);
 }
 
 template <typename TargetT>

--- a/src/recon_buildblock/Reconstruction.cxx
+++ b/src/recon_buildblock/Reconstruction.cxx
@@ -176,6 +176,15 @@ set_enable_output(bool _val)
     this->_disable_output = _val;
 }
 
+template < typename TargetT>
+shared_ptr<TargetT >
+Reconstruction<TargetT>::
+get_target_image()
+{
+    if (!is_null_ptr(target_data_sptr))
+        return target_data_sptr;
+}
+
 template class Reconstruction<DiscretisedDensity<3,float> >; 
 template class Reconstruction<ParametricVoxelsOnCartesianGrid >; 
 END_NAMESPACE_STIR

--- a/src/recon_test/recontest.cxx
+++ b/src/recon_test/recontest.cxx
@@ -23,6 +23,7 @@
 #include "stir/Succeeded.h"
 #include "stir/CPUTimer.h"
 #include "stir/HighResWallClockTimer.h"
+#include "stir/IO/write_to_file.h"
 
 static void print_usage_and_exit()
 {
@@ -69,9 +70,12 @@ int main(int argc, const char *argv[])
     shared_ptr < Reconstruction < DiscretisedDensity < 3, float > > >
             reconstruction_method_sptr;
 
+    std::string output_filename;
+
     KeyParser parser;
     parser.add_start_key("Reconstruction");
     parser.add_stop_key("End Reconstruction");
+    parser.add_key("output filename prefix", &output_filename);
     parser.add_parsing_key("reconstruction method", &reconstruction_method_sptr);
     parser.parse(argv[1]);
 
@@ -79,11 +83,11 @@ int main(int argc, const char *argv[])
     t.reset();
     t.start();
 
+
     if (reconstruction_method_sptr->reconstruct() == Succeeded::yes)
     {
         t.stop();
         std::cout << "Total Wall clock time: " << t.value() << " seconds" << std::endl;
-        return Succeeded::yes;
     }
     else
     {
@@ -91,6 +95,20 @@ int main(int argc, const char *argv[])
         return Succeeded::no;
     }
 
+    //
+    // Save the reconstruction output from this location.
+    //
+
+    if (output_filename.length() > 0 )
+    {
+        shared_ptr  < DiscretisedDensity < 3, float > > reconstructed_image =
+                reconstruction_method_sptr->get_target_image();
+
+        OutputFileFormat<DiscretisedDensity < 3, float > >::default_sptr()->
+                write_to_file(output_filename, *reconstructed_image.get());
+    }
+
+    return Succeeded::yes;
     return EXIT_SUCCESS;
 }
 


### PR DESCRIPTION
Crucial functionality that I forgot to implement. 
Now target_image is global in the Reconstruction.h and the new function
Reconstruction::get_target_image() has been implemented.

Sorry. 