### PR TITLE
Compilation error due to make_array moved in boost

### DIFF
--- a/src/include/stir/GeneralisedPoissonNoiseGenerator.h
+++ b/src/include/stir/GeneralisedPoissonNoiseGenerator.h
@@ -28,7 +28,10 @@
 #include <boost/random/variate_generator.hpp>
 #include <algorithm>
 #include <boost/bind.hpp>
+// boost::serialization::make_array was moved in boost 1.64
+#if BOOST_VERSION == 106400
 #include <boost/serialization/array_wrapper.hpp>
+#endif
 
 START_NAMESPACE_STIR
 

--- a/src/include/stir/GeneralisedPoissonNoiseGenerator.h
+++ b/src/include/stir/GeneralisedPoissonNoiseGenerator.h
@@ -28,6 +28,7 @@
 #include <boost/random/variate_generator.hpp>
 #include <algorithm>
 #include <boost/bind.hpp>
+#include <boost/serialization/array_wrapper.hpp>
 
 START_NAMESPACE_STIR
 


### PR DESCRIPTION
test_GeneralisedPoissonNoiseGenerator was not compiling with boost 1.64, because make_array was moved in this release of boost.
To fix this, a new boost include was added to GeneralisedPoissonNoiseGenerator.h and fixed the issue.

Fixes #167