### PR TITLE
_PI warning fix.

### DIFF
--- a/src/include/stir/common.h
+++ b/src/include/stir/common.h
@@ -295,7 +295,9 @@ START_NAMESPACE_STIR
 
 //! The constant pi to high precision.
 /*! \ingroup buildblock */
-const double _PI = boost::math::constants::pi<double>();
+#ifndef _PI
+#define _PI  boost::math::constants::pi<double>()
+#endif
 
 //! returns the square of a number, templated.
 /*! \ingroup buildblock */


### PR DESCRIPTION
This fixes the extra warning which were introduced by #102 and was mentioned #110.
It is a bit ugly, the correct behaviour would be to remove all of the _PI definitions, and replace them 
with boost's pi<>. Anyway, this is a reasonable workaround for now. 