### PR TITLE
Fix #87

### DIFF
--- a/src/include/stir/IO/SAFIRCListmodeInputFileFormat.h
+++ b/src/include/stir/IO/SAFIRCListmodeInputFileFormat.h
@@ -90,16 +90,17 @@ public:
 		std::ifstream par_file(filename.c_str());
 		std::string key;
 		std::getline(par_file, key, ':');
-		key.erase(std::remove_if(key.begin(), key.end(), is_whitespace), key.end());
-		if( !boost::iequals(key, std::string("CListModeDataSAFIRParameters")) ) { 
+		key = standardise_interfile_keyword(key);
+		if( key != std::string("clistmodedatasafir parameters")) { 
 			return false;
 		}
 
 		bool can_parse = actual_do_parsing(filename);
+		if( !can_parse ) return false;
 		std::ifstream data_file(listmode_filename.c_str(), std::ios::binary);
 		char* buffer = new char[32];
 		data_file.read(buffer, 32);
-		bool cr = (!strncmp(buffer, "MUPET CListModeData\0", 20) ||  !strncmp(buffer, "SAFIR CListModeData\0", 20)) && can_parse;
+		bool cr = (!strncmp(buffer, "MUPET CListModeData\0", 20) ||  !strncmp(buffer, "SAFIR CListModeData\0", 20));
 		
 		delete[] buffer;
 		return cr;
@@ -173,10 +174,6 @@ private:
 	bool file_exists( const std::string& filename) {
 		std::ifstream infile(filename.c_str());
 		return infile.good();
-	}
-
-	static const bool is_whitespace( unsigned char const c ) {
-		return std::isspace(c);
 	}
 
 };

--- a/src/include/stir/IO/SAFIRCListmodeInputFileFormat.h
+++ b/src/include/stir/IO/SAFIRCListmodeInputFileFormat.h
@@ -91,16 +91,18 @@ public:
 		std::string key;
 		std::getline(par_file, key, ':');
 		key = standardise_interfile_keyword(key);
-		if( key != std::string("clistmodedatasafir parameters")) { 
+		if( key != std::string("clistmodedatasafir parameters")) {
+			warning("SAFIRListModeInputFileFormat tried to read parameters from " + filename + "but it does not start with the correct key." );
 			return false;
 		}
-
-		bool can_parse = actual_do_parsing(filename);
-		if( !can_parse ) return false;
+		if( !actual_do_parsing(filename) ) return false;
 		std::ifstream data_file(listmode_filename.c_str(), std::ios::binary);
 		char* buffer = new char[32];
 		data_file.read(buffer, 32);
 		bool cr = (!strncmp(buffer, "MUPET CListModeData\0", 20) ||  !strncmp(buffer, "SAFIR CListModeData\0", 20));
+		if( !cr ) {
+			warning("SAFIRCListModeInputFileFormat tried to read file " + listmode_filename + " but it seems to have the wrong signature.");
+		}
 		
 		delete[] buffer;
 		return cr;


### PR DESCRIPTION
Hi Kris,
I have fixed the can_read issue. I have at the same time removed the ability to call can_read() with an ifstream as argument --> always returns false now as in the ECAT file format libraries. This makes it a bit cleaner and does not impair functionality as we probably always call the parser with a filename of the parameter file.
Your original suggestion did not work, because a) ParsingObject does not have the parse(...,write_warning) syntax, only KeyParser does, and b) Even KeyParser::parse(..., false) will print the warning in question (https://github.com/UCL/STIR/blob/master/src/buildblock/KeyParser.cxx#L270).
The code now checks for the CListModeDataSAFIR Parameter at the beginning of the file, whitespace is ignored. If this is successful, the file is parsed and the file signature in the binary file checked as done before.
Cheers, Jannis