### PR TITLE
Typo in UsersGuide

### DIFF
--- a/documentation/STIR-UsersGuide.tex
+++ b/documentation/STIR-UsersGuide.tex
@@ -1754,7 +1754,7 @@ template.
 
 \cmdline{%
 create\_tail\_mask\_from\_ACFs		--ACF-filename <projdata> \textbackslash \\
-					--ACF-threshold <number (1.01)> \textbackslash \\
+					--ACF-threshold <number (1.1)> \textbackslash \\
 					--output-filename <projdata> \textbackslash \\
 					--safety-margin <0>%
 }
@@ -3843,7 +3843,7 @@ result.
 \begin{verbatim}
 Forward Projector Using Matrix Parameters:=
 Matrix type := some value
-End Forward Projector Pair Using Matrix Parameters:=
+End Forward Projector Using Matrix Parameters:=
 \end{verbatim}
 
 See Section \ref{sec:projmatrix} for possible values for the 'matrix type' keyword.
@@ -3903,7 +3903,7 @@ This back projector uses a projection matrix to compute its result.
 \begin{verbatim}
 Back Projector Using Matrix Parameters:=
 Matrix type := some value
-Back Forward Projector Pair Using Matrix Parameters:=
+End Back Projector Using Matrix Parameters:=
 \end{verbatim}
 
 See Section \ref{sec:projmatrix} for possible values for the 'matrix type' keyword.


### PR DESCRIPTION
- For create_tail_mask_from_ACFs the default ACF_threshold is 1.1 in the code while in the documentation it is 1.01.

- The parameters defined for forward and back projectors are wrong. See sections 4.13.5.1 and  4.13.6.1. 