### PR TITLE
Travis CI: Enabling OS X support, fixing 'expr substr' bug.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,11 @@ compiler:
   - clang
   - gcc
 
+# Cross-operating system test
+os:
+  - linux
+  - osx
+
 # Enviroment variables:
 global:
   - BUILD_FLAGS="-DBUILD_SWIG_PYTHON=1 -DSTIR_MPI=0 -DBUILD_SWIG_MATLAB=0"

--- a/recon_test_pack/SPECT/run_SPECT_tests.sh
+++ b/recon_test_pack/SPECT/run_SPECT_tests.sh
@@ -135,7 +135,7 @@ for reconpar in FBP2D OSEM_2DPSF OSEM_3DPSF; do
     output_image=${output_filename}.hv
 
     # horrible way to replace "out" with "org" (as we don't want to rely on bash)
-    org_output_image=out`expr substr ${output_image} 4 100`
+    org_output_image=out`echo ${output_image}|cut -c 4-`
 
     if compare_image ${org_output_image} ${output_image}
     then


### PR DESCRIPTION
There are plenty of ways to fix the 'expr substr' bug:
cut, awk, sed, etc.
Cut is standardized among unixes, so I chose this one, and I also removed the unnecessary length parameter,  it will process the whole string, regardless of its size.

After fixing this bug, the OS X support can be enabled.