### PR TITLE
Travis integration: recon_test_pack enabled, preparation for OpenMP

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,3 +44,5 @@ script:
   - ./run_test_simulate_and_recon_with_motion.sh
   - ./run_scatter_tests.sh
   - ./run_tests.sh --nointbp
+  - cd $TRAVIS_BUILD_DIR/recon_test_pack/SPECT
+  - ./run_SPECT_tests.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,4 +43,4 @@ script:
   - ./run_test_simulate_and_recon.sh
   - ./run_test_simulate_and_recon_with_motion.sh
   - ./run_scatter_tests.sh
-  - ./run_tests.sh
+  - ./run_tests.sh --nointbp

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,15 @@ compiler:
   - clang
   - gcc
 
-# Latest supported Ubuntu
+# Enviroment variables:
+global:
+  - BUILD_FLAGS="-DBUILD_SWIG_PYTHON=1 -DSTIR_MPI=0 -DBUILD_SWIG_MATLAB=0"
+env:
+  - EXTRA_BUILD_FLAGS="-DSTIR_OPENMP=0"
+# when OpenMP is enabled:
+# - EXTRA_BUILD_FLAGS="-DSTIR_OPENMP=1"
+
+# Ubuntu 14.04 LTS (trusty)
 dist: trusty
 
 # No need for sudo
@@ -17,14 +25,22 @@ sudo: false
 addons:
   apt:
     packages:
-    - libboost-all-dev
-    - swig
+      - libboost-all-dev
+      - swig
+      - libgomp1
 
 # Actual compilation script
-# cmake parameters could be refined
+
 script:
-  - mkdir build
+  - mkdir build install
   - cd build
-  - cmake ..
-  - make -j 8
+  - cmake $BUILD_FLAGS $EXTRA_BUILD_FLAGS ..
+  - make -j 8 all
   - make test
+  - make DESTDIR=$TRAVIS_BUILD_DIR/install all install
+  - export PATH=$PATH:$TRAVIS_BUILD_DIR/install/usr/local/bin
+  - cd $TRAVIS_BUILD_DIR/recon_test_pack
+  - ./run_test_simulate_and_recon.sh
+  - ./run_test_simulate_and_recon_with_motion.sh
+  - ./run_scatter_tests.sh
+  - ./run_tests.sh

--- a/recon_test_pack/SPECT/run_SPECT_tests.sh
+++ b/recon_test_pack/SPECT/run_SPECT_tests.sh
@@ -20,6 +20,13 @@
 # Author Kris Thielemans
 # 
 
+# Scripts should exit with error code when a test fails:
+
+if [ -n "$TRAVIS" ]; then
+    # The code runs inside Travis
+    set -e
+fi
+
 echo This script should work with STIR version 3.0. If you have
 echo a later version, you might have to update your test pack.
 echo Please check the web site.

--- a/recon_test_pack/run_ecat_tests.sh
+++ b/recon_test_pack/run_ecat_tests.sh
@@ -21,6 +21,9 @@
 #      
 # Author Kris Thielemans
 
+# Scripts should exit with error code when a test fails:
+set -e
+
 echo This script should work with STIR version 2.3, 2.4 and 3.0. If you have
 echo a later version, you might have to update your test pack.
 echo Please check the web site.

--- a/recon_test_pack/run_ecat_tests.sh
+++ b/recon_test_pack/run_ecat_tests.sh
@@ -22,7 +22,10 @@
 # Author Kris Thielemans
 
 # Scripts should exit with error code when a test fails:
-set -e
+if [ -n "$TRAVIS" ]; then
+    # The code runs inside Travis
+    set -e
+fi
 
 echo This script should work with STIR version 2.3, 2.4 and 3.0. If you have
 echo a later version, you might have to update your test pack.

--- a/recon_test_pack/run_scatter_tests.sh
+++ b/recon_test_pack/run_scatter_tests.sh
@@ -20,6 +20,9 @@
 # Author Kris Thielemans
 # 
 
+# Scripts should exit with error code when a test fails:
+set -e
+
 echo This script should work with STIR version 2.3, 2.4 and 3.0. If you have
 echo a later version, you might have to update your test pack.
 echo Please check the web site.

--- a/recon_test_pack/run_scatter_tests.sh
+++ b/recon_test_pack/run_scatter_tests.sh
@@ -21,7 +21,10 @@
 # 
 
 # Scripts should exit with error code when a test fails:
-set -e
+if [ -n "$TRAVIS" ]; then
+    # The code runs inside Travis
+    set -e
+fi
 
 echo This script should work with STIR version 2.3, 2.4 and 3.0. If you have
 echo a later version, you might have to update your test pack.

--- a/recon_test_pack/run_test_simulate_and_recon.sh
+++ b/recon_test_pack/run_test_simulate_and_recon.sh
@@ -22,7 +22,10 @@
 # 
 
 # Scripts should exit with error code when a test fails:
-set -e
+if [ -n "$TRAVIS" ]; then
+    # The code runs inside Travis
+    set -e
+fi
 
 echo This script should work with STIR version 2.2, 2.3, 2.4 and 3.0. If you have
 echo a later version, you might have to update your test pack.

--- a/recon_test_pack/run_test_simulate_and_recon.sh
+++ b/recon_test_pack/run_test_simulate_and_recon.sh
@@ -21,6 +21,9 @@
 # Author Kris Thielemans
 # 
 
+# Scripts should exit with error code when a test fails:
+set -e
+
 echo This script should work with STIR version 2.2, 2.3, 2.4 and 3.0. If you have
 echo a later version, you might have to update your test pack.
 echo Please check the web site.

--- a/recon_test_pack/run_test_simulate_and_recon_with_motion.sh
+++ b/recon_test_pack/run_test_simulate_and_recon_with_motion.sh
@@ -23,6 +23,9 @@
 # Author Kris Thielemans
 # 
 
+# Scripts should exit with error code when a test fails:
+set -e
+
 echo This script should work with STIR version 2.4 and 3.0. If you have
 echo a later version, you might have to update your test pack.
 echo Please check the web site.

--- a/recon_test_pack/run_test_simulate_and_recon_with_motion.sh
+++ b/recon_test_pack/run_test_simulate_and_recon_with_motion.sh
@@ -24,7 +24,10 @@
 # 
 
 # Scripts should exit with error code when a test fails:
-set -e
+if [ -n "$TRAVIS" ]; then
+    # The code runs inside Travis
+    set -e
+fi
 
 echo This script should work with STIR version 2.4 and 3.0. If you have
 echo a later version, you might have to update your test pack.

--- a/recon_test_pack/run_tests.sh
+++ b/recon_test_pack/run_tests.sh
@@ -21,6 +21,9 @@
 #      
 # Author Kris Thielemans
 
+# Scripts should exit with error code when a test fails:
+set -e
+
 echo This script should work with STIR version 2.1, 2.2, 2.3, 2.4 and 3.0. If you have
 echo a later version, you might have to update your test pack.
 echo Please check the web site.

--- a/recon_test_pack/run_tests.sh
+++ b/recon_test_pack/run_tests.sh
@@ -22,7 +22,10 @@
 # Author Kris Thielemans
 
 # Scripts should exit with error code when a test fails:
-set -e
+if [ -n "$TRAVIS" ]; then
+    # The code runs inside Travis
+    set -e
+fi
 
 echo This script should work with STIR version 2.1, 2.2, 2.3, 2.4 and 3.0. If you have
 echo a later version, you might have to update your test pack.

--- a/recon_test_pack/simulate_data.sh
+++ b/recon_test_pack/simulate_data.sh
@@ -20,6 +20,9 @@
 # Author Kris Thielemans
 # 
 
+# Scripts should exit with error code when a test fails:
+set -e
+
 if [ $# -ne 3 ]; then
   echo "Usage: `basename $0` emission_image attenuation_image template_sino"
   echo "Creates my_prompts.hs my_randoms.hs my_acfs.hs my_additive_sinogram.hs "

--- a/recon_test_pack/simulate_data.sh
+++ b/recon_test_pack/simulate_data.sh
@@ -21,7 +21,10 @@
 # 
 
 # Scripts should exit with error code when a test fails:
-set -e
+if [ -n "$TRAVIS" ]; then
+    # The code runs inside Travis
+    set -e
+fi
 
 if [ $# -ne 3 ]; then
   echo "Usage: `basename $0` emission_image attenuation_image template_sino"

--- a/recon_test_pack/simulate_scatter.sh
+++ b/recon_test_pack/simulate_scatter.sh
@@ -20,7 +20,10 @@
 # 
 
 # Scripts should exit with error code when a test fails:
-set -e
+if [ -n "$TRAVIS" ]; then
+    # The code runs inside Travis
+    set -e
+fi
 
 if [ $# -ne 4 ]; then
   echo "Usage: `basename $0` output_prefix emission_image attenuation_image template_sino"

--- a/recon_test_pack/simulate_scatter.sh
+++ b/recon_test_pack/simulate_scatter.sh
@@ -19,6 +19,9 @@
 # Author Kris Thielemans
 # 
 
+# Scripts should exit with error code when a test fails:
+set -e
+
 if [ $# -ne 4 ]; then
   echo "Usage: `basename $0` output_prefix emission_image attenuation_image template_sino"
   exit 1


### PR DESCRIPTION
These two commits enable automatic tests after the compilation.
OpenMP tests at the moment fail, so OpenMP compilation is not enabled (and would be tricky with clang because reliable openmp requires at least clang 3.8 which is not yet present in Travis).

Travis shows a test error, which is fixed in PR#27. (Merge first PR#27, then this request.) 