### PR TITLE
Fix VoxelsOnCartesianGrid::clone

### DIFF
--- a/src/buildblock/VoxelsOnCartesianGrid.cxx
+++ b/src/buildblock/VoxelsOnCartesianGrid.cxx
@@ -321,7 +321,9 @@ VoxelsOnCartesianGrid<elemT>*
 #endif
 VoxelsOnCartesianGrid<elemT>::clone() const
 {
-  return new VoxelsOnCartesianGrid(*this);
+  VoxelsOnCartesianGrid *temp = new VoxelsOnCartesianGrid(*this);
+  temp->set_exam_info(*temp->get_exam_info_sptr()->create_shared_clone());
+  return temp;
 }
 
 template<class elemT>


### PR DESCRIPTION
Beforehand, we weren't performing a deep copy of the exam info. Use `create_shared_clone` to avoid this.