### PR TITLE
Add missing include

### DIFF
--- a/src/test/test_GeneralisedPoissonNoiseGenerator.cxx
+++ b/src/test/test_GeneralisedPoissonNoiseGenerator.cxx
@@ -30,6 +30,7 @@
 #include "stir/GeneralisedPoissonNoiseGenerator.h"
 #include <boost/accumulators/accumulators.hpp>
 #include <boost/accumulators/statistics.hpp>
+#include <boost/format.hpp>
 #include <algorithm>
 #include <iostream>
 


### PR DESCRIPTION
With boost 1.63.0, this file won't compile without including boost/format.hpp.