### PR TITLE
Add Travis CI configuration file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,22 @@
+language: cpp
+
+compiler:
+  - clang
+  - gcc
+
+dist: trusty
+
+sudo: false
+
+addons:
+  apt:
+    packages:
+    - libboost-all-dev
+    - swig
+
+script:
+  - mkdir build
+  - cd build
+  - cmake ..
+  - make -j 8
+  - make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,27 @@
+# Language selection
 language: cpp
 
+# Both clang and gcc can be tested. The more is the better.
 compiler:
   - clang
   - gcc
 
+# Latest supported Ubuntu
 dist: trusty
 
+# No need for sudo
 sudo: false
 
+
+# Compilation dependencies
 addons:
   apt:
     packages:
     - libboost-all-dev
     - swig
 
+# Actual compilation script
+# cmake parameters could be refined
 script:
   - mkdir build
   - cd build


### PR DESCRIPTION
Travis CI configuration file for integration.
There is a final step after the merge to get Travis to work:
the maintainer has to log into Travis with his github account to activate the service.
