### PR TITLE
Fix for LmToProjData (issue #61)-check if compatible template

### DIFF
--- a/src/include/stir/listmode/CListEventCylindricalScannerWithDiscreteDetectors.h
+++ b/src/include/stir/listmode/CListEventCylindricalScannerWithDiscreteDetectors.h
@@ -70,6 +70,13 @@ public:
   */
   inline virtual void get_bin(Bin& bin, const ProjDataInfo& proj_data_info) const;
 
+  //! This method checks if the template is valid for LmToProjData
+  /*! Used before the actual processing of the data (see issue #61), before calling get_bin()
+   *  Most scanners have listmode data that correspond to non arc-corrected data and
+   *  this check avoids a crash when an unsupported template is used as input.
+   */
+  inline virtual bool is_valid_template(const ProjDataInfo&) const;
+
  protected:
    shared_ptr<ProjDataInfoCylindricalNoArcCorr>
     get_uncompressed_proj_data_info_sptr() const

--- a/src/include/stir/listmode/CListEventCylindricalScannerWithDiscreteDetectors.inl
+++ b/src/include/stir/listmode/CListEventCylindricalScannerWithDiscreteDetectors.inl
@@ -87,4 +87,14 @@ get_bin(Bin& bin, const ProjDataInfo& proj_data_info) const
     bin.set_bin_value(1);
 }
 
+bool
+CListEventCylindricalScannerWithDiscreteDetectors::
+is_valid_template(const ProjDataInfo& proj_data_info) const
+{
+	if (dynamic_cast<ProjDataInfoCylindricalNoArcCorr const*>(&proj_data_info)!= 0)
+		return true;
+
+	return false;
+}
+
 END_NAMESPACE_STIR

--- a/src/include/stir/listmode/CListEventCylindricalScannerWithViewTangRingRingEncoding.h
+++ b/src/include/stir/listmode/CListEventCylindricalScannerWithViewTangRingRingEncoding.h
@@ -86,6 +86,13 @@ public CListEventCylindricalScannerWithDiscreteDetectors
     void 
     get_bin(Bin&, const ProjDataInfo&) const;
 
+  //! This method checks if the template is valid for LmToProjData
+  /*! Used before the actual processing of the data (see issue #61), before calling get_bin()
+   *  Most scanners have listmode data that correspond to non arc-corrected data and
+   *  this check avoids a crash when an unsupported template is used as input.
+   */
+  inline virtual bool is_valid_template(const ProjDataInfo&) const;
+
   inline void get_uncompressed_bin(Bin& bin) const;
 
 };

--- a/src/include/stir/listmode/CListEventCylindricalScannerWithViewTangRingRingEncoding.inl
+++ b/src/include/stir/listmode/CListEventCylindricalScannerWithViewTangRingRingEncoding.inl
@@ -113,6 +113,17 @@ get_bin(Bin& bin, const ProjDataInfo& proj_data_info) const
 }
 
 template <class Derived>
+bool
+CListEventCylindricalScannerWithViewTangRingRingEncoding<Derived>::
+is_valid_template(const ProjDataInfo& proj_data_info) const
+{
+	if (dynamic_cast<ProjDataInfoCylindricalNoArcCorr const*>(&proj_data_info)!= 0)
+		return true;
+
+	return false;
+}
+
+template <class Derived>
 void 
 CListEventCylindricalScannerWithViewTangRingRingEncoding<Derived>::
 get_uncompressed_bin(Bin& bin) const

--- a/src/include/stir/listmode/CListRecord.h
+++ b/src/include/stir/listmode/CListRecord.h
@@ -107,6 +107,15 @@ public:
     void
     get_bin(Bin& bin, const ProjDataInfo&) const;
 
+  //! This method checks if the template is valid for LmToProjData
+  /*! Used before the actual processing of the data (see issue #61), before calling get_bin()
+   *  Most scanners have listmode data that correspond to non arc-corrected data and
+   *  this check avoids a crash when an unsupported template is used as input.
+   */
+  virtual
+  bool
+  is_valid_template(const ProjDataInfo&) const =0;
+
 }; /*-coincidence event*/
 
 

--- a/src/include/stir/listmode/CListRecordSAFIR.h
+++ b/src/include/stir/listmode/CListRecordSAFIR.h
@@ -72,6 +72,12 @@ public:
 	inline CListEventSAFIR( shared_ptr<DetectorCoordinateMapFromFile> map ) : map(map) {}
 	//! Returns LOR corresponding to the given event.
 	inline virtual LORAs2Points<float> get_LOR() const;
+  //! This method checks if the template is valid for LmToProjData
+  /*! Used before the actual processing of the data (see issue #61), before calling get_bin()
+   *  Most scanners have listmode data that correspond to non arc-corrected data and
+   *  this check avoids a crash when an unsupported template is used as input.
+   */
+	inline virtual bool is_valid_template(const ProjDataInfo&) const {return true;}
 
 	//! Returns 0 if event is prompt and 1 if random/delayed
 	inline bool is_prompt()

--- a/src/listmode_buildblock/LmToProjData.cxx
+++ b/src/listmode_buildblock/LmToProjData.cxx
@@ -533,6 +533,10 @@ process_data()
   shared_ptr <CListRecord> record_sptr = lm_data_ptr->get_empty_record_sptr();
   CListRecord& record = *record_sptr;
 
+  if (!record.event().is_valid_template(*template_proj_data_info_ptr))
+	  error("The scanner template is not valid for LmToProjData. This might be because of unsupported arc correction.");
+
+
   /* Here starts the main loop which will store the listmode data. */
   for (current_frame_num = 1;
        current_frame_num<=frame_defs.get_num_frames();


### PR DESCRIPTION
see #61 

Jannis (@jafische), can you check if the fix in src/include/stir/listmode/CListRecordSAFIR.h is correct?
The new method "is_valid_template", used within lm_to_projdata to check whether the input template is compatible, returns always true in the case of CListEventSAFIR as the crash should never occur.
Are you happy with this modification?

Cheers,
Elise
