### PR TITLE
Add default value for do_time_frame

### DIFF
--- a/src/listmode_buildblock/LmToProjData.cxx
+++ b/src/listmode_buildblock/LmToProjData.cxx
@@ -156,6 +156,7 @@ set_defaults()
   post_normalisation_ptr.reset(new TrivialBinNormalisation);
   do_pre_normalisation =0;
   num_events_to_store = 0;
+  do_time_frame = false; 
 
 }
 


### PR DESCRIPTION
Without this default, do_time_frame is (as far as I can tell) uninitialized and only might get set to true. This was causing num_events_to_store to be ignored with do_time_frame should have been false.