### PR TITLE
Fixes problem in ParametricDiscretisedDensity::read_from_file

### DIFF
--- a/src/buildblock/DynamicDiscretisedDensity.cxx
+++ b/src/buildblock/DynamicDiscretisedDensity.cxx
@@ -144,7 +144,9 @@ DynamicDiscretisedDensity*
 DynamicDiscretisedDensity::
 read_from_file(const string& filename) // The written image is read in respect to its center as origin!!!
 {
-  return stir::read_from_file<DynamicDiscretisedDensity>(filename).get();
+  unique_ptr<DynamicDiscretisedDensity> dyn_sptr
+    (stir::read_from_file<DynamicDiscretisedDensity>(filename));
+  return dyn_sptr.release();
 }
 
 //Warning write_time_frame_definitions() is not yet implemented, so time information is missing.

--- a/src/modelling_buildblock/ParametricDiscretisedDensity.cxx
+++ b/src/modelling_buildblock/ParametricDiscretisedDensity.cxx
@@ -153,7 +153,9 @@ ParamDiscDensity *
 ParamDiscDensity::
 read_from_file(const std::string& filename) // The written image is read in respect to its center as origin!!!
 {
-  return stir::read_from_file<ParamDiscDensity>(filename).get();
+  unique_ptr<ParamDiscDensity> param_sptr
+    (stir::read_from_file<ParamDiscDensity>(filename));
+  return param_sptr.release();
 }
 
 TEMPLATE


### PR DESCRIPTION
We were using .get() of a unique pointer. This means that when the unique_ptr gets deleted, problems were happening. 

To fix this, I simply copied the implementation from DiscretisedDensity.