### PR TITLE
fixes #82

### DIFF
--- a/src/include/stir/IO/InputStreamFromROOTFile.inl
+++ b/src/include/stir/IO/InputStreamFromROOTFile.inl
@@ -57,9 +57,6 @@ Succeeded
 InputStreamFromROOTFile::
 set_get_position(const InputStreamFromROOTFile::SavedPosition& pos)
 {
-    if (current_position == nentries)
-        return Succeeded::no;
-
     assert(pos < saved_get_positions.size());
     if (saved_get_positions[pos] > nentries)
         current_position = nentries; // go to eof


### PR DESCRIPTION
With the prospect of handling TOF listmode unlisting properly, this fix adds the possibility to go back to the beginning of the ROOT listmode when the end of the file was already reached (e.g. in a TOF loop in LmToProjData where the file must be parsed as many times as the number of TOF bins).