### PR TITLE
Fixing header guard bug.

### DIFF
--- a/src/include/stir/Shape/Ellipsoid.h
+++ b/src/include/stir/Shape/Ellipsoid.h
@@ -25,7 +25,7 @@
   \author Kris Thielemans
 */
 #ifndef __stir_Shape_Ellipsoid_h__
-#define __stir_Shape_Elliposoid_h__
+#define __stir_Shape_Ellipsoid_h__
 
 
 #include "stir/RegisteredParsingObject.h"


### PR DESCRIPTION
That's a quite trivial bug, but it is a good occasion to discuss something related:
shouldn't we aim more modern c++ constructs?

Like  #pragma once 
which would eliminate this kind of errors, 
(See https://en.wikipedia.org/wiki/Pragma_once )
or the c++11 features like the auto specifier,  constexpr,  or range-based loops?
