### PR TITLE
Fix unsigned long 32bit problem

### DIFF
--- a/src/include/stir/listmode/CListRecordSAFIR.h
+++ b/src/include/stir/listmode/CListRecordSAFIR.h
@@ -32,6 +32,8 @@
 #ifndef __stir_listmode_CListRecordSAFIR_H__
 #define __stir_listmode_CListRecordSAFIR_H__
 
+#include<cstint>
+
 #include "stir/listmode/CListRecord.h"
 #include "stir/DetectionPositionPair.h"
 #include "stir/Succeeded.h"
@@ -151,9 +153,9 @@ private:
 #if STIRIsNativeByteOrderBigEndian
 	unsigned type : 1;
 	unsigned reserved : 15;
-	unsigned long time : 48;
+	uint_least64_t time : 48;
 #else
-	unsigned long time : 48;
+	uint_least64_t time : 48;
 	unsigned reserved : 15;
 	unsigned type : 1;
 #endif

--- a/src/include/stir/listmode/CListRecordSAFIR.h
+++ b/src/include/stir/listmode/CListRecordSAFIR.h
@@ -32,8 +32,6 @@
 #ifndef __stir_listmode_CListRecordSAFIR_H__
 #define __stir_listmode_CListRecordSAFIR_H__
 
-#include<cstint>
-
 #include "stir/listmode/CListRecord.h"
 #include "stir/DetectionPositionPair.h"
 #include "stir/Succeeded.h"
@@ -145,7 +143,7 @@ public:
 	{ return static_cast<unsigned long>(time);  }
 	inline Succeeded set_time_in_millisecs(const unsigned long time_in_millisecs)
 	{
-		time = ((1UL<<49)-1) & static_cast<unsigned long>(time_in_millisecs);
+		time = ((1ULL<<49)-1) & static_cast<unsigned long>(time_in_millisecs);
 		return Succeeded::yes;
 	}
 private:
@@ -153,9 +151,9 @@ private:
 #if STIRIsNativeByteOrderBigEndian
 	unsigned type : 1;
 	unsigned reserved : 15;
-	uint_least64_t time : 48;
+	unsigned long long time : 48;
 #else
-	uint_least64_t time : 48;
+	unsigned long long time : 48;
 	unsigned reserved : 15;
 	unsigned type : 1;
 #endif


### PR DESCRIPTION
Dear Kris,
sorry for this problem. Here is a fix, the unsigned long long should be at least 64bit on all architectures as defined by the C++ standard. This then allows for the bit shift and a bit field of size 48.
I was wondering if this could somehow be checked by the Travis system. My naive try to add -m32 to the compiler flags does not work because then a lot of libraries are missing...
Cheers,
Jannis