### PR TITLE
AppVeyor integration

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,33 @@
+shallow_clone: true
+
+version: '{build}'
+
+os:
+  - Visual Studio 2015
+  - Visual Studio 2013
+
+platform:
+  - x64
+  - x86
+
+configuration:
+  - Release
+
+build:
+  verbosity: detailed
+
+environment:
+  BOOST_ROOT: C:\Libraries\boost_1_63_0
+  CMAKE_INSTALL_PREFIX: C:\projects\stir\install\
+
+build_script:
+  - mkdir build
+  - mkdir install
+  - cd build
+  - cmake.exe .. -DCMAKE_INSTALL_PREFIX="C:\projects\stir\install" -DCMAKE_BUILD_TYPE=%CONFIGURATION%  -DCMAKE_CONFIGURATION_TYPES=%CONFIGURATION% 
+  - cmake.exe --build . --config %CONFIGURATION%
+  - cmake.exe --build . --target install --config %CONFIGURATION%
+
+test_script:
+  - cd C:\projects\stir\build
+  - ctest -C %CONFIGURATION%

--- a/README.md
+++ b/README.md
@@ -17,3 +17,4 @@ This software is distributed under an open source license, see LICENSE.txt
 for details.
 
 
+[![Build Status](https://travis-ci.org/UCL/STIR.svg?branch=master)](https://travis-ci.org/UCL/STIR)


### PR DESCRIPTION
AppVeyor is a continuous integration platform, similar to Travis CI but it runs on Windows platforms.
This pull request adds configuration file to STIR.
The workflow for the integration:
- opening appveyor account (just log in with github)
- add project from github and grant permissions
- merge the pull request 
- check the AppVeyor results

At this moment the windows tests seem to be outdated compared to the linux tests.
So theoretically the scripts are called, but this part should be refined later.
However, the compilation part should work and it should detect build errors.

Current compilers: Visual Studio 2013 and 2015 with 32bit and 64bit support, but this list could be extended with a lot of other compilers (VS 2017, gcc, clang, etc.) 
For the complete feature set, see the AppVeyor documentation:
https://www.appveyor.com/docs/

One strange feature of the AppVeyor builds: the version number should be set in the config file, at this moment I set 3.1, so the builds will be 3.1.1, 3.1.2 and so on. 

