### PR TITLE
fixes ROOT file in different directory #106

### DIFF
--- a/src/IO/InputStreamFromROOTFile.cxx
+++ b/src/IO/InputStreamFromROOTFile.cxx
@@ -71,12 +71,12 @@ InputStreamFromROOTFile::post_processing()
 Succeeded
 InputStreamFromROOTFile::set_up(const std::string & header_path)
 {
-    // Read the 4 bytes to check whether this is a ROOT file, indeed.
+
     FilePath f(filename,false);
     f.prepend_directory_name(header_path);
 
-    std::string fullfilename = f.get_as_string();
-
+    const std::string fullfilename = f.get_as_string();
+    // Read the 4 bytes to check whether this is a ROOT file.
     FileSignature signature(fullfilename.c_str());
     if ( strncmp(signature.get_signature(), "root", 4) != 0)
     {

--- a/src/IO/InputStreamFromROOTFile.cxx
+++ b/src/IO/InputStreamFromROOTFile.cxx
@@ -19,6 +19,7 @@
 #include "stir/IO/InputStreamFromROOTFile.h"
 #include "stir/IO/FileSignature.h"
 #include "stir/error.h"
+#include "stir/FilePath.h"
 
 START_NAMESPACE_STIR
 
@@ -64,15 +65,27 @@ InputStreamFromROOTFile::initialise_keymap()
 bool
 InputStreamFromROOTFile::post_processing()
 {
+    return false;
+}
+
+Succeeded
+InputStreamFromROOTFile::set_up(const std::string & header_path)
+{
     // Read the 4 bytes to check whether this is a ROOT file, indeed.
-    FileSignature signature(filename.c_str());
+    FilePath f(filename,false);
+    f.prepend_directory_name(header_path);
+
+    std::string fullfilename = f.get_as_string();
+
+    FileSignature signature(fullfilename.c_str());
     if ( strncmp(signature.get_signature(), "root", 4) != 0)
-      {
-	error("InputStreamFromROOTFile: File '%s' is not a ROOT file! (first 4 bytes should say 'root')",
-	      filename.c_str());
-      }
+    {
+        error("InputStreamFromROOTFile: File '%s' is not a ROOT file! (first 4 bytes should say 'root')",
+              filename.c_str());
+    }
+
     stream_ptr = new TChain(this->chain_name.c_str());
-    stream_ptr->Add(this->filename.c_str());
+    stream_ptr->Add(fullfilename.c_str());
 
     stream_ptr->SetBranchAddress("time1", &time1);
     stream_ptr->SetBranchAddress("time2", &time2);
@@ -83,7 +96,8 @@ InputStreamFromROOTFile::post_processing()
     stream_ptr->SetBranchAddress("energy2", &energy2);
     stream_ptr->SetBranchAddress("comptonPhantom1", &comptonphantom1);
     stream_ptr->SetBranchAddress("comptonPhantom2", &comptonphantom2);
-    return false;
+
+    return Succeeded::yes;
 }
 
 END_NAMESPACE_STIR

--- a/src/IO/InputStreamFromROOTFileForCylindricalPET.cxx
+++ b/src/IO/InputStreamFromROOTFileForCylindricalPET.cxx
@@ -155,6 +155,8 @@ InputStreamFromROOTFileForCylindricalPET::initialise_keymap()
 bool InputStreamFromROOTFileForCylindricalPET::
 post_processing()
 {
+    if (base_type::post_processing())
+        return true;
     return false;
 }
 

--- a/src/IO/InputStreamFromROOTFileForCylindricalPET.cxx
+++ b/src/IO/InputStreamFromROOTFileForCylindricalPET.cxx
@@ -155,8 +155,15 @@ InputStreamFromROOTFileForCylindricalPET::initialise_keymap()
 bool InputStreamFromROOTFileForCylindricalPET::
 post_processing()
 {
-    if (base_type::post_processing())
-        return true;
+    return false;
+}
+
+Succeeded
+InputStreamFromROOTFileForCylindricalPET::
+set_up(const std::string & header_path)
+{
+    if (base_type::set_up(header_path) == Succeeded::no)
+        return  Succeeded::no;
     stream_ptr->SetBranchAddress("crystalID1",&crystalID1);
     stream_ptr->SetBranchAddress("crystalID2",&crystalID2);
     stream_ptr->SetBranchAddress("submoduleID1",&submoduleID1);
@@ -170,7 +177,7 @@ post_processing()
     if (nentries == 0)
         error("The total number of entries in the ROOT file is zero. Abort.");
 
-    return false;
+    return Succeeded::yes;
 }
 
 END_NAMESPACE_STIR

--- a/src/IO/InputStreamFromROOTFileForECATPET.cxx
+++ b/src/IO/InputStreamFromROOTFileForECATPET.cxx
@@ -138,8 +138,14 @@ InputStreamFromROOTFileForECATPET::initialise_keymap()
 bool InputStreamFromROOTFileForECATPET::
 post_processing()
 {
-    if (base_type::post_processing())
-        return true;
+    return false;
+}
+
+Succeeded InputStreamFromROOTFileForECATPET::
+set_up(const std::string & header_path )
+{
+    if (base_type::set_up(header_path) == Succeeded::no)
+        return Succeeded::no;
     stream_ptr->SetBranchAddress("crystalID1",&crystalID1);
     stream_ptr->SetBranchAddress("crystalID2",&crystalID2);
     stream_ptr->SetBranchAddress("blockID1",&blockID1);
@@ -149,7 +155,7 @@ post_processing()
     if (nentries == 0)
         error("The total number of entries in the ROOT file is zero. Abort.");
 
-    return false;
+    return Succeeded::yes;
 }
 
 END_NAMESPACE_STIR

--- a/src/buildblock/FilePath.cxx
+++ b/src/buildblock/FilePath.cxx
@@ -237,6 +237,20 @@ FilePath::get_path() const
 }
 
 std::string
+FilePath::get_path_only() const
+{
+    std::size_t i = my_string.rfind(separator, my_string.length());
+    if (i != std::string::npos)
+    {
+        return(my_string.substr(0, i+1));
+    }
+
+    std::string empty;
+    return empty;
+}
+
+
+std::string
 FilePath::get_filename() const
 {
 	std::size_t i = 0; 
@@ -266,6 +280,12 @@ FilePath::get_extension() const
         return(my_string.substr(i+1, my_string.length() - i));
     }
     return("");
+}
+
+std::string
+FilePath::get_as_string() const
+{
+    return my_string;
 }
 
 void FilePath::checks() const

--- a/src/include/stir/FilePath.h
+++ b/src/include/stir/FilePath.h
@@ -99,12 +99,16 @@ public:
     void replace_extension(const std::string& e);
     //! Get path from string
     std::string get_path() const;
+    //! Get the path from string. If no path in string returns empty string.
+    std::string get_path_only() const;
     //! Get only the filename
 	//! An inherent functionality from utilities is that on Windows all separators will be checked.
     std::string get_filename() const;
     //! Get the extension of the filename.
     // This function will return the the bit that is after the last dot.
     std::string get_extension() const ;
+    //! Return the current full string
+    std::string get_as_string() const;
 
     inline bool operator==(const FilePath& other);
 

--- a/src/include/stir/IO/InputStreamFromROOTFile.h
+++ b/src/include/stir/IO/InputStreamFromROOTFile.h
@@ -83,6 +83,8 @@ public:
     Succeeded get_next_record(CListRecordROOT& record) = 0;
     //! Go to the first event.
     inline Succeeded reset();
+    //! Must be called before calling for the first event.
+    virtual Succeeded set_up(const std::string& header_path);
     //! Save current position in a vector
     inline
     SavedPosition save_get_position();

--- a/src/include/stir/IO/InputStreamFromROOTFileForCylindricalPET.h
+++ b/src/include/stir/IO/InputStreamFromROOTFileForCylindricalPET.h
@@ -62,6 +62,8 @@ public:
 
     virtual
     Succeeded get_next_record(CListRecordROOT& record);
+    //! Must be called before calling for the first event.
+    virtual Succeeded set_up(const std::string & header_path);
 
     //! gives method information
     virtual std::string method_info() const;

--- a/src/include/stir/IO/InputStreamFromROOTFileForECATPET.h
+++ b/src/include/stir/IO/InputStreamFromROOTFileForECATPET.h
@@ -62,6 +62,8 @@ public:
 
     //! gives method information
     virtual std::string method_info() const;
+    //! Must be called before calling for the first event.
+    virtual Succeeded set_up(const std::string & header_path);
 
     //! Calculate the number of rings based on the crystals and blocks
     inline virtual int get_num_rings() const;

--- a/src/listmode_buildblock/CListModeDataROOT.cxx
+++ b/src/listmode_buildblock/CListModeDataROOT.cxx
@@ -28,6 +28,7 @@
 #include "stir/listmode/CListModeDataROOT.h"
 #include "stir/Scanner.h"
 #include "stir/Succeeded.h"
+#include "stir/FilePath.h"
 #include "stir/info.h"
 #include "stir/warning.h"
 #include "stir/error.h"
@@ -59,6 +60,9 @@ CListModeDataROOT(const std::string& hroot_filename)
     this->parser.add_parsing_key("GATE scanner type", &this->root_file_sptr);
     if(!this->parser.parse(hroot_filename.c_str()))
         error("CListModeDataROOT: error parsing '%s'", hroot_filename.c_str());
+
+    FilePath f(hroot_filename);
+    root_file_sptr->set_up( f.get_path_only());
 
 //    this->root_file_sptr->set_up();
     // ExamInfo initialisation

--- a/src/listmode_buildblock/CListModeDataROOT.cxx
+++ b/src/listmode_buildblock/CListModeDataROOT.cxx
@@ -62,7 +62,8 @@ CListModeDataROOT(const std::string& hroot_filename)
         error("CListModeDataROOT: error parsing '%s'", hroot_filename.c_str());
 
     FilePath f(hroot_filename);
-    root_file_sptr->set_up( f.get_path_only());
+    if (root_file_sptr->set_up( f.get_path_only()) == Succeeded::no)
+        error("CListModeDataROOT: Unable to set_up() from the input Header file (.hroot).");
 
 //    this->root_file_sptr->set_up();
     // ExamInfo initialisation


### PR DESCRIPTION
Introduced virtual InputStreamFromROOTFile::set_up(const std::string&). The function takes over functionality previously in post_processing(). But in addition the full path of the header file location can be used. 

FilePath is used for the merging of the strings. As this is the first time the class is used small modifications had to be made to make the functionality relevant. 

1. new function get_as_string() const; which returns the current my_string, wether it is path or file. 
2. If my_string has just a filename, function get_path_only) returns an empty string.