### PR TITLE
Add checks if projectors/normalisation are used accordingly to how they were set up

### DIFF
--- a/documentation/release_3.1.htm
+++ b/documentation/release_3.1.htm
@@ -66,16 +66,22 @@ Benjamin Thomas (CIRC ASTAR and UCL), Yu-jung Tsai, Vesna Cuplov).
 
 <h2> Summary for end users (also to be read by developers)</h2>
 
-<h3>Important bug fixes</h3>
+<h3>Bbug fixes</h3>
 <ul>
 <li>bug fixed in writing of SPECT interfile headers: "direction of rotation" was set incorrect. This 
 affected output of forward_project (and stir_math -s). Reconstruction was not affected though.
 </li>
-<li>fix conversion from raw GATE (it was using the wrong segment-order and data-type).</li>
+<li>fix conversion from raw GATE using
+  <tt>conv_GATE_raw_ECAT_projdata_to_interfile</tt>(it was using the wrong segment-order and data-type).</li>
 <li>the function value of the quadratic prior value was inconsistent with its gradient. It is now
 divided by 2. This bug did not affect OSMAPOSL nor OSSPS, but did affect the value of the 
 objective function being printed out. This bug would cause major problems if you developed your
-own reconstruction algorithms that used the objective function value. (bug found by Yu-Jung Tsai).</li>
+  own reconstruction algorithms that used the objective function value. (bug found by Yu-Jung Tsai).</li>
+<li>minor bug fix in FBP3DRP. The determination of the rmin/rmax of the missing data was incorrect for 
+negative delta (the range was too narrow). In principle, this could
+have caused problems, but only when a projector was used where the
+segment symmetry is switched off.
+</li>
 </ul>
 
 <h3>New functionality</h3>

--- a/documentation/release_3.1.htm
+++ b/documentation/release_3.1.htm
@@ -278,7 +278,8 @@ In order to ensure backwards compatibility, at the moment, it is completely opti
   <code>GeneralisedPoissonNoiseGenerator</code>.
   </li>
  <li>Added the ability to <code>KeyParser</code> to parse <code>long int</code> numbers. Also add <code>remove_key</code>.
-  </li>
+ </li>
+ <li>Introduce <code>operator&gt;=</code> for <code>ProjDataInfo</code>.</li>
 </ul>
 
 <h3>Other code changes</h3>

--- a/documentation/release_3.1.htm
+++ b/documentation/release_3.1.htm
@@ -99,7 +99,6 @@ These are only minimally documented at the present stage unfortunately.
 <li>List-mode classes for Siemens ECAT8 (32-bit).</li>
 <li>add Verbosity level (currently only to be set from interactive languages)</li
 <li>Added the anatomical parallel level sets (PLS) prior. If an uniform anatomical image is provided it will work as a (smoothed) total variation (TV) prior </li>
-======
 <li>New input: GATE compatibility layer. ROOT files from cylindricalPET and ECAT simulated scanners can be imported as listmode files. Some simple options are provided, like exclude scattered or randoms. </li>
 <li>New header file, with .hroot extension is provided for ROOT files </li>
 <li><code>CListModeData</code> got a new function <code>get_total_number_of_events()</code>, BUT currently only <code>CListModeDataFromROOT</code> supports it. </li> 
@@ -109,6 +108,10 @@ These are only minimally documented at the present stage unfortunately.
     <li>added GeneralisedPoissonNoiseGenerator</li>
   </ul>
 </li>
+<li>Projection- and normalisation-related classes have had changes to make them much safer to use in an interactive
+  environment such as Python. The methods will now check if <code>set_up()</code> has been called
+  and if the images/projection data have the same characteristics as those used when the object was set-up.
+  </li>
 </ul>
 
 
@@ -250,6 +253,9 @@ from the above):</H2>
   is used. Finally, use the preprocessor define <code>MAKE_SHARED</code> as opposed to
   <code>std::make_shared</code>.
 </li>
+<li>Projection- and BinNormalisation-related derived classes now have to call <code>set_up()</code> of their base
+  class. Otherwise, you will get run-time errors saying that <code>set_up()</code> was not called.
+  </li>
 </ul>
 
 <h3>New functionality</h3>

--- a/documentation/release_3.1.htm
+++ b/documentation/release_3.1.htm
@@ -117,6 +117,7 @@ These are only minimally documented at the present stage unfortunately.
 <li>Projection- and normalisation-related classes have had changes to make them much safer to use in an interactive
   environment such as Python. The methods will now check if <code>set_up()</code> has been called
   and if the images/projection data have the same characteristics as those used when the object was set-up.
+  (Actually, projection data can be &quote;smaller&quote;, e.g. less segments).
   </li>
 </ul>
 

--- a/src/analytic/FBP3DRP/FBP3DRPReconstruction.cxx
+++ b/src/analytic/FBP3DRP/FBP3DRPReconstruction.cxx
@@ -164,7 +164,7 @@ static void find_rmin_rmax(int& rmin, int& rmax,
   // (i.e. y=0, x=-ring_radius)
   // use image coordinates first
   float z_in_image_coordinates =
-    -delta*num_planes_per_virtual_ring*num_virtual_rings_per_physical_ring*
+    -fabs(delta)*num_planes_per_virtual_ring*num_virtual_rings_per_physical_ring*
     (fovrad + proj_data_info_cyl.get_ring_radius())/(2*proj_data_info_cyl.get_ring_radius());
   // now shift it to the edge of the FOV 
   // (taking into account that z==get_min_z() is in the middle of the voxel)

--- a/src/buildblock/ProjDataInfo.cxx
+++ b/src/buildblock/ProjDataInfo.cxx
@@ -584,6 +584,31 @@ operator !=(const root_type& that) const
   return !((*this) == that);
 }
 
+bool
+ProjDataInfo::
+operator>=(const ProjDataInfo& proj_data_info) const
+{
+  if (typeid(*this) != typeid(proj_data_info))
+    return false;
+
+  const ProjDataInfo& larger_proj_data_info = *this;
+
+  if (larger_proj_data_info == proj_data_info)
+    return true;
+
+  if (proj_data_info.get_max_segment_num() > larger_proj_data_info.get_max_segment_num() ||
+      proj_data_info.get_min_segment_num() < larger_proj_data_info.get_min_segment_num() ||
+      proj_data_info.get_max_tangential_pos_num() > larger_proj_data_info.get_max_tangential_pos_num() ||
+      proj_data_info.get_min_tangential_pos_num() < larger_proj_data_info.get_min_tangential_pos_num())
+    return false;
+
+  shared_ptr<ProjDataInfo> smaller_proj_data_info_sptr(larger_proj_data_info.clone());
+  smaller_proj_data_info_sptr->reduce_segment_range(proj_data_info.get_min_segment_num(), proj_data_info.get_max_segment_num());  
+  smaller_proj_data_info_sptr->set_min_tangential_pos_num(proj_data_info.get_min_tangential_pos_num());
+  smaller_proj_data_info_sptr->set_max_tangential_pos_num(proj_data_info.get_max_tangential_pos_num());
+
+  return (proj_data_info == *smaller_proj_data_info_sptr);
+}
 
 END_NAMESPACE_STIR
 

--- a/src/buildblock/ProjDataInfo.cxx
+++ b/src/buildblock/ProjDataInfo.cxx
@@ -4,6 +4,7 @@
     Copyright (C) 2000 PARAPET partners
     Copyright (C) 2000 - 2009-05-13, Hammersmith Imanet Ltd
     Copyright (C) 2011-07-01 - 2011, Kris Thielemans
+    Copyright (C) 2018, University College London
     This file is part of STIR.
 
     This file is free software; you can redistribute it and/or modify
@@ -584,6 +585,13 @@ operator !=(const root_type& that) const
   return !((*this) == that);
 }
 
+/*!
+  \return
+     \c true only if the types are the same, they are equal, or the range for the
+     segments, axial and tangential positions is at least as large.
+
+  \warning Currently view ranges have to be identical.
+*/
 bool
 ProjDataInfo::
 operator>=(const ProjDataInfo& proj_data_info) const
@@ -602,10 +610,31 @@ operator>=(const ProjDataInfo& proj_data_info) const
       proj_data_info.get_min_tangential_pos_num() < larger_proj_data_info.get_min_tangential_pos_num())
     return false;
 
+  for (int segment_num=proj_data_info.get_min_segment_num();
+       segment_num<=proj_data_info.get_max_segment_num();
+       ++segment_num)
+    {
+      if (proj_data_info.get_max_axial_pos_num(segment_num) > larger_proj_data_info.get_max_axial_pos_num(segment_num) ||
+          proj_data_info.get_min_axial_pos_num(segment_num) < larger_proj_data_info.get_min_axial_pos_num(segment_num))
+        return false;
+    }
+
+  // now check all the rest. That's a bit hard, so what we'll do is reduce the sizes of the larger one
+  // to the ones from proj_data_info (which we can safely do as we've checked that they're smaller)
+  // and then check for equality.
+  // This will check stuff like scanners etc etc...
   shared_ptr<ProjDataInfo> smaller_proj_data_info_sptr(larger_proj_data_info.clone());
   smaller_proj_data_info_sptr->reduce_segment_range(proj_data_info.get_min_segment_num(), proj_data_info.get_max_segment_num());  
   smaller_proj_data_info_sptr->set_min_tangential_pos_num(proj_data_info.get_min_tangential_pos_num());
   smaller_proj_data_info_sptr->set_max_tangential_pos_num(proj_data_info.get_max_tangential_pos_num());
+
+  for (int segment_num=proj_data_info.get_min_segment_num();
+       segment_num<=proj_data_info.get_max_segment_num();
+       ++segment_num)
+    {
+      smaller_proj_data_info_sptr->set_min_axial_pos_num(proj_data_info.get_min_axial_pos_num(segment_num), segment_num);
+      smaller_proj_data_info_sptr->set_max_axial_pos_num(proj_data_info.get_max_axial_pos_num(segment_num), segment_num);
+    }
 
   return (proj_data_info == *smaller_proj_data_info_sptr);
 }

--- a/src/include/stir/ProjDataInfo.h
+++ b/src/include/stir/ProjDataInfo.h
@@ -307,7 +307,17 @@ public:
   //! check equality
   bool operator ==(const ProjDataInfo& proj) const; 
   
-  bool operator !=(const ProjDataInfo& proj) const; 
+  bool operator !=(const ProjDataInfo& proj) const;
+
+  //! Check if \c *this contains \c proj
+  /*!
+    \return \c true only if the types are the same, they are equal, or the range for the 
+       segments and tangential positions is at least as large.
+
+     \warning Currently axial positions have to be identical (for the same segments).
+  */
+  virtual bool operator>=(const ProjDataInfo& proj) const;
+
   //@}
 
   //! \name Functions that return sinograms etc (filled with 0)

--- a/src/include/stir/ProjDataInfo.h
+++ b/src/include/stir/ProjDataInfo.h
@@ -310,12 +310,6 @@ public:
   bool operator !=(const ProjDataInfo& proj) const;
 
   //! Check if \c *this contains \c proj
-  /*!
-    \return \c true only if the types are the same, they are equal, or the range for the 
-       segments and tangential positions is at least as large.
-
-     \warning Currently axial positions have to be identical (for the same segments).
-  */
   virtual bool operator>=(const ProjDataInfo& proj) const;
 
   //@}

--- a/src/include/stir/recon_buildblock/BackProjectorByBin.h
+++ b/src/include/stir/recon_buildblock/BackProjectorByBin.h
@@ -14,6 +14,7 @@
 /*
     Copyright (C) 2000 PARAPET partners
     Copyright (C) 2000- 2011, Hammersmith Imanet Ltd
+    Copyright (C) 2018, University College London
     This file is part of STIR.
 
     This file is free software; you can redistribute it and/or modify
@@ -68,10 +69,11 @@ public:
   with input corresponding to the arguments of the last call to set_up(). 
 
   \warning there is currently no check on this.
+  \warning Derived classes have to call set_up from the base class.
   */
  virtual void set_up(		 
     const shared_ptr<ProjDataInfo>& proj_data_info_ptr,
-    const shared_ptr<DiscretisedDensity<3,float> >& density_info_ptr // TODO should be Info only
+    const shared_ptr<DiscretisedDensity<3,float> >& density_info_sptr // TODO should be Info only
     ) =0;
 
   /*! \brief Informs on which symmetries the projector handles
@@ -112,7 +114,20 @@ protected:
                                    const RelatedViewgrams<float>&,
 		                   const int min_axial_pos_num, const int max_axial_pos_num,
 		                   const int min_tangential_pos_num, const int max_tangential_pos_num) = 0;
-private:
+  //! check if the argument is the same as what was used for set_up()
+  /*! calls error() if anything is wrong.
+
+      If overriding this function in a derived class, you need to call this one.
+   */
+  virtual void check(const ProjDataInfo& proj_data_info, const DiscretisedDensity<3,float>& density_info) const;
+  bool _already_set_up;
+
+ private:
+  shared_ptr<ProjDataInfo> _proj_data_info_sptr;
+  //! The density ptr set with set_up()
+  /*! \todo it is wasteful to have to store the whole image as this uses memory that we don't need. */
+  shared_ptr<DiscretisedDensity<3,float> > _density_info_sptr;
+
   void do_segments(DiscretisedDensity<3,float>& image, 
             const ProjData& proj_data_org,
 	    const int start_segment_num, const int end_segment_num,

--- a/src/include/stir/recon_buildblock/BinNormalisation.h
+++ b/src/include/stir/recon_buildblock/BinNormalisation.h
@@ -57,6 +57,9 @@ class DataSymmetriesForViewSegmentNumbers;
 class BinNormalisation : public RegisteredObject<BinNormalisation>
 {
 public:
+
+  BinNormalisation();
+
   virtual ~BinNormalisation();
 
   //! check if we would be multiplying with 1 (i.e. do nothing)
@@ -127,6 +130,16 @@ public:
   void undo(ProjData&,const double start_time, const double end_time, 
             shared_ptr<DataSymmetriesForViewSegmentNumbers> = shared_ptr<DataSymmetriesForViewSegmentNumbers>()) const; 
 
+ protected:
+  //! check if the argument is the same as what was used for set_up()
+  /*! calls error() if anything is wrong.
+
+      If overriding this function in a derived class, you need to call this one.
+   */
+  virtual void check(const ProjDataInfo& proj_data_info) const;
+  bool _already_set_up;
+private:
+  shared_ptr<ProjDataInfo> _proj_data_info_sptr;
 };
 
 END_NAMESPACE_STIR

--- a/src/include/stir/recon_buildblock/ForwardProjectorByBin.h
+++ b/src/include/stir/recon_buildblock/ForwardProjectorByBin.h
@@ -17,6 +17,7 @@
 /*
     Copyright (C) 2000 PARAPET partners
     Copyright (C) 2000- 2011, Hammersmith Imanet Ltd
+    Copyright (C) 2018, University College London
     This file is part of STIR.
 
     This file is free software; you can redistribute it and/or modify
@@ -69,10 +70,11 @@ public:
   with input corresponding to the arguments of the last call to set_up(). 
 
   \warning there is currently no check on this.
+  \warning Derived classes have to call set_up from the base class.
   */
 virtual void set_up(		 
     const shared_ptr<ProjDataInfo>& proj_data_info_ptr,
-    const shared_ptr<DiscretisedDensity<3,float> >& density_info_ptr // TODO should be Info only
+    const shared_ptr<DiscretisedDensity<3,float> >& density_info_sptr // TODO should be Info only
     ) =0;
 
   //! Informs on which symmetries the projector handles
@@ -110,6 +112,19 @@ protected:
 		  const int min_axial_pos_num, const int max_axial_pos_num,
 		  const int min_tangential_pos_num, const int max_tangential_pos_num) = 0;
 
+  //! check if the argument is the same as what was used for set_up()
+  /*! calls error() if anything is wrong.
+
+      If overriding this function in a derived class, you need to call this one.
+   */
+  virtual void check(const ProjDataInfo& proj_data_info, const DiscretisedDensity<3,float>& density_info) const;
+  bool _already_set_up;
+
+private:
+  shared_ptr<ProjDataInfo> _proj_data_info_sptr;
+  //! The density ptr set with set_up()
+  /*! \todo it is wasteful to have to store the whole image as this uses memory that we don't need. */
+  shared_ptr<DiscretisedDensity<3,float> > _density_info_sptr;
 };
 
 END_NAMESPACE_STIR

--- a/src/include/stir/recon_buildblock/ProjectorByBinPair.h
+++ b/src/include/stir/recon_buildblock/ProjectorByBinPair.h
@@ -66,6 +66,7 @@ public:
 
   Derived classes can assume that the projectors  will be called
   with input corresponding to the arguments of the last call to set_up(). 
+  \warning Derived classes have to call set_up from the base class.
   */
   virtual Succeeded
     set_up(		 
@@ -101,6 +102,19 @@ protected:
   shared_ptr<ForwardProjectorByBin> forward_projector_sptr;
   shared_ptr<BackProjectorByBin> back_projector_sptr;
 
+  //! check if the argument is the same as what was used for set_up()
+  /*! calls error() if anything is wrong.
+
+      If overriding this function in a derived class, you need to call this one.
+   */
+  virtual void check(const ProjDataInfo& proj_data_info, const DiscretisedDensity<3,float>& density_info) const;
+  bool _already_set_up;
+
+ private:
+  shared_ptr<ProjDataInfo> _proj_data_info_sptr;
+  //! The density ptr set with set_up()
+  /*! \todo it is wasteful to have to store the whole image as this uses memory that we don't need. */
+  shared_ptr<DiscretisedDensity<3,float> > _density_info_sptr;
 };
 
 END_NAMESPACE_STIR

--- a/src/recon_buildblock/BackProjectorByBin.cxx
+++ b/src/recon_buildblock/BackProjectorByBin.cxx
@@ -70,7 +70,7 @@ check(const ProjDataInfo& proj_data_info, const DiscretisedDensity<3,float>& den
 {
   if (!this->_already_set_up)
     error("BackProjectorByBin method called without calling set_up first.");
-  if (*this->_proj_data_info_sptr!= proj_data_info)
+  if (!(*this->_proj_data_info_sptr >= proj_data_info))
     error(boost::format("BackProjectorByBin set-up with different geometry for projection data.\nSet_up was with\n%1%\nCalled with\n%2%")
           % this->_proj_data_info_sptr->parameter_info() % proj_data_info.parameter_info());
   if (! this->_density_info_sptr->has_same_characteristics(density_info))

--- a/src/recon_buildblock/BackProjectorByBin.cxx
+++ b/src/recon_buildblock/BackProjectorByBin.cxx
@@ -13,7 +13,7 @@
 /*
     Copyright (C) 2000 PARAPET partners
     Copyright (C) 2000- 2011, Hammersmith Imanet Ltd
-    Copyright (C) 2015, University College London
+    Copyright (C) 2015, 2018, University College London
     This file is part of STIR.
 
     This file is free software; you can redistribute it and/or modify
@@ -34,16 +34,19 @@
 #include "stir/recon_buildblock/find_basic_vs_nums_in_subsets.h"
 #include "stir/RelatedViewgrams.h"
 #include "stir/ProjData.h"
+#include "stir/DiscretisedDensity.h"
 #include <vector>
 #ifdef STIR_OPENMP
 #include "stir/is_null_ptr.h"
 #include "stir/DiscretisedDensity.h"
 #include <omp.h>
 #endif
+#include <boost/format.hpp>
 
 START_NAMESPACE_STIR
 
 BackProjectorByBin::BackProjectorByBin()
+  :   _already_set_up(false)
 {
 }
 
@@ -51,10 +54,34 @@ BackProjectorByBin::~BackProjectorByBin()
 {
 }
 
+void
+BackProjectorByBin::
+set_up(const shared_ptr<ProjDataInfo>& proj_data_info_sptr, 
+       const shared_ptr<DiscretisedDensity<3,float> >& density_info_sptr)
+{
+  _already_set_up = true;
+  _proj_data_info_sptr = proj_data_info_sptr->create_shared_clone();
+  _density_info_sptr = density_info_sptr;
+}
+
+void
+BackProjectorByBin::
+check(const ProjDataInfo& proj_data_info, const DiscretisedDensity<3,float>& density_info) const
+{
+  if (!this->_already_set_up)
+    error("BackProjectorByBin method called without calling set_up first.");
+  if (*this->_proj_data_info_sptr!= proj_data_info)
+    error(boost::format("BackProjectorByBin set-up with different geometry for projection data.\nSet_up was with\n%1%\nCalled with\n%2%")
+          % this->_proj_data_info_sptr->parameter_info() % proj_data_info.parameter_info());
+  if (! this->_density_info_sptr->has_same_characteristics(density_info))
+    error("BackProjectorByBin set-up with different geometry for density or volume data.");
+}  
+
 void 
 BackProjectorByBin::back_project(DiscretisedDensity<3,float>& image,
 				 const ProjData& proj_data)
 {
+  check(*proj_data.get_proj_data_info_sptr(), image);
     
   shared_ptr<DataSymmetriesForViewSegmentNumbers> 
     symmetries_sptr(this->get_symmetries_used()->clone());  
@@ -142,6 +169,8 @@ back_project(DiscretisedDensity<3,float>& density,
 {
   if (viewgrams.get_num_viewgrams()==0)
     return;
+
+  check(*viewgrams.get_proj_data_info_sptr(), density);
 
   start_timers();
 

--- a/src/recon_buildblock/BackProjectorByBinUsingInterpolation.cxx
+++ b/src/recon_buildblock/BackProjectorByBinUsingInterpolation.cxx
@@ -3,6 +3,7 @@
 /*
     Copyright (C) 2000 PARAPET partners
     Copyright (C) 2000- 2011, Hammersmith Imanet Ltd
+    Copyright (C) 2018, University College London
     This file is part of STIR.
 
     This file is free software; you can redistribute it and/or modify
@@ -102,7 +103,11 @@ initialise_keymap()
 
 const DataSymmetriesForViewSegmentNumbers *
  BackProjectorByBinUsingInterpolation::get_symmetries_used() const
-{ return symmetries_ptr.get(); }
+{
+  if (!this->_already_set_up)
+    error("BackProjectorByBin method called without calling set_up first.");
+  return symmetries_ptr.get();
+}
 
 BackProjectorByBinUsingInterpolation::
 BackProjectorByBinUsingInterpolation(const bool use_piecewise_linear_interpolation,
@@ -129,6 +134,7 @@ void
 BackProjectorByBinUsingInterpolation::set_up(shared_ptr<ProjDataInfo> const& proj_data_info_ptr,
 				     shared_ptr<DiscretisedDensity<3,float> > const& image_info_ptr)
 {
+  BackProjectorByBin::set_up(proj_data_info_ptr, image_info_ptr);
   this->symmetries_ptr.
     reset(new DataSymmetriesForBins_PET_CartesianGrid(proj_data_info_ptr, image_info_ptr,
 						      do_symmetry_90degrees_min_phi,

--- a/src/recon_buildblock/BackProjectorByBinUsingProjMatrixByBin.cxx
+++ b/src/recon_buildblock/BackProjectorByBinUsingProjMatrixByBin.cxx
@@ -16,6 +16,7 @@
 /*
     Copyright (C) 2000 PARAPET partners
     Copyright (C) 2000- 2011, Hammersmith Imanet Ltd
+    Copyright (C) 2018, University College London
     This file is part of STIR.
 
     This file is free software; you can redistribute it and/or modify
@@ -97,7 +98,8 @@ BackProjectorByBinUsingProjMatrixByBin(
     )		   
     : proj_matrix_ptr(proj_matrix_ptr)
 {
-  assert(!is_null_ptr(proj_matrix_ptr));	 
+  if (is_null_ptr(proj_matrix_ptr))
+    error("BackProjector initialised with zero projection matrix ptr");
 }
 
 void
@@ -105,13 +107,16 @@ BackProjectorByBinUsingProjMatrixByBin::
 set_up(const shared_ptr<ProjDataInfo>& proj_data_info_ptr,
        const shared_ptr<DiscretisedDensity<3,float> >& image_info_ptr)
 
-{    	   
+{
+  BackProjectorByBin::set_up(proj_data_info_ptr, image_info_ptr);
   proj_matrix_ptr->set_up(proj_data_info_ptr, image_info_ptr);
 }
 
 const DataSymmetriesForViewSegmentNumbers *
 BackProjectorByBinUsingProjMatrixByBin::get_symmetries_used() const
 {
+  if (!this->_already_set_up)
+    error("BackProjectorByBin method called without calling set_up first.");
   return proj_matrix_ptr->get_symmetries_ptr();
 }
 

--- a/src/recon_buildblock/BackProjectorByBinUsingSquareProjMatrixByBin.cxx
+++ b/src/recon_buildblock/BackProjectorByBinUsingSquareProjMatrixByBin.cxx
@@ -66,6 +66,8 @@ BackProjectorByBinUsingSquareProjMatrixByBin(
 const DataSymmetriesForViewSegmentNumbers *
 BackProjectorByBinUsingSquareProjMatrixByBin::get_symmetries_used() const
 {
+  if (!this->_already_set_up)
+    error("BackProjectorByBin method called without calling set_up first.");
   return proj_matrix_ptr->get_symmetries_ptr();
 }
 
@@ -133,7 +135,8 @@ BackProjectorByBinUsingSquareProjMatrixByBin::
 set_up(const shared_ptr<ProjDataInfo>& proj_data_info_ptr,
        const shared_ptr<DiscretisedDensity<3,float> >& image_info_ptr)
 
-{    	   
+{
+  BackProjectorByBin::set_up(proj_data_info_ptr, image_info_ptr);
   proj_matrix_ptr->set_up(proj_data_info_ptr, image_info_ptr);
 }
 

--- a/src/recon_buildblock/BinNormalisation.cxx
+++ b/src/recon_buildblock/BinNormalisation.cxx
@@ -65,7 +65,7 @@ check(const ProjDataInfo& proj_data_info) const
 {
   if (!this->_already_set_up)
     error("BinNormalisation method called without calling set_up first.");
-  if (*this->_proj_data_info_sptr!= proj_data_info)
+  if (!(*this->_proj_data_info_sptr >= proj_data_info))
     error(boost::format("BinNormalisation set-up with different geometry for projection data.\nSet_up was with\n%1%\nCalled with\n%2%")
           % this->_proj_data_info_sptr->parameter_info() % proj_data_info.parameter_info());
 }

--- a/src/recon_buildblock/BinNormalisation.cxx
+++ b/src/recon_buildblock/BinNormalisation.cxx
@@ -2,7 +2,7 @@
 //
 /*
     Copyright (C) 2003- 2007, Hammersmith Imanet Ltd
-    Copyright (C) 2014, University College London
+    Copyright (C) 2014, 2018 University College London
     This file is part of STIR.
 
     This file is free software; you can redistribute it and/or modify
@@ -35,8 +35,16 @@
 #include "stir/ProjData.h"
 #include "stir/is_null_ptr.h"
 #include "stir/Succeeded.h"
+#include "stir/error.h"
+#include <boost/format.hpp>
 
 START_NAMESPACE_STIR
+
+BinNormalisation::
+BinNormalisation()
+  :   _already_set_up(false)
+{
+}
 
 BinNormalisation::
 ~BinNormalisation()
@@ -44,17 +52,31 @@ BinNormalisation::
 
 Succeeded
 BinNormalisation::
-set_up(const shared_ptr<ProjDataInfo>& )
+set_up(const shared_ptr<ProjDataInfo>& proj_data_info_sptr)
 {
+  _already_set_up = true;
+  _proj_data_info_sptr = proj_data_info_sptr->create_shared_clone();
   return Succeeded::yes;  
 }
 
+void
+BinNormalisation::
+check(const ProjDataInfo& proj_data_info) const
+{
+  if (!this->_already_set_up)
+    error("BinNormalisation method called without calling set_up first.");
+  if (*this->_proj_data_info_sptr!= proj_data_info)
+    error(boost::format("BinNormalisation set-up with different geometry for projection data.\nSet_up was with\n%1%\nCalled with\n%2%")
+          % this->_proj_data_info_sptr->parameter_info() % proj_data_info.parameter_info());
+}
+  
 // TODO remove duplication between apply and undo by just having 1 functino that does the loops
 
 void 
 BinNormalisation::apply(RelatedViewgrams<float>& viewgrams,
 			const double start_time, const double end_time) const 
 {
+  this->check(*viewgrams.get_proj_data_info_sptr());
   for (RelatedViewgrams<float>::iterator iter = viewgrams.begin(); iter != viewgrams.end(); ++iter)
   {
     Bin bin(iter->get_segment_num(),iter->get_view_num(), 0,0);
@@ -73,6 +95,7 @@ void
 BinNormalisation::
 undo(RelatedViewgrams<float>& viewgrams,const double start_time, const double end_time) const 
 {
+  this->check(*viewgrams.get_proj_data_info_sptr());
   for (RelatedViewgrams<float>::iterator iter = viewgrams.begin(); iter != viewgrams.end(); ++iter)
   {
     Bin bin(iter->get_segment_num(),iter->get_view_num(), 0,0);
@@ -93,6 +116,7 @@ BinNormalisation::
 apply(ProjData& proj_data,const double start_time, const double end_time, 
       shared_ptr<DataSymmetriesForViewSegmentNumbers> symmetries_sptr) const
 {
+  this->check(*proj_data.get_proj_data_info_sptr());
   if (is_null_ptr(symmetries_sptr))
     symmetries_sptr.reset(new TrivialDataSymmetriesForBins(proj_data.get_proj_data_info_ptr()->create_shared_clone()));
 
@@ -138,6 +162,7 @@ BinNormalisation::
 undo(ProjData& proj_data,const double start_time, const double end_time, 
      shared_ptr<DataSymmetriesForViewSegmentNumbers> symmetries_sptr) const
 {
+  this->check(*proj_data.get_proj_data_info_sptr());
   if (is_null_ptr(symmetries_sptr))
     symmetries_sptr.reset(new TrivialDataSymmetriesForBins(proj_data.get_proj_data_info_ptr()->create_shared_clone()));
 

--- a/src/recon_buildblock/BinNormalisationFromAttenuationImage.cxx
+++ b/src/recon_buildblock/BinNormalisationFromAttenuationImage.cxx
@@ -130,6 +130,7 @@ Succeeded
 BinNormalisationFromAttenuationImage::
 set_up(const shared_ptr<ProjDataInfo>& proj_data_info_ptr)
 {
+  BinNormalisation::set_up(proj_data_info_ptr);
   forward_projector_ptr->set_up(proj_data_info_ptr, attenuation_image_ptr);
   return Succeeded::yes;
 }
@@ -138,6 +139,7 @@ set_up(const shared_ptr<ProjDataInfo>& proj_data_info_ptr)
 void 
 BinNormalisationFromAttenuationImage::apply(RelatedViewgrams<float>& viewgrams,const double start_time, const double end_time) const 
 {
+  this->check(*viewgrams.get_proj_data_info_sptr());
   RelatedViewgrams<float> attenuation_viewgrams = viewgrams.get_empty_copy();
   forward_projector_ptr->forward_project(attenuation_viewgrams, *attenuation_image_ptr);
 	
@@ -156,6 +158,7 @@ void
 BinNormalisationFromAttenuationImage::
 undo(RelatedViewgrams<float>& viewgrams,const double start_time, const double end_time) const 
 {
+  this->check(*viewgrams.get_proj_data_info_sptr());
   RelatedViewgrams<float> attenuation_viewgrams = viewgrams.get_empty_copy();
   forward_projector_ptr->forward_project(attenuation_viewgrams, *attenuation_image_ptr);
 	

--- a/src/recon_buildblock/BinNormalisationFromECAT7.cxx
+++ b/src/recon_buildblock/BinNormalisationFromECAT7.cxx
@@ -218,6 +218,8 @@ Succeeded
 BinNormalisationFromECAT7::
 set_up(const shared_ptr<ProjDataInfo>& proj_data_info_ptr_v)
 {
+  BinNormalisation::set_up(proj_data_info_ptr_v);
+
   proj_data_info_ptr = proj_data_info_ptr_v;
   proj_data_info_cyl_ptr =
     dynamic_cast<const ProjDataInfoCylindricalNoArcCorr *>(proj_data_info_ptr.get());

--- a/src/recon_buildblock/BinNormalisationFromECAT8.cxx
+++ b/src/recon_buildblock/BinNormalisationFromECAT8.cxx
@@ -211,6 +211,8 @@ Succeeded
 BinNormalisationFromECAT8::
 set_up(const shared_ptr<ProjDataInfo>& proj_data_info_ptr_v)
 {
+  BinNormalisation::set_up(proj_data_info_ptr_v);
+
   proj_data_info_ptr = proj_data_info_ptr_v;
   proj_data_info_cyl_ptr =
     dynamic_cast<const ProjDataInfoCylindricalNoArcCorr *>(proj_data_info_ptr.get());

--- a/src/recon_buildblock/BinNormalisationFromProjData.cxx
+++ b/src/recon_buildblock/BinNormalisationFromProjData.cxx
@@ -93,14 +93,9 @@ set_up(const shared_ptr<ProjDataInfo>& proj_data_info_ptr)
     const ProjDataInfo& norm_proj = *(norm_proj_data_ptr->get_proj_data_info_ptr());
     const ProjDataInfo& proj = *proj_data_info_ptr;
     bool ok = 
-      typeid(norm_proj) == typeid(proj) &&
-      *norm_proj.get_scanner_ptr()== *(proj.get_scanner_ptr()) &&
-      (norm_proj.get_min_view_num()==proj.get_min_view_num()) &&
-      (norm_proj.get_max_view_num()==proj.get_max_view_num()) &&
+      (norm_proj >= proj) &&
       (norm_proj.get_min_tangential_pos_num() ==proj.get_min_tangential_pos_num())&&
-      (norm_proj.get_max_tangential_pos_num() ==proj.get_max_tangential_pos_num()) &&
-      norm_proj.get_min_segment_num() <= proj.get_min_segment_num() &&
-      norm_proj.get_max_segment_num() >= proj.get_max_segment_num();
+      (norm_proj.get_max_tangential_pos_num() ==proj.get_max_tangential_pos_num());
     
     for (int segment_num=proj.get_min_segment_num();
 	 ok && segment_num<=proj.get_max_segment_num();

--- a/src/recon_buildblock/BinNormalisationFromProjData.cxx
+++ b/src/recon_buildblock/BinNormalisationFromProjData.cxx
@@ -84,6 +84,8 @@ Succeeded
 BinNormalisationFromProjData::
 set_up(const shared_ptr<ProjDataInfo>& proj_data_info_ptr)
 {
+  BinNormalisation::set_up(proj_data_info_ptr);
+
   if (*(norm_proj_data_ptr->get_proj_data_info_ptr()) == *proj_data_info_ptr)
     return Succeeded::yes;
   else
@@ -146,6 +148,7 @@ is_trivial() const
 void 
 BinNormalisationFromProjData::apply(RelatedViewgrams<float>& viewgrams,const double start_time, const double end_time) const 
   {
+    this->check(*viewgrams.get_proj_data_info_sptr());
     const ViewSegmentNumbers vs_num=viewgrams.get_basic_view_segment_num();
     shared_ptr<DataSymmetriesForViewSegmentNumbers> symmetries_sptr(viewgrams.get_symmetries_ptr()->clone());
     viewgrams *= 
@@ -156,6 +159,7 @@ void
 BinNormalisationFromProjData::
 undo(RelatedViewgrams<float>& viewgrams,const double start_time, const double end_time) const 
   {
+    this->check(*viewgrams.get_proj_data_info_sptr());
     const ViewSegmentNumbers vs_num=viewgrams.get_basic_view_segment_num();
     shared_ptr<DataSymmetriesForViewSegmentNumbers> symmetries_sptr(viewgrams.get_symmetries_ptr()->clone());
     viewgrams /= 

--- a/src/recon_buildblock/ForwardProjectorByBin.cxx
+++ b/src/recon_buildblock/ForwardProjectorByBin.cxx
@@ -16,7 +16,7 @@
     Copyright (C) 2000 PARAPET partners
     Copyright (C) 2000-2011 Hammersmith Imanet Ltd
     Copyright (C) 2013 Kris Thielemans
-    Copyright (C) 2015, University College London
+    Copyright (C) 2015, 2018, University College London
     This file is part of STIR.
 
     This file is free software; you can redistribute it and/or modify
@@ -48,12 +48,36 @@ START_NAMESPACE_STIR
 
 
 ForwardProjectorByBin::ForwardProjectorByBin()
+  :   _already_set_up(false)
 {
 }
 
 ForwardProjectorByBin::~ForwardProjectorByBin()
 {
 }
+
+void
+ForwardProjectorByBin::
+set_up(const shared_ptr<ProjDataInfo>& proj_data_info_sptr, 
+       const shared_ptr<DiscretisedDensity<3,float> >& density_info_sptr)
+{
+  _already_set_up = true;
+  _proj_data_info_sptr = proj_data_info_sptr->create_shared_clone();
+  _density_info_sptr = density_info_sptr;
+}
+
+void
+ForwardProjectorByBin::
+check(const ProjDataInfo& proj_data_info, const DiscretisedDensity<3,float>& density_info) const
+{
+  if (!this->_already_set_up)
+    error("ForwardProjectorByBin method called without calling set_up first.");
+  if (*this->_proj_data_info_sptr!= proj_data_info)
+    error(boost::format("ForwardProjectorByBin set-up with different geometry for projection data.\nSet_up was with\n%1%\nCalled with\n%2%")
+          % this->_proj_data_info_sptr->parameter_info() % proj_data_info.parameter_info());
+  if (! this->_density_info_sptr->has_same_characteristics(density_info))
+    error("ForwardProjectorByBin set-up with different geometry for density or volume data.");
+}  
 
 void 
 ForwardProjectorByBin::forward_project(ProjData& proj_data, 
@@ -62,7 +86,8 @@ ForwardProjectorByBin::forward_project(ProjData& proj_data,
   
  // this->set_up(proj_data_ptr->get_proj_data_info_ptr()->clone(),
 //			     image_sptr);
-    
+
+  check(*proj_data.get_proj_data_info_sptr(), image);
   shared_ptr<DataSymmetriesForViewSegmentNumbers> 
     symmetries_sptr(this->get_symmetries_used()->clone());
   
@@ -127,7 +152,7 @@ forward_project(RelatedViewgrams<float>& viewgrams,
 {
   if (viewgrams.get_num_viewgrams()==0)
     return;
-
+  check(*viewgrams.get_proj_data_info_sptr(), density);
   start_timers();
 
   // first check symmetries    

--- a/src/recon_buildblock/ForwardProjectorByBin.cxx
+++ b/src/recon_buildblock/ForwardProjectorByBin.cxx
@@ -72,7 +72,7 @@ check(const ProjDataInfo& proj_data_info, const DiscretisedDensity<3,float>& den
 {
   if (!this->_already_set_up)
     error("ForwardProjectorByBin method called without calling set_up first.");
-  if (*this->_proj_data_info_sptr!= proj_data_info)
+  if (!(*this->_proj_data_info_sptr >= proj_data_info))
     error(boost::format("ForwardProjectorByBin set-up with different geometry for projection data.\nSet_up was with\n%1%\nCalled with\n%2%")
           % this->_proj_data_info_sptr->parameter_info() % proj_data_info.parameter_info());
   if (! this->_density_info_sptr->has_same_characteristics(density_info))

--- a/src/recon_buildblock/ForwardProjectorByBinUsingProjMatrixByBin.cxx
+++ b/src/recon_buildblock/ForwardProjectorByBinUsingProjMatrixByBin.cxx
@@ -105,12 +105,15 @@ ForwardProjectorByBinUsingProjMatrixByBin::
 set_up(const shared_ptr<ProjDataInfo>& proj_data_info_ptr,
        const shared_ptr<DiscretisedDensity<3,float> >& image_info_ptr)
 {    	   
+  ForwardProjectorByBin::set_up(proj_data_info_ptr, image_info_ptr);
   proj_matrix_ptr->set_up(proj_data_info_ptr, image_info_ptr);
 }
 
 const DataSymmetriesForViewSegmentNumbers *
 ForwardProjectorByBinUsingProjMatrixByBin::get_symmetries_used() const
 {
+  if (!this->_already_set_up)
+    error("ForwardProjectorByBin method called without calling set_up first.");
   return proj_matrix_ptr->get_symmetries_ptr();
 }
 

--- a/src/recon_buildblock/ForwardProjectorByBinUsingRayTracing.cxx
+++ b/src/recon_buildblock/ForwardProjectorByBinUsingRayTracing.cxx
@@ -117,6 +117,8 @@ ForwardProjectorByBinUsingRayTracing::
 set_up(const shared_ptr<ProjDataInfo>& proj_data_info_ptr,
        const shared_ptr<DiscretisedDensity<3,float> >& image_info_ptr)
 {
+  ForwardProjectorByBin::set_up(proj_data_info_ptr, image_info_ptr);
+  
   if (proj_data_info_ptr->get_num_views()%2 != 0)
     {
       error("The on-the-fly Ray tracing forward projector cannot handle data with odd number of views. Use another projector. Sorry.");
@@ -174,6 +176,8 @@ set_up(const shared_ptr<ProjDataInfo>& proj_data_info_ptr,
 const DataSymmetriesForViewSegmentNumbers * 
 ForwardProjectorByBinUsingRayTracing::get_symmetries_used() const
 {
+  if (!this->_already_set_up)
+    error("ForwardProjectorByBin method called without calling set_up first.");
   return symmetries_ptr.get(); 
 }
 

--- a/src/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMeanAndProjData.cxx
+++ b/src/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMeanAndProjData.cxx
@@ -569,11 +569,12 @@ set_up_before_sensitivity(shared_ptr<TargetT > const& target_sptr)
     }
 
   shared_ptr<ProjDataInfo> proj_data_info_sptr(this->proj_data_sptr->get_proj_data_info_ptr()->clone());
-
+#if 0
+  // KT 4/3/2017 disabled this. It isn't necessary and resolves modyfing the projectors in unexpected ways.
   proj_data_info_sptr->
     reduce_segment_range(-this->max_segment_num_to_process,
                          +this->max_segment_num_to_process);
-  
+#endif
   if (is_null_ptr(this->projector_pair_ptr))
     { error("You need to specify a projector pair"); return Succeeded::no; }
 

--- a/src/recon_buildblock/ProjMatrixByBinFromFile.cxx
+++ b/src/recon_buildblock/ProjMatrixByBinFromFile.cxx
@@ -208,29 +208,8 @@ set_up(
   /* do consistency checks on projection data.
      It's safe as long as the stored range is larger than what we need.
   */
-  {
-    boost::scoped_ptr<ProjDataInfo> smaller_proj_data_info_sptr(this->proj_data_info_ptr->clone());
-    // first reduce to input segment-range
-    {
-      const int new_max = std::min(proj_data_info_ptr_v->get_max_segment_num(),
-				   this->proj_data_info_ptr->get_max_segment_num());
-      const int new_min = std::max(proj_data_info_ptr_v->get_min_segment_num(),
-				   this->proj_data_info_ptr->get_min_segment_num());
-      smaller_proj_data_info_sptr->reduce_segment_range(new_min, new_max);
-    }
-    // same for tangential_pos range
-    {
-      const int new_max = std::min(proj_data_info_ptr_v->get_max_tangential_pos_num(),
-				   this->proj_data_info_ptr->get_max_tangential_pos_num());
-      const int new_min = std::max(proj_data_info_ptr_v->get_min_tangential_pos_num(),
-				   this->proj_data_info_ptr->get_min_tangential_pos_num());
-      smaller_proj_data_info_sptr->set_min_tangential_pos_num(new_min);
-      smaller_proj_data_info_sptr->set_max_tangential_pos_num(new_max);
-    }
-
-    if (*proj_data_info_ptr_v != *smaller_proj_data_info_sptr)
-      error("ProjMatrixByBinFromFile set-up with proj data with wrong characteristics");
-  }
+  if (!( *this->proj_data_info_ptr >= *proj_data_info_ptr_v))
+    error("ProjMatrixByBinFromFile set-up with proj data with wrong characteristics");
 
   // note: currently setting up with proj_data_info stored in the file
   // even though it's potentially larger. This is because we currently store

--- a/src/recon_buildblock/ProjectorByBinPair.cxx
+++ b/src/recon_buildblock/ProjectorByBinPair.cxx
@@ -64,7 +64,7 @@ check(const ProjDataInfo& proj_data_info, const DiscretisedDensity<3,float>& den
 {
   if (!this->_already_set_up)
     error("ProjectorByBinPair method called without calling set_up first.");
-  if (*this->_proj_data_info_sptr!= proj_data_info)
+  if (!(*this->_proj_data_info_sptr >= proj_data_info))
     error(boost::format("ProjectorByBinPair set-up with different geometry for projection data.\nSet_up was with\n%1%\nCalled with\n%2%")
           % this->_proj_data_info_sptr->parameter_info() % proj_data_info.parameter_info());
   if (! this->_density_info_sptr->has_same_characteristics(density_info))

--- a/src/recon_buildblock/ProjectorByBinPair.cxx
+++ b/src/recon_buildblock/ProjectorByBinPair.cxx
@@ -11,6 +11,7 @@
 */
 /*
     Copyright (C) 2000- 2009, Hammersmith Imanet Ltd
+    Copyright (C) 2018, University College London
     This file is part of STIR.
 
     This file is free software; you can redistribute it and/or modify
@@ -28,27 +29,47 @@
 
 
 #include "stir/recon_buildblock/ProjectorByBinPair.h"
+#include "stir/ProjDataInfo.h"
+#include "stir/DiscretisedDensity.h"
 #include "stir/Succeeded.h"
+#include <boost/format.hpp>
 
 START_NAMESPACE_STIR
 
 
 ProjectorByBinPair::
 ProjectorByBinPair()
+  :   _already_set_up(false)
 {
 }
 
 Succeeded
 ProjectorByBinPair::
-set_up(const shared_ptr<ProjDataInfo>& proj_data_info_ptr,
-       const shared_ptr<DiscretisedDensity<3,float> >& image_info_ptr)
+set_up(const shared_ptr<ProjDataInfo>& proj_data_info_sptr,
+       const shared_ptr<DiscretisedDensity<3,float> >& image_info_sptr)
 
 {    	 
-  // TODO use return values
-  forward_projector_sptr->set_up(proj_data_info_ptr, image_info_ptr);
-  back_projector_sptr->set_up(proj_data_info_ptr, image_info_ptr);
+  _already_set_up = true;
+  _proj_data_info_sptr = proj_data_info_sptr->create_shared_clone();
+  _density_info_sptr = image_info_sptr;
+  forward_projector_sptr->set_up(proj_data_info_sptr, image_info_sptr);
+  back_projector_sptr->set_up(proj_data_info_sptr, image_info_sptr);
   return Succeeded::yes;
 }
+
+
+void
+ProjectorByBinPair::
+check(const ProjDataInfo& proj_data_info, const DiscretisedDensity<3,float>& density_info) const
+{
+  if (!this->_already_set_up)
+    error("ProjectorByBinPair method called without calling set_up first.");
+  if (*this->_proj_data_info_sptr!= proj_data_info)
+    error(boost::format("ProjectorByBinPair set-up with different geometry for projection data.\nSet_up was with\n%1%\nCalled with\n%2%")
+          % this->_proj_data_info_sptr->parameter_info() % proj_data_info.parameter_info());
+  if (! this->_density_info_sptr->has_same_characteristics(density_info))
+    error("ProjectorByBinPair set-up with different geometry for density or volume data.");
+}  
 
 //ForwardProjectorByBin const * 
 const shared_ptr<ForwardProjectorByBin>

--- a/src/test/test_proj_data_info.cxx
+++ b/src/test/test_proj_data_info.cxx
@@ -15,6 +15,7 @@
 /*
     Copyright (C) 2000 PARAPET partners
     Copyright (C) 2000- 2011, Hammersmith Imanet Ltd
+    Copyright (C) 2018, University College London
     This file is part of STIR.
 
     This file is free software; you can redistribute it and/or modify
@@ -252,10 +253,19 @@ test_generic_proj_data_info(ProjDataInfo& proj_data_info)
       check(proj_data_info >= *smaller, "check on operator>= and equal objects");
       smaller->set_min_tangential_pos_num(0);
       check(proj_data_info >= *smaller, "check on tangential_pos and operator>=");
+      smaller->set_min_axial_pos_num(4, 0);
+      check(proj_data_info >= *smaller, "check on axial_pos and operator>=");
+
       smaller->reduce_segment_range(0,0);
       check(proj_data_info >= *smaller, "check on reduce_segment_range and operator>=");
+      // make one range larger, so should now fail
       smaller->set_min_tangential_pos_num(proj_data_info.get_min_tangential_pos_num() - 4);
-      check(!(proj_data_info >= *smaller), "check on mixed case and operator>=");
+      check(!(proj_data_info >= *smaller), "check on mixed case with tangential_pos_num and operator>=");
+      // reset and do the same for axial pos
+      smaller->set_min_tangential_pos_num(proj_data_info.get_min_tangential_pos_num() + 4);
+      check(proj_data_info >= *smaller, "check on reduced segments and tangential_pos and operator>=");
+      smaller->set_max_axial_pos_num(proj_data_info.get_max_axial_pos_num(0)+4, 0);
+      check(!(proj_data_info >= *smaller), "check on mixed case with axial_pos_num and operator>=");
     }
 }
 

--- a/src/test/test_proj_data_info.cxx
+++ b/src/test/test_proj_data_info.cxx
@@ -245,6 +245,18 @@ test_generic_proj_data_info(ProjDataInfo& proj_data_info)
 	 << ", axial pos " << max_diff_axial_pos_num
 	 << ", view = " << max_diff_view_num 
 	 << ", tangential_pos_num = " << max_diff_tangential_pos_num << "\n";
+
+    // test on reduce_segment_range and operator>=
+    {
+      shared_ptr<ProjDataInfo> smaller(proj_data_info.clone());
+      check(proj_data_info >= *smaller, "check on operator>= and equal objects");
+      smaller->set_min_tangential_pos_num(0);
+      check(proj_data_info >= *smaller, "check on tangential_pos and operator>=");
+      smaller->reduce_segment_range(0,0);
+      check(proj_data_info >= *smaller, "check on reduce_segment_range and operator>=");
+      smaller->set_min_tangential_pos_num(proj_data_info.get_min_tangential_pos_num() - 4);
+      check(!(proj_data_info >= *smaller), "check on mixed case and operator>=");
+    }
 }
 
 


### PR DESCRIPTION
addresses #51.
Also fixes a minor 3DRP bug that came to light when using these checks.