### PR TITLE
little bit of code modernization

### DIFF
--- a/src/buildblock/ProjDataInfoCylindricalNoArcCorr.cxx
+++ b/src/buildblock/ProjDataInfoCylindricalNoArcCorr.cxx
@@ -40,6 +40,8 @@
 #include <sstream>
 #endif
 
+#include <boost/static_assert.hpp>
+
 #ifndef STIR_NO_NAMESPACES
 using std::endl;
 using std::ends;
@@ -141,8 +143,6 @@ ProjDataInfoCylindricalNoArcCorr::parameter_info()  const
 }
 
 /*
-   TODO make compile time assert
-
    Warning:
    this code makes use of an implementation dependent feature:
    bit shifting negative ints to the right.
@@ -151,6 +151,8 @@ ProjDataInfoCylindricalNoArcCorr::parameter_info()  const
    This is ok on SUNs (gcc, but probably SUNs cc as well), Parsytec (gcc),
    Pentium (gcc, VC++) and probably every other system which uses
    the 2-complement convention.
+
+   Update: compile time assert is implemented.
 */
 
 /*!
@@ -173,8 +175,8 @@ void
 ProjDataInfoCylindricalNoArcCorr::
 initialise_uncompressed_view_tangpos_to_det1det2() const
 {
-  assert(-1 >> 1 == -1);
-  assert(-2 >> 1 == -1);
+  BOOST_STATIC_ASSERT(-1 >> 1 == -1);
+  BOOST_STATIC_ASSERT(-2 >> 1 == -1);
 
   const int num_detectors =
     get_scanner_ptr()->get_num_detectors_per_ring();
@@ -220,8 +222,8 @@ void
 ProjDataInfoCylindricalNoArcCorr::
 initialise_det1det2_to_uncompressed_view_tangpos() const
 {
-  assert(-1 >> 1 == -1);
-  assert(-2 >> 1 == -1);
+  BOOST_STATIC_ASSERT(-1 >> 1 == -1);
+  BOOST_STATIC_ASSERT(-2 >> 1 == -1);
 
   const int num_detectors =
     get_scanner_ptr()->get_num_detectors_per_ring();

--- a/src/buildblock/error.cxx
+++ b/src/buildblock/error.cxx
@@ -53,6 +53,8 @@ void error(const char *const s, ...)
   char tmp[size];
   const int returned_size= vsnprintf(tmp,size, s, ap);
   std::stringstream ss;
+  va_end(ap);
+
   if (returned_size<0)
 	  ss << "\nERROR: but error formatting error message" << std::endl;
   else

--- a/src/buildblock/warning.cxx
+++ b/src/buildblock/warning.cxx
@@ -53,6 +53,7 @@ void warning(const char *const s, ...)
   char tmp[size];
   const int returned_size= vsnprintf(tmp,size, s, ap);
   std::stringstream ss;
+  va_end(ap);
   if (returned_size < 0)
 	  ss << "\nWARNING: error formatting warning message" << std::endl;
   else

--- a/src/include/stir/common.h
+++ b/src/include/stir/common.h
@@ -103,7 +103,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <cmath>
-
+#include <boost/math/constants/constants.hpp>
 
 //*************** namespace macros
 #ifndef STIR_NO_NAMESPACES
@@ -295,7 +295,7 @@ START_NAMESPACE_STIR
 
 //! The constant pi to high precision.
 /*! \ingroup buildblock */
-const double _PI = 3.14159265358979323846264338327950288419716939937510;
+const double _PI = boost::math::constants::pi<double>();
 
 //! returns the square of a number, templated.
 /*! \ingroup buildblock */

--- a/src/recon_buildblock/SPECTUB_Tools.cxx
+++ b/src/recon_buildblock/SPECTUB_Tools.cxx
@@ -27,6 +27,7 @@
 #include <boost/math/special_functions/fpclassify.hpp>
 #include "stir/error.h"
 #include <boost/format.hpp>
+#include <boost/math/constants/constants.hpp>
 
 using namespace std;
 //using std::string;
@@ -48,10 +49,6 @@ namespace SPECTUB {
 #define minim(a,b) ((a)<=(b)?(a):(b))
 #define abs(a) ((a)>=0?(a):(-a))
 #define SIGN(a) (a<-EPSILON?-1:(a>EPSILON?1:0))
- 
-#ifndef M_PI
-#define M_PI 3.14159265
-#endif
 
 #define DELIMITER1 '#' //delimiter character in input parameter text file
 #define DELIMITER2 '%' //delimiter character in input parameter text file
@@ -561,7 +558,7 @@ float calc_sigma_v( voxel_type	vox, collim_type COL)
 void fill_ang ( angle_type *ang )
 {
 	float DX    = (float) 0.5 / wmh.psfres ;
-	float dg2rd = (float)M_PI / (float)180. ;
+	float dg2rd = boost::math::constants::pi<float>() / (float)180. ;
 	
 	for ( int i = 0; i < wmh.prj.Nang ; i++ ){
 		

--- a/src/recon_buildblock/SPECTUB_Weight3d.cxx
+++ b/src/recon_buildblock/SPECTUB_Weight3d.cxx
@@ -26,6 +26,7 @@
 #include "stir/recon_buildblock/SPECTUB_Weight3d.h"
 #include "stir/error.h"
 #include <boost/format.hpp>
+#include <boost/math/constants/constants.hpp>
 
 //system libraries
 #include <stdio.h>
@@ -44,10 +45,6 @@ namespace SPECTUB {
 #define abs(a) ((a)>=0?(a):(-a))
 #define SIGN(a) (a<-EPSILON?-1:(a>EPSILON?1:0))
  
-#ifndef M_PI
-#define M_PI 3.14159265
-#endif
-
 #define REF_DIST 5.    //reference distance for fanbeam PSF
 
 using namespace std;
@@ -462,7 +459,7 @@ void wm_size_estimation (int kOS,
 
 void calc_gauss( discrf_type *gaussdens )
 {
-	float K0 = (float)0.3989422863; //Normalization factor: 1/sqrt(2*M_PI)
+	const float K0 = 1.0f/boost::math::constants::root_two_pi<float>(); //Normalization factor: 1/sqrt(2*M_PI)
 	float x  = 0;
 	float g;
 	

--- a/src/test/test_ArrayFilter.cxx
+++ b/src/test/test_ArrayFilter.cxx
@@ -41,6 +41,7 @@
 #include "stir/stream.h"//XXX
 #include <iostream>
 #include <algorithm>
+#include <boost/static_assert.hpp>
 
 #ifdef DO_TIMINGS
 #include "stir/CPUTimer.h"
@@ -186,8 +187,8 @@ ArrayFilterTests::run_tests()
       const int kernel_half_length=30;
       const int DFT_kernel_size=256;
       // necessary to avoid aliasing in DFT
-      assert(DFT_kernel_size>=(kernel_half_length*2+1)*2);
-      assert(DFT_kernel_size>=2*size1+3);// note +3 as test grows the array
+      BOOST_STATIC_ASSERT(DFT_kernel_size>=(kernel_half_length*2+1)*2);
+      BOOST_STATIC_ASSERT(DFT_kernel_size>=2*size1+3);// note +3 as test grows the array
       Array<1,float> kernel_for_DFT(IndexRange<1>(0,DFT_kernel_size-1));
       Array<1,float> kernel_for_conv(IndexRange<1>(-kernel_half_length,kernel_half_length));
       for (int i=-kernel_half_length; i<kernel_half_length; ++i)
@@ -341,9 +342,9 @@ ArrayFilterTests::run_tests()
       const int kernel_half_length=14;
       const int DFT_kernel_size=64;
       // necessary to avoid aliasing in DFT
-      assert(DFT_kernel_size>=(kernel_half_length*2+1)*2);
-      assert(DFT_kernel_size>=2*size2+3);// note +3 as test grows the array
-      assert(DFT_kernel_size>=2*size1+3);// note +3 as test grows the array
+      BOOST_STATIC_ASSERT(DFT_kernel_size>=(kernel_half_length*2+1)*2);
+      BOOST_STATIC_ASSERT(DFT_kernel_size>=2*size2+3);// note +3 as test grows the array
+      BOOST_STATIC_ASSERT(DFT_kernel_size>=2*size1+3);// note +3 as test grows the array
       const Coordinate2D<int> sizes(DFT_kernel_size/2,DFT_kernel_size);
       Array<2,float> kernel_for_DFT(IndexRange2D(DFT_kernel_size/2,DFT_kernel_size));
       Array<2,float> kernel_for_conv(IndexRange2D(-(kernel_half_length/2),kernel_half_length/2,
@@ -397,10 +398,10 @@ ArrayFilterTests::run_tests()
       const int kernel_half_length=7;
       const int DFT_kernel_size=32;
       // necessary to avoid aliasing in DFT
-      assert(DFT_kernel_size>=(kernel_half_length*2+1)*2);
-      assert(DFT_kernel_size/2>=2*size1+3);// note +3 as test grows the array
-      assert(DFT_kernel_size>=2*size2+3);// note +3 as test grows the array
-      assert(DFT_kernel_size>=2*size3+3);// note +3 as test grows the array
+      BOOST_STATIC_ASSERT(DFT_kernel_size>=(kernel_half_length*2+1)*2);
+      BOOST_STATIC_ASSERT(DFT_kernel_size/2>=2*size1+3);// note +3 as test grows the array
+      BOOST_STATIC_ASSERT(DFT_kernel_size>=2*size2+3);// note +3 as test grows the array
+      BOOST_STATIC_ASSERT(DFT_kernel_size>=2*size3+3);// note +3 as test grows the array
       const Coordinate3D<int> sizes(DFT_kernel_size/2,DFT_kernel_size,DFT_kernel_size);
       Array<3,float> kernel_for_DFT(IndexRange3D(DFT_kernel_size/2,DFT_kernel_size,DFT_kernel_size));
       Array<3,float> kernel_for_conv(IndexRange3D(-(kernel_half_length/2),kernel_half_length/2,


### PR DESCRIPTION
Most part of the PR is code modernization.

First of all, vsnprintf is supported since VS 2005, and C99/C++11 compilers must implement it, 
so it is time to drop the ```#ifdef``` workarounds.

Second, some asserts could and should be replaced with compile time checks.

Third: "\n" should be replaced with std::endl. I didn't do it everywhere, there are 3.5 thousand such lines,
but it least I fixed them in the function I already edited for other reasons. 
(But if somebody has patience, there are gems like this: ```"...filename>\n"<<endl;```)

Fourth: M_PI, and similar constants shouldn't be defined locally but rather take it from a library. Visual Studio has/had issues with cmath, so let's use BOOST.
(Another big part should be: checking the arithmetic functions, especially atan, atan2 and acos, because their use is quite strange sometimes, but this remains a task for the future.)

Finally, there is a tiny bug about variadic function parameters: the va_start macro should have a va_end pair, but it is missing from one of the files.