### PR TITLE
FIX: BackProjectorByBin method called without calling set_up first

### DIFF
--- a/src/recon_buildblock/PostsmoothingBackProjectorByBin.cxx
+++ b/src/recon_buildblock/PostsmoothingBackProjectorByBin.cxx
@@ -88,6 +88,7 @@ PostsmoothingBackProjectorByBin::
 set_up(const shared_ptr<ProjDataInfo>& proj_data_info_ptr,
        const shared_ptr<DiscretisedDensity<3,float> >& image_info_ptr)
 {
+  BackProjectorByBin::set_up(proj_data_info_ptr, image_info_ptr);
   original_back_projector_ptr->set_up(proj_data_info_ptr, image_info_ptr);
   // don't do set_up as image sizes might change
   //if (!is_null_ptr(image_processor_ptr))

--- a/src/recon_buildblock/PresmoothingForwardProjectorByBin.cxx
+++ b/src/recon_buildblock/PresmoothingForwardProjectorByBin.cxx
@@ -89,6 +89,7 @@ PresmoothingForwardProjectorByBin::
 set_up(const shared_ptr<ProjDataInfo>& proj_data_info_ptr,
        const shared_ptr<DiscretisedDensity<3,float> >& image_info_ptr)
 {
+  ForwardProjectorByBin::set_up(proj_data_info_ptr, image_info_ptr);
   original_forward_projector_ptr->set_up(proj_data_info_ptr, image_info_ptr);
   if (!is_null_ptr(image_processor_ptr))
     image_processor_ptr->set_up(*image_info_ptr);


### PR DESCRIPTION
Fixes
```
ERROR: BackProjectorByBin method called without calling set_up first.                                                                        
terminate called after throwing an instance of 'std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >'                  
Aborted (core dumped)   
```

When using PresmoothingForwardProjector and PostsmoothingBackProjector.