### PR TITLE
removed warning from SAFIRCListModeInputFileFormat::can_read, fixes #144

### DIFF
--- a/src/include/stir/IO/SAFIRCListmodeInputFileFormat.h
+++ b/src/include/stir/IO/SAFIRCListmodeInputFileFormat.h
@@ -92,7 +92,6 @@ public:
 		std::getline(par_file, key, ':');
 		key = standardise_interfile_keyword(key);
 		if( key != std::string("clistmodedatasafir parameters")) {
-			warning("SAFIRListModeInputFileFormat tried to read parameters from " + filename + "but it does not start with the correct key." );
 			return false;
 		}
 		if( !actual_do_parsing(filename) ) return false;


### PR DESCRIPTION
Hi Kris,
yes, sorry about that. Here is the pull request.
Cheers,
Jannis