### PR TITLE
Cosmetic fixes and some leaks.

### DIFF
--- a/src/IO/stir_AVW.cxx
+++ b/src/IO/stir_AVW.cxx
@@ -153,6 +153,7 @@ AVW_Volume_to_VoxelsOnCartesianGrid(AVW_Volume const* const avw_volume,
     {
       warning("AVW_Volume_to_VoxelsOnCartesianGrid: unsupported data type %d\n",
         avw_volume->DataType);
+      delete volume_ptr;
       return 0;
     }
   }

--- a/src/IO/stir_ecat7.cxx
+++ b/src/IO/stir_ecat7.cxx
@@ -1585,6 +1585,7 @@ ECAT7_to_VoxelsOnCartesianGrid(const string& ECAT7_filename,
       warning("%s: cannot open %s using C++ ifstream.\n"
 	      "%s",  
 	      warning_prefix, ECAT7_filename.c_str(), warning_suffix); 
+      delete image_ptr;
       return 0;
     }
 
@@ -1595,7 +1596,7 @@ ECAT7_to_VoxelsOnCartesianGrid(const string& ECAT7_filename,
 	      "error seeking to position of data.\n"
 	      "%s",  
 	      warning_prefix, ECAT7_filename.c_str(), warning_suffix); 
-
+      delete image_ptr;
       return 0;
     }
   
@@ -1608,7 +1609,7 @@ ECAT7_to_VoxelsOnCartesianGrid(const string& ECAT7_filename,
 		"error in reading data with convertion to floats.\n",
 		"%s", 
 		warning_prefix, ECAT7_filename.c_str(), warning_suffix); 
-
+	delete image_ptr;
 	return 0;
       }
   }

--- a/src/local/utilities/show_ecat7_header.cxx
+++ b/src/local/utilities/show_ecat7_header.cxx
@@ -195,11 +195,11 @@ dump_subheader(MatrixFile * mptr,
 
 int main(int argc, char *argv[])
 {
-  char cti_name[1000];
+  std::string cti_name;
   
   if(argc==2)
   {
-    strcpy(cti_name, argv[1]);
+    cti_name=argv[1];
   }  
   else 
   {
@@ -207,15 +207,14 @@ int main(int argc, char *argv[])
         << "Usage: \n"
 	<< "\t" << argv[0] << "  ECAT7_name \n\n"
 	<< "I will now ask you the same info interactively...\n\n";
-    ask_filename_with_extension(cti_name,"Name of the ECAT7 file? ",
-        ".scn");
+    cti_name=ask_filename_with_extension("Name of the ECAT7 file? ", ".scn");
   }
 
 
   MatrixFile *mptr=
-    matrix_open( cti_name, MAT_READ_ONLY, MAT_UNKNOWN_FTYPE);
+    matrix_open( cti_name.c_str(), MAT_READ_ONLY, MAT_UNKNOWN_FTYPE);
   if (!mptr) {
-    matrix_perror(cti_name);
+    matrix_perror(cti_name.c_str());
     exit(EXIT_FAILURE);
   }
   

--- a/src/recon_buildblock/Reconstruction.cxx
+++ b/src/recon_buildblock/Reconstruction.cxx
@@ -181,8 +181,7 @@ shared_ptr<TargetT >
 Reconstruction<TargetT>::
 get_target_image()
 {
-    if (!is_null_ptr(target_data_sptr))
-        return target_data_sptr;
+    return target_data_sptr;
 }
 
 template class Reconstruction<DiscretisedDensity<3,float> >; 

--- a/src/test/modelling/test_modelling.cxx
+++ b/src/test/modelling/test_modelling.cxx
@@ -92,8 +92,8 @@ void modellingTests::run_tests()
 
       PlasmaData::const_iterator cur_iter_1, cur_iter_2;
 
-      for (cur_iter_1=file_plasma_data.begin(), cur_iter_2=testing_plasma_data.begin(); 
-	   cur_iter_1!=file_plasma_data.end(), cur_iter_2!=testing_plasma_data.end() ; 
+      for (cur_iter_1=file_plasma_data.begin(), cur_iter_2=testing_plasma_data.begin();
+	   cur_iter_1!=file_plasma_data.end() && cur_iter_2!=testing_plasma_data.end();
 	   ++cur_iter_1, ++cur_iter_2)
 	{
 	  check_if_equal((*cur_iter_1).get_time_in_s(),(*cur_iter_2).get_time_in_s(), "Check Reading Time of PlasmaData ");
@@ -161,8 +161,8 @@ void modellingTests::run_tests()
     testing_plasma_data.decay_correct_PlasmaData();
     PlasmaData::const_iterator cur_iter_1, cur_iter_2;
     
-    for (cur_iter_1=sample_plasma_data_in_frames.begin()+16, cur_iter_2=testing_plasma_data.begin(); 
-	   cur_iter_1!=sample_plasma_data_in_frames.end(), cur_iter_2!=testing_plasma_data.end() ; 
+    for (cur_iter_1=sample_plasma_data_in_frames.begin()+16, cur_iter_2=testing_plasma_data.begin();
+	   cur_iter_1!=sample_plasma_data_in_frames.end() && cur_iter_2!=testing_plasma_data.end();
 	   ++cur_iter_1, ++cur_iter_2)
 	{	  
 	  check_if_equal((*cur_iter_1).get_plasma_counts_in_kBq(),(*cur_iter_2).get_plasma_counts_in_kBq(),"Check Plasma when sampling PlasmaData into frames");

--- a/src/test/test_find_fwhm_in_image.cxx
+++ b/src/test/test_find_fwhm_in_image.cxx
@@ -39,7 +39,7 @@
 #include "stir/Coordinate3D.h"
 #include <iostream>
 #include <string>
-#include <strstream>
+#include <sstream>
 #include <list>
 
 #ifndef STIR_NO_NAMESPACES


### PR DESCRIPTION
Some cosmetic changes, e.g. switching from char array to strings,
and some memory leak fixes.
The leaks are not serious (the code will exit anyway) but
I try to reduce the number of warnings, so I could focus on the more serious ones.
Deprecated header import, deprecated source:  I think we don't need them anymore.

Let's see if the build passes the tests.