### PR TITLE
Change of Origin

### DIFF
--- a/src/IO/ITKOutputFileFormat.cxx
+++ b/src/IO/ITKOutputFileFormat.cxx
@@ -99,7 +99,7 @@ actual_write_to_file(std::string& filename,
     {
       add_extension(filename, this->default_extension);
 
-      const VoxelsOnCartesianGrid<float> image_ptr =
+      const VoxelsOnCartesianGrid<float> image =
         dynamic_cast<const VoxelsOnCartesianGrid<float>& >(density);
       CartesianCoordinate3D<int> min_indices;
       CartesianCoordinate3D<int> max_indices;
@@ -112,9 +112,6 @@ actual_write_to_file(std::string& filename,
       typedef itk::Image< float, 3> ImageType;
       typedef itk::ImageFileWriter<ImageType> WriterType;
       WriterType::Pointer writer = WriterType::New();
-
-      //Creating the image
-      ImageType::Pointer image = ImageType::New();
       
       // use 0 start indices in ITK
       ImageType::IndexType start;
@@ -127,41 +124,51 @@ actual_write_to_file(std::string& filename,
       CartesianCoordinate3D<float> stir_offset = density.get_physical_coordinates_for_indices(min_indices);
       origin[0] = stir_offset.x();
       origin[1] = stir_offset.y();
-      // Note: need to use - for z-coordinate because of different axis conventions
-      origin[2] = -stir_offset.z();
-      
+      origin[2] = stir_offset.z();
+
       // find ITK size
       ImageType::SizeType size;
-      size[0] = image_ptr.get_x_size(); // size along X
-      size[1] = image_ptr.get_y_size(); // size along Y
-      size[2] = image_ptr.get_z_size(); // size along Z
+      size[0] = image.get_x_size(); // size along X
+      size[1] = image.get_y_size(); // size along Y
+      size[2] = image.get_z_size(); // size along Z
 
       // find ITK voxel size
       ImageType::SpacingType spacing;
-      spacing[0] = image_ptr.get_voxel_size().x(); // size along X
-      spacing[1] = image_ptr.get_voxel_size().y(); // size along Y
-      spacing[2] = image_ptr.get_voxel_size().z(); // size along Z
+      spacing[0] = image.get_voxel_size().x(); // size along X
+      spacing[1] = image.get_voxel_size().y(); // size along Y
+      spacing[2] = image.get_voxel_size().z(); // size along Z
 
       // ITK orientation (RAI)
+      // NB: ITK Matrix is in row, column order
+      // In ITK Direction matrix, each column is a direction vector for each
+      // axis
       ImageType::DirectionType matrix;
-      matrix.Fill(0.F);
-      matrix(0,0) = 1.F;
-      matrix(1,1) = 1.F;
-      matrix(2,2) = -1.F;
+      for (unsigned int axis=0; axis<3; ++axis) {
+        for (unsigned int dim=0; dim<3; ++dim) {
+          CartesianCoordinate3D<int> next_idx_along_this_dim(min_indices);
+          next_idx_along_this_dim[dim] += 1;
+          CartesianCoordinate3D<float> next_coord_along_this_dim
+            = density.get_physical_coordinates_for_indices(next_idx_along_this_dim);
+          matrix(axis, dim) = stir_offset[dim] - next_coord_along_this_dim[dim];
+        }
+      }
 
       ImageType::RegionType region;
       region.SetSize( size );
       region.SetIndex( start );
 
-      image->SetSpacing(spacing);
-      image->SetRegions( region );
-      image->SetOrigin(origin);
-      image->SetDirection( matrix );
-      image->Allocate();
+      //Creating the image
+      ImageType::Pointer itk_image = ImageType::New();
+
+      itk_image->SetSpacing(spacing);
+      itk_image->SetRegions( region );
+      itk_image->SetOrigin(origin);
+      itk_image->SetDirection( matrix );
+      itk_image->Allocate();
 	
       // copy data
       typedef itk::ImageRegionIterator< ImageType >	IteratorType;
-      IteratorType it (image, image->GetLargestPossibleRegion() );	
+      IteratorType it (itk_image, itk_image->GetLargestPossibleRegion() );	
       DiscretisedDensity<3,float>::const_full_iterator stir_iter = density.begin_all_const();
       for ( it = it.Begin(); !it.IsAtEnd(); ++it, ++stir_iter  ){
 
@@ -169,7 +176,7 @@ actual_write_to_file(std::string& filename,
       }
 
       // write it!
-      writer->SetInput(image);
+      writer->SetInput(itk_image);
       writer->SetFileName(filename);
       writer->Update();
 

--- a/src/IO/InterfileHeader.cxx
+++ b/src/IO/InterfileHeader.cxx
@@ -1283,7 +1283,8 @@ bool InterfilePDFSHeader::post_processing()
                 num_transaxial_crystals_per_singles_unit,
                 num_detector_layers,
                 energy_resolution,
-                reference_energy));
+                reference_energy,
+                guessed_scanner_ptr->get_reference_origin()));
 
   bool is_consistent =
     scanner_ptr_from_file->check_consistency() == Succeeded::yes;

--- a/src/Shape_buildblock/CMakeLists.txt
+++ b/src/Shape_buildblock/CMakeLists.txt
@@ -17,4 +17,4 @@ set(${dir_LIB_SOURCES}
 
 include(stir_lib_target)
 
-target_link_libraries(Shape_buildblock buildblock IO )
+target_link_libraries(Shape_buildblock buildblock IO numerics_buildblock )

--- a/src/buildblock/ProjDataInfo.cxx
+++ b/src/buildblock/ProjDataInfo.cxx
@@ -654,10 +654,10 @@ get_location_of_vendor_frame_of_reference_in_gantry_space() const {
     = (scanner_ptr->get_num_rings() - 1) * scanner_ptr->get_ring_spacing();
 
   switch (scanner_ptr->get_reference_origin()) {
-  case Scanner::VendorReferenceOrigin::FirstRing:
+  case Scanner::FirstRing:
     return CartesianCoordinate3D<float>(-gantry_length / 2.F, 0, 0);
 
-  case Scanner::VendorReferenceOrigin::Middle:
+  case Scanner::Middle:
     return CartesianCoordinate3D<float>(0, 0, 0);
 
   default:

--- a/src/buildblock/ProjDataInfo.cxx
+++ b/src/buildblock/ProjDataInfo.cxx
@@ -650,7 +650,12 @@ operator>=(const ProjDataInfo& proj_data_info) const
 const CartesianCoordinate3D<float>
 ProjDataInfo::
 get_location_of_vendor_frame_of_reference_in_gantry_space() const {
-  return CartesianCoordinate3D<float>(0, 0, 0);
+  warning("Vendor origin unknown. Defaulting to STIR legacy, middle of first ring.");
+  double gantry_length
+    = (scanner_ptr->get_num_rings() - 1) * scanner_ptr->get_ring_spacing();
+  std::cout << "nring: " << scanner_ptr->get_num_rings()
+            << ", spacing: " << scanner_ptr->get_ring_spacing() << std::endl;
+  return CartesianCoordinate3D<float>(-gantry_length / 2.F, 0, 0);
 }
 
 END_NAMESPACE_STIR

--- a/src/buildblock/ProjDataInfo.cxx
+++ b/src/buildblock/ProjDataInfo.cxx
@@ -647,5 +647,11 @@ operator>=(const ProjDataInfo& proj_data_info) const
   return (proj_data_info == *smaller_proj_data_info_sptr);
 }
 
+const CartesianCoordinate3D<float>
+ProjDataInfo::
+get_location_of_vendor_frame_of_reference_in_gantry_space() const {
+  return CartesianCoordinate3D<float>(0, 0, 0);
+}
+
 END_NAMESPACE_STIR
 

--- a/src/buildblock/ProjDataInfo.cxx
+++ b/src/buildblock/ProjDataInfo.cxx
@@ -650,13 +650,19 @@ operator>=(const ProjDataInfo& proj_data_info) const
 const CartesianCoordinate3D<float>
 ProjDataInfo::
 get_location_of_vendor_frame_of_reference_in_gantry_space() const {
-  warning("Vendor origin unknown. Defaulting to STIR legacy, middle of first ring.");
   double gantry_length
     = (scanner_ptr->get_num_rings() - 1) * scanner_ptr->get_ring_spacing();
-  std::cout << "nring: " << scanner_ptr->get_num_rings()
-            << ", spacing: " << scanner_ptr->get_ring_spacing() << std::endl;
-  return CartesianCoordinate3D<float>(-gantry_length / 2.F, 0, 0);
+
+  switch (scanner_ptr->get_reference_origin()) {
+  case Scanner::VendorReferenceOrigin::FirstRing:
+    return CartesianCoordinate3D<float>(-gantry_length / 2.F, 0, 0);
+
+  case Scanner::VendorReferenceOrigin::Middle:
+    return CartesianCoordinate3D<float>(0, 0, 0);
+
+  default:
+    throw std::runtime_error("Unknown reference origin.");
+  }
 }
 
 END_NAMESPACE_STIR
-

--- a/src/buildblock/Scanner.cxx
+++ b/src/buildblock/Scanner.cxx
@@ -4,6 +4,8 @@
     Copyright (C) 2011, Kris Thielemans
     Copyright (C) 2010-2013, King's College London
     Copyright (C) 2013-2016, University College London
+    Copyright (C) 2018, Commonwealth Scientific and Industrial Research Organisation
+                        Australian eHealth Research Centre
     This file is part of STIR.
 
     This file is free software; you can redistribute it and/or modify
@@ -25,6 +27,7 @@
 
   \brief Implementations for class stir::Scanner
 
+  \author Ashley Gillman
   \author Nikos Efthimiou
   \author Charalampos Tsoumpas
   \author Sanida Mustafovic
@@ -98,6 +101,7 @@ Scanner::Scanner(Type scanner_type)
   //            int num_axial_crystals_per_singles_unit_v,
   //            int num_transaxial_crystals_per_singles_unit_v,
   //            int num_detector_layers_v
+  // (optional) VendorReferenceOrigin reference_origin
   //
 
   
@@ -202,7 +206,9 @@ Scanner::Scanner(Type scanner_type)
     set_params(Siemens_mMR, string_list("Siemens mMR", "mMR", "2008"),
                64, 344, 2* 252,
                328.0F, 7.0F, 4.0625F, 2.08626F, 0.0F,
-               2, 1, 8, 9, 16, 9, 1 ); // TODO bucket/singles info incorrect? 224 buckets in total, but not sure how distributed
+               2, 1, 8, 9, 16, 9, 1, // TODO bucket/singles info incorrect? 224 buckets in total, but not sure how distributed
+               -1.F, -1.F,
+               Scanner::VendorReferenceOrigin::Middle);
     break;
 
   case RPT:
@@ -434,7 +440,8 @@ Scanner::Scanner(Type type_v, const list<string>& list_of_names_v,
                  int num_transaxial_crystals_per_singles_unit_v,
                  int num_detector_layers_v,
                  float energy_resolution_v,
-                 float reference_energy_v)
+                 float reference_energy_v,
+                 Scanner::VendorReferenceOrigin reference_origin_v)
 {
   set_params(type_v, list_of_names_v, num_rings_v,
              max_num_non_arccorrected_bins_v,
@@ -449,7 +456,8 @@ Scanner::Scanner(Type type_v, const list<string>& list_of_names_v,
              num_transaxial_crystals_per_singles_unit_v,
              num_detector_layers_v,
              energy_resolution_v,
-             reference_energy_v);
+             reference_energy_v,
+             reference_origin_v);
 }
 
 
@@ -466,7 +474,8 @@ Scanner::Scanner(Type type_v, const string& name,
                  int num_transaxial_crystals_per_singles_unit_v,
                  int num_detector_layers_v,
                  float energy_resolution_v,
-                 float reference_energy_v) 
+                 float reference_energy_v,
+                 Scanner::VendorReferenceOrigin reference_origin_v)
 {
   set_params(type_v, string_list(name), num_rings_v,
              max_num_non_arccorrected_bins_v,
@@ -481,7 +490,8 @@ Scanner::Scanner(Type type_v, const string& name,
              num_transaxial_crystals_per_singles_unit_v,
              num_detector_layers_v,
              energy_resolution_v,
-             reference_energy_v);
+             reference_energy_v,
+             reference_origin_v);
 }
 
 
@@ -506,7 +516,8 @@ set_params(Type type_v,const list<string>& list_of_names_v,
            int num_transaxial_crystals_per_singles_unit_v,
            int num_detector_layers_v,
            float energy_resolution_v,
-           float reference_energy_v)
+           float reference_energy_v,
+           Scanner::VendorReferenceOrigin reference_origin_v)
 {
   set_params(type_v, list_of_names_v, num_rings_v,
              max_num_non_arccorrected_bins_v,
@@ -521,7 +532,8 @@ set_params(Type type_v,const list<string>& list_of_names_v,
              num_transaxial_crystals_per_singles_unit_v,
 	     num_detector_layers_v,
              energy_resolution_v,
-             reference_energy_v);
+             reference_energy_v,
+             reference_origin_v);
 }
 
 
@@ -542,7 +554,8 @@ set_params(Type type_v,const list<string>& list_of_names_v,
            int num_transaxial_crystals_per_singles_unit_v,
            int num_detector_layers_v,
            float energy_resolution_v,
-           float reference_energy_v)
+           float reference_energy_v,
+           Scanner::VendorReferenceOrigin reference_origin_v)
 {
   type = type_v;
   list_of_names = list_of_names_v;  
@@ -562,10 +575,16 @@ set_params(Type type_v,const list<string>& list_of_names_v,
   num_axial_crystals_per_singles_unit = num_axial_crystals_per_singles_unit_v;
   num_transaxial_crystals_per_singles_unit = num_transaxial_crystals_per_singles_unit_v;
   num_detector_layers = num_detector_layers_v;
-
   energy_resolution = energy_resolution_v;
   reference_energy = reference_energy_v;
-
+  if (reference_origin_v == Scanner::VendorReferenceOrigin::Unknown) {
+    if (type != Scanner::Type::Unknown_scanner) {
+      warning("Vendor origin unknown. "
+              "Defaulting to STIR legacy, middle of first ring.");
+    }
+    reference_origin_v = Scanner::VendorReferenceOrigin::FirstRing;
+  }
+  reference_origin = reference_origin_v;
 }
 
 

--- a/src/buildblock/VoxelsOnCartesianGrid.cxx
+++ b/src/buildblock/VoxelsOnCartesianGrid.cxx
@@ -4,6 +4,8 @@
     Copyright (C) 2000 PARAPET partners
     Copyright (C) 2000- 2012, Hammersmith Imanet Ltd
     Copyright (C) 2018, University College London
+    Copyright (C) 2018, Commonwealth Scientific and Industrial Research Organisation
+                        Australian eHealth Research Centre
 
     This file is free software; you can redistribute it and/or modify
     it under the terms of the GNU Lesser General Public License as published by
@@ -25,6 +27,7 @@
   \author Sanida Mustafovic 
   \author Kris Thielemans (with help from Alexey Zverovich)
   \author PARAPET project
+  \author Ashley Gillman
 
 
 */
@@ -246,15 +249,24 @@ init_from_proj_data_info(const ProjDataInfo& proj_data_info,
   if (y_size_used == 0)
     warning("VoxelsOnCartesianGrid: constructed image with y_size 0\n");
 
-  // Origin is -'ve of the location of the vendor frame of reference
-  // in this space.
+  /* we want centre_of_gantry + offset
+           = origin_in_gantry_space + origin + image_centre_in_image_space
+
+     NB: The following is only valid because we want gantry and image
+     space have same axes direction. Otherwise vectors in image and
+     gantry space couln't be added directly.
+  */
+
   // TODO: is there something weird happens if {x,y}_size is even?
-  CartesianCoordinate3D<float> centre_of_gantry
-    = CartesianCoordinate3D<float>(z_size * z_sampling / 2.F, 0, 0);
-  this->set_origin(
-    -(centre_of_gantry
-      + proj_data_info.get_location_of_vendor_frame_of_reference_in_gantry_space())
-    + offset);
+  CartesianCoordinate3D<float> image_centre_in_image_space
+    = CartesianCoordinate3D<float>((z_size - 1) * z_sampling / 2.F, 0, 0);
+  CartesianCoordinate3D<float> origin_in_gantry_space
+    = proj_data_info.get_location_of_vendor_frame_of_reference_in_gantry_space();
+
+  std::cout << "zsize: " << z_size
+            << ", zsample: " << z_sampling << std::endl;
+  this->set_origin(-(origin_in_gantry_space + image_centre_in_image_space)
+                   + offset);
 
   IndexRange3D range(0, z_size-1,
                      -(y_size_used/2), -(y_size_used/2) + y_size_used-1,

--- a/src/buildblock/VoxelsOnCartesianGrid.cxx
+++ b/src/buildblock/VoxelsOnCartesianGrid.cxx
@@ -263,8 +263,6 @@ init_from_proj_data_info(const ProjDataInfo& proj_data_info,
   CartesianCoordinate3D<float> origin_in_gantry_space
     = proj_data_info.get_location_of_vendor_frame_of_reference_in_gantry_space();
 
-  std::cout << "zsize: " << z_size
-            << ", zsample: " << z_sampling << std::endl;
   this->set_origin(-(origin_in_gantry_space + image_centre_in_image_space)
                    + offset);
 

--- a/src/cmake/stir_dirs.cmake
+++ b/src/cmake/stir_dirs.cmake
@@ -55,6 +55,7 @@ SET( STIR_LIBRARIES analytic_FBP3DRP analytic_FBP2D       iterative_OSMAPOSL
       Shape_buildblock eval_buildblock 
       # repeat for linking
       numerics_buildblock modelling_buildblock listmode_buildblock
+      IO modelling_buildblock IO buildblock
 )
 
 #copy to PARENT_SCOPE

--- a/src/include/stir/BasicCoordinate.h
+++ b/src/include/stir/BasicCoordinate.h
@@ -172,8 +172,9 @@ http://groups.google.com/group/comp.lang.c%2B%2B.moderated/browse_thread/thread/
   //@{
   inline BasicCoordinate operator+ (const coordT& a) const;
   inline BasicCoordinate operator- (const coordT& a) const;
-  inline BasicCoordinate operator* (const coordT& a) const;	      
+  inline BasicCoordinate operator* (const coordT& a) const;
   inline BasicCoordinate operator/ (const coordT& a) const;
+  inline BasicCoordinate operator- () const;
   //@}
 
   //! \name basic iterator support

--- a/src/include/stir/BasicCoordinate.inl
+++ b/src/include/stir/BasicCoordinate.inl
@@ -336,6 +336,16 @@ BasicCoordinate<num_dimensions, coordT> BasicCoordinate<num_dimensions, coordT>:
 }
 
 
+template <int num_dimensions, class coordT>
+BasicCoordinate<num_dimensions, coordT> BasicCoordinate<num_dimensions, coordT>::
+operator-() const
+{
+  BasicCoordinate<num_dimensions, coordT> tmp(0);
+  tmp -= (*this);
+  return tmp;
+}
+
+
 
 /*
    External functions

--- a/src/include/stir/DiscretisedDensity.h
+++ b/src/include/stir/DiscretisedDensity.h
@@ -175,6 +175,12 @@ public:
     CartesianCoordinate3D<float>
     get_physical_coordinates_for_indices(const BasicCoordinate<num_dimensions,float>& indices) const;
 
+  inline CartesianCoordinate3D<float>
+  get_LPS_coordinates_for_indices(const BasicCoordinate<num_dimensions,int>& indices) const;
+
+  inline CartesianCoordinate3D<float>
+  get_LPS_coordinates_for_indices(const BasicCoordinate<num_dimensions,float>& indices) const;
+
   //! Return the relative coordinates of the centre of the basis-function corresponding to \c indices.
   /*! Implementation uses actual_get_relative_coordinates_for_indices
   */

--- a/src/include/stir/DiscretisedDensity.h
+++ b/src/include/stir/DiscretisedDensity.h
@@ -5,6 +5,8 @@
     Copyright (C) 2000- 2009-07-08, Hammersmith Imanet Ltd
     Copyright (C) 2011-07-01 - 2011, Kris Thielemans
     Copyright (C) 2018, University College London
+    Copyright (C) 2018, Commonwealth Scientific and Industrial Research Organisation
+                        Australian eHealth Research Centre
     This file is part of STIR.
 
     This file is free software; you can redistribute it and/or modify
@@ -31,8 +33,7 @@
   \author Kris Thielemans 
   \author (help from Alexey Zverovich)
   \author PARAPET project
-
-
+  \author Ashley Gillman
 
 */
 
@@ -53,7 +54,14 @@ START_NAMESPACE_STIR
 
   It defines functionality common to all discretised densities: the
   data structure itself (Array) and an origin.
- 
+
+  The origin of a DiscretisedDensity is defined as the vector from the
+  frame-of-reference point to the center of the first z plane in the
+  data structure (TODO: what about 1D??). The frame-of-reference point
+  attempts to be identical to what the vendor would call the origin
+  for the scanner. For many scanners, this is not supported in STIR,
+  and will default to the center of the first ring of the scanner.
+
   \warning The origin is always a CartesianCoordinate3D<float>, 
   independent of what coordinate system (or even dimension) this
   class represents. Similarly, the functions that translate from
@@ -132,10 +140,12 @@ public:
                             const IndexRange<num_dimensions>& range,
                             const CartesianCoordinate3D<float>& origin);
 
-  //! Return the origin 
+  //! Return the origin, the vector from the frame-of-reference point
+  //! to the center of the first z plane
   inline const CartesianCoordinate3D<float>& get_origin()  const;
 
-  //! Set the origin
+  //! Set the origin, the vector from the frame-of-reference point
+  //! to the center of the first z plane
   inline void set_origin(const CartesianCoordinate3D<float> &origin);
 
   //! \name Translation between indices and physical coordinates

--- a/src/include/stir/DiscretisedDensity.inl
+++ b/src/include/stir/DiscretisedDensity.inl
@@ -210,4 +210,56 @@ get_indices_closest_to_physical_coordinates(const CartesianCoordinate3D<float>& 
     this->get_indices_closest_to_relative_coordinates(coords - this->get_origin());
 }
 
+template<int num_dimensions, typename elemT>
+CartesianCoordinate3D<float>
+DiscretisedDensity<num_dimensions, elemT>::
+get_LPS_coordinates_for_indices(const BasicCoordinate<num_dimensions, float>& indices) const
+{
+  CartesianCoordinate3D<float> coordinates
+    = this->get_physical_coordinates_for_indices(indices);
+  const PatientPosition::PositionValue patient_position
+    = this->get_exam_info().patient_position.get_position();
+
+  switch (patient_position) {
+  case PatientPosition::unknown_position:
+    // If unknown, assume HFS
+  case PatientPosition::HFS:
+    // HFS means currently in LAS
+    coordinates.y() *= -1;
+    break;
+
+  case PatientPosition::HFP:
+    // HFP means currently in RPS
+    coordinates.x() *= -1;
+    break;
+
+  case PatientPosition::FFS:
+    // FFS means currently in RAI
+    coordinates.x() *= -1;
+    coordinates.y() *= -1;
+    coordinates.z() *= -1;
+    break;
+
+  case PatientPosition::FFP:
+    // FFP means currently in LPI
+    coordinates.z() *= -1;
+    break;
+
+  // We can do
+
+  default:
+    throw std::runtime_error("Unsupported patient position, can't convert to LPS.");
+  }
+
+  return coordinates;
+}
+
+template<int num_dimensions, typename elemT>
+CartesianCoordinate3D<float>
+DiscretisedDensity<num_dimensions, elemT>::
+get_LPS_coordinates_for_indices(const BasicCoordinate<num_dimensions, int>& indices) const
+{
+  return get_LPS_coordinates_for_indices(BasicCoordinate<num_dimensions, float>(indices));
+}
+
 END_NAMESPACE_STIR

--- a/src/include/stir/LORCoordinates.h
+++ b/src/include/stir/LORCoordinates.h
@@ -9,12 +9,15 @@
   \brief defines various classes for specifying a line in 3 dimensions
   \warning This is all preliminary and likely to change.
   \author Kris Thielemans
+  \author Ashley GIllman
 
 
 */
 /*
     Copyright (C) 2004 - 2009-06-22, Hammersmith Imanet Ltd
     Copyright (C) 2011-07-01 - 2013, Kris Thielemans
+    Copyright (C) 2018, Commonwealth Scientific and Industrial Research Organisation
+                        Australian eHealth Research Centre
     This file is part of STIR.
 
     This file is free software; you can redistribute it and/or modify
@@ -308,6 +311,11 @@ class LORAs2Points : public LOR<coordT>
     Succeeded
     get_intersections_with_cylinder(LORAs2Points<coordT>&,
 				    const double radius) const;
+
+  float get_s() const;
+  float get_phi() const;
+  float get_m() const;
+  float get_tantheta() const;
 
  private:
   CartesianCoordinate3D<coordT> _p1;

--- a/src/include/stir/LORCoordinates.inl
+++ b/src/include/stir/LORCoordinates.inl
@@ -7,11 +7,14 @@
   \brief Implementations for LORCoordinates.h
   \warning This is all preliminary and likely to change.
   \author Kris Thielemans
+  \author Ashley GIllman
 
 
 */
 /*
     Copyright (C) 2004- 2013, Hammersmith Imanet Ltd
+    Copyright (C) 2018, Commonwealth Scientific and Industrial Research Organisation
+                        Australian eHealth Research Centre
     This file is part of STIR.
 
     This file is free software; you can redistribute it and/or modify
@@ -305,6 +308,54 @@ LORAs2Points<coordT>::
 LORAs2Points(const LORInAxialAndNoArcCorrSinogramCoordinates<coordT>& coords)
 {
   *this = LORInCylinderCoordinates<coordT>(coords);
+}
+
+
+template <class coordT>
+float
+LORAs2Points<coordT>::
+get_s() const
+{
+  // TODO - can this be done more generally? It assumes that points lie on
+  // gantry radius
+  float s = sqrt(square(_p1.x() + _p2.x()) + square(_p1.y() + _p2.y())) / 2;
+  assert(s >= 0);
+  return s;
+}
+
+
+template <class coordT>
+float
+LORAs2Points<coordT>::
+get_phi() const
+{
+  float phi = to_0_pi(-atan2(_p2.x() - _p1.x(), _p2.y() - _p1.y()));
+  assert(phi >= 0);
+  assert(phi < _PI);
+  return phi;
+}
+
+
+template <class coordT>
+float
+LORAs2Points<coordT>::
+get_m() const
+{
+  float m = (_p1.z() + _p2.z()) / 2;
+  return m;
+}
+
+
+template <class coordT>
+float
+LORAs2Points<coordT>::
+get_tantheta() const
+{
+  // TODO: should check which order these should be. But how?
+  float axial_diff = (_p2.z() - _p1.z());
+  float transaxial_diff = sqrt(square(_p2.x() - _p1.x())
+                               + square(_p2.y() - _p1.y()));
+  return axial_diff / transaxial_diff;
 }
 
 

--- a/src/include/stir/ProjDataInfo.h
+++ b/src/include/stir/ProjDataInfo.h
@@ -33,6 +33,7 @@
 
 #include "stir/VectorWithOffset.h"
 #include "stir/Scanner.h"
+#include "stir/CartesianCoordinate3D.h"
 #include "stir/shared_ptr.h"
 #include "stir/unique_ptr.h"
 #include <string>
@@ -348,7 +349,12 @@ public:
   
   //! Return a string describing the object
   virtual std::string parameter_info() const;
-  
+
+  //! Get the location of the scanners frame-of-reference in mm from
+  //! center of gantry.
+  const CartesianCoordinate3D<float>
+  get_location_of_vendor_frame_of_reference_in_gantry_space() const;
+
 protected:
   virtual bool blindly_equals(const root_type * const) const = 0;
 

--- a/src/include/stir/Scanner.h
+++ b/src/include/stir/Scanner.h
@@ -3,6 +3,8 @@
     Copyright (C) 2000-2010, Hammersmith Imanet Ltd
     Copyright (C) 2011-2013, King's College London
     Copyright (C) 2016, UCL
+    Copyright (C) 2018, Commonwealth Scientific and Industrial Research Organisation
+                        Australian eHealth Research Centre
  
     This file is part of STIR.
 
@@ -25,6 +27,7 @@
 
   \brief Declaration of class stir::Scanner
 
+  \author Ashley Gillman
   \author Claire Labbe
   \author Kris Thielemans
   \author Sanida Mustafovic
@@ -112,7 +115,14 @@ class Scanner
 	     Advance, DiscoveryLS, DiscoveryST, DiscoverySTE, DiscoveryRX, Discovery600,
 	     HZLR, RATPET, PANDA, HYPERimage, nanoPET, HRRT, Allegro, GeminiTF, User_defined_scanner,
 	     Unknown_scanner};
-  
+
+  /*! The reference location for the vendor origin. Currenly allowed:
+      \li Unknown - Defaults FirstRing with warning.
+      \li FirstRing - Middle of the first ring, nearest the bed.
+      \li Middle - Middle of the whole gantry.
+  */
+  enum VendorReferenceOrigin {Unknown, FirstRing, Middle};
+
   //! constructor that takes scanner type as an input argument
   Scanner(Type scanner_type);
 
@@ -134,7 +144,8 @@ class Scanner
           int num_transaxial_crystals_per_singles_unit_v,
           int num_detector_layers_v,
           float energy_resolution_v = -1.0f,
-          float reference_energy_v = -1.0f);
+          float reference_energy_v = -1.0f,
+          VendorReferenceOrigin reference_origin_v = VendorReferenceOrigin::Unknown);
 
   //! constructor ( a single name)
   /*! size info is in mm
@@ -153,7 +164,8 @@ class Scanner
           int num_transaxial_crystals_per_singles_unit_v,
           int num_detector_layers_v,
           float energy_resolution_v = -1.0f,
-          float reference_energy_v = -1.0f);
+          float reference_energy_v = -1.0f,
+          VendorReferenceOrigin reference_origin_v = VendorReferenceOrigin::Unknown);
 
 
 
@@ -275,6 +287,9 @@ class Scanner
   //! get the reference energy of the energy resolution
   inline float get_reference_energy() const;
 
+  //! get the reference origin positon of the scanner
+  inline VendorReferenceOrigin get_reference_origin() const;
+
   //@} (end of get detector responce info)
 
   //! \name Functions setting info
@@ -328,7 +343,10 @@ class Scanner
   inline void set_reference_energy(const float new_num);
   //@} (end of set info)
   //@} (end of set info)
-  
+
+  //! set the reference origin positon of the scanner
+  inline void set_reference_origin(const VendorReferenceOrigin new_reference_origin);
+
   // Calculate a singles bin index from axial and transaxial singles bin coordinates.
   inline int get_singles_bin_index(int axial_index, int transaxial_index) const;
 
@@ -342,7 +360,6 @@ class Scanner
 
   // Get the transaxial singles bin coordinate from a singles bin.
   inline int get_transaxial_singles_unit(int singles_bin_index) const;
-  
 
 private:
   Type type;
@@ -382,6 +399,8 @@ private:
   //! A negative value indicates, unknown.
   float reference_energy;
 
+  VendorReferenceOrigin reference_origin;
+
 
   // ! set all parameters, case where default_num_arccorrected_bins==max_num_non_arccorrected_bins
   void set_params(Type type_v, const std::list<std::string>& list_of_names_v,
@@ -398,7 +417,8 @@ private:
                   int num_transaxial_crystals_per_singles_unit_v,
                   int num_detector_layers_v,
                   float energy_resolution_v = -1.0f,
-                  float reference_energy = -1.0f);
+                  float reference_energy = -1.0f,
+                  VendorReferenceOrigin reference_origin = VendorReferenceOrigin::Unknown);
 
   // ! set all parameters
   void set_params(Type type_v, const std::list<std::string>& list_of_names_v,
@@ -416,8 +436,8 @@ private:
                   int num_transaxial_crystals_per_singles_unit_v,
                   int num_detector_layers_v,
                   float energy_resolution_v = -1.0f,
-                  float reference_energy = -1.0f);
-
+                  float reference_energy = -1.0f,
+                  VendorReferenceOrigin reference_origin = VendorReferenceOrigin::Unknown);
 
 };
 

--- a/src/include/stir/Scanner.h
+++ b/src/include/stir/Scanner.h
@@ -145,7 +145,7 @@ class Scanner
           int num_detector_layers_v,
           float energy_resolution_v = -1.0f,
           float reference_energy_v = -1.0f,
-          VendorReferenceOrigin reference_origin_v = VendorReferenceOrigin::Unknown);
+          VendorReferenceOrigin reference_origin_v = Unknown);
 
   //! constructor ( a single name)
   /*! size info is in mm
@@ -165,7 +165,7 @@ class Scanner
           int num_detector_layers_v,
           float energy_resolution_v = -1.0f,
           float reference_energy_v = -1.0f,
-          VendorReferenceOrigin reference_origin_v = VendorReferenceOrigin::Unknown);
+          VendorReferenceOrigin reference_origin_v = Unknown);
 
 
 
@@ -418,7 +418,7 @@ private:
                   int num_detector_layers_v,
                   float energy_resolution_v = -1.0f,
                   float reference_energy = -1.0f,
-                  VendorReferenceOrigin reference_origin = VendorReferenceOrigin::Unknown);
+                  VendorReferenceOrigin reference_origin = Unknown);
 
   // ! set all parameters
   void set_params(Type type_v, const std::list<std::string>& list_of_names_v,
@@ -437,7 +437,7 @@ private:
                   int num_detector_layers_v,
                   float energy_resolution_v = -1.0f,
                   float reference_energy = -1.0f,
-                  VendorReferenceOrigin reference_origin = VendorReferenceOrigin::Unknown);
+                  VendorReferenceOrigin reference_origin = Unknown);
 
 };
 

--- a/src/include/stir/Scanner.inl
+++ b/src/include/stir/Scanner.inl
@@ -4,6 +4,8 @@
     Copyright (C) 2000 PARAPET partners
     Copyright (C) 2000- 2007, Hammersmith Imanet Ltd
     Copyright (C) 2016, UCL
+    Copyright (C) 2018, Commonwealth Scientific and Industrial Research Organisation
+                        Australian eHealth Research Centre
     This file is part of STIR.
 
     This file is free software; you can redistribute it and/or modify
@@ -23,12 +25,12 @@
   \ingroup buildblock
   \brief implementation of inline functions of class Scanner
 
+  \author Ashley Gillman
   \author Nikos Efthimiou
   \author Sanida Mustafovic
   \author Kris Thielemans
   \author Long Zhang (set*() functions)
   \author PARAPET project
-
 
 */
 
@@ -229,6 +231,12 @@ Scanner::get_reference_energy() const
     return reference_energy;
 }
 
+Scanner::VendorReferenceOrigin
+Scanner::get_reference_origin() const
+{
+    return reference_origin;
+}
+
 //************************ set ******************************8
 
 void Scanner::set_type(const Type & new_type)
@@ -332,6 +340,12 @@ void
 Scanner::set_reference_energy(const float new_num)
 {
     reference_energy = new_num;
+}
+
+void
+Scanner::set_reference_origin(const VendorReferenceOrigin new_reference_origin)
+{
+  reference_origin = new_reference_origin;
 }
 
 /********    Calculate singles bin index from detection position    *********/

--- a/src/include/stir/VoxelsOnCartesianGrid.h
+++ b/src/include/stir/VoxelsOnCartesianGrid.h
@@ -86,9 +86,11 @@ VoxelsOnCartesianGrid(const shared_ptr < ExamInfo > & exam_info_sptr,
 		      const CartesianCoordinate3D<float>& origin, 
 		      const BasicCoordinate<3,float>& grid_spacing);
 
-  // KT 10/12/2001 replace 2 constructors with the more general one below
-//! use ProjDataInfo to obtain the size information
+//! use ProjDataInfo to obtain the size and origin information
 /*!
+   The resulting FOV will be centered around the middle of the gantry,
+   with some specified offset.
+
    When sizes.x() is -1, a default size in x is found by taking the diameter 
    of the FOV spanned by the projection data. Similar for sizes.y().
 
@@ -101,7 +103,7 @@ VoxelsOnCartesianGrid(const shared_ptr < ExamInfo > & exam_info_sptr,
 
    Actual index ranges start from 0 for z, but from -(x_size_used/2) for x (and similar for y).
 
-   x,y grid spacing are set to the 
+   x,y grid spacing are set to the
    <code>proj_data_info_ptr-\>get_scanner_ptr()-\>get_default_bin_size()/zoom</code>.
    This is to make sure that the voxel size is independent on if arc-correction is used or not.
    If the default bin size is 0, the sampling distance in s (for bin 0) is used.
@@ -109,11 +111,10 @@ VoxelsOnCartesianGrid(const shared_ptr < ExamInfo > & exam_info_sptr,
    z grid spacing is set to half the scanner ring distance.
 
    All voxel values are set 0.
-
 */
 VoxelsOnCartesianGrid(const ProjDataInfo& proj_data_info_ptr,
 		      const float zoom = 1.F,
-		      const CartesianCoordinate3D<float>& origin = CartesianCoordinate3D<float>(0.F,0.F,0.F), 
+		      const CartesianCoordinate3D<float>& offset = CartesianCoordinate3D<float>(0.F,0.F,0.F),
 		      const CartesianCoordinate3D<int>& sizes = CartesianCoordinate3D<int>(-1,-1,-1));
 
 //! Constructor from exam_info and proj_data_info
@@ -125,7 +126,7 @@ VoxelsOnCartesianGrid(const ProjDataInfo& proj_data_info_ptr,
 VoxelsOnCartesianGrid(const shared_ptr < ExamInfo > & exam_info_sptr,
                       const ProjDataInfo& proj_data_info,
 		      const float zoom = 1.F,
-		      const CartesianCoordinate3D<float>& origin = CartesianCoordinate3D<float>(0.F,0.F,0.F),
+		      const CartesianCoordinate3D<float>& offset = CartesianCoordinate3D<float>(0.F,0.F,0.F),
 		      const CartesianCoordinate3D<int>& sizes = CartesianCoordinate3D<int>(-1,-1,-1));
 
 
@@ -190,6 +191,12 @@ void grow_z_range(const int min_z, const int max_z);
 
   //@}
 
+private:
+  void
+  init_from_proj_data_info(const ProjDataInfo& proj_data_info,
+                           const float zoom,
+                           const CartesianCoordinate3D<float>& offset,
+                           const CartesianCoordinate3D<int>& sizes);
 };
 
 
@@ -197,15 +204,3 @@ END_NAMESPACE_STIR
 
 #include "stir/VoxelsOnCartesianGrid.inl"
 #endif
-
-
-
-
-
-
-
-
-
-
-
-

--- a/src/include/stir/modulo.h
+++ b/src/include/stir/modulo.h
@@ -154,6 +154,16 @@ to_0_2pi(const FloatOrDouble phi)
   return modulo(phi, static_cast<FloatOrDouble>(2*_PI));
 }
 
+//! Convert angle to standard range when period is 180 degrees
+/*! Identical to <tt>modulo(phi, static_cast<FloatOrDouble>(_PI))</tt> */
+template <typename FloatOrDouble>
+inline
+FloatOrDouble
+to_0_pi(const FloatOrDouble phi)
+{
+  return modulo(phi, static_cast<FloatOrDouble>(_PI));
+}
+
 //@}
 
 END_NAMESPACE_STIR

--- a/src/include/stir/recon_buildblock/ProjMatrixByBinUsingRayTracing.h
+++ b/src/include/stir/recon_buildblock/ProjMatrixByBinUsingRayTracing.h
@@ -200,6 +200,7 @@ private:
   CartesianCoordinate3D<int> max_index;
 
   shared_ptr<ProjDataInfo> proj_data_info_ptr;
+  shared_ptr< DiscretisedDensity<3,float> > density_info_ptr;
 
 
   virtual void 

--- a/src/include/stir/recon_buildblock/ProjMatrixByBinUsingRayTracing.h
+++ b/src/include/stir/recon_buildblock/ProjMatrixByBinUsingRayTracing.h
@@ -199,8 +199,8 @@ private:
   CartesianCoordinate3D<int> min_index;
   CartesianCoordinate3D<int> max_index;
 
-  shared_ptr<ProjDataInfo> proj_data_info_ptr;
-  shared_ptr< DiscretisedDensity<3,float> > density_info_ptr;
+  shared_ptr<ProjDataInfo> proj_data_info_sptr;
+  shared_ptr< DiscretisedDensity<3,float> > density_info_sptr;
 
 
   virtual void 

--- a/src/recon_buildblock/ProjMatrixByBinUsingRayTracing.cxx
+++ b/src/recon_buildblock/ProjMatrixByBinUsingRayTracing.cxx
@@ -545,25 +545,10 @@ calculate_proj_matrix_elems_for_one_bin(
 
   assert(lor.size() == 0);
    
-  float phi;
+  float phi = proj_data_info_ptr->get_phi(bin);
   float s_in_mm = proj_data_info_ptr->get_s(bin);
-  /* Implementation note.
-     KT initialised s_in_mm above instead of in the if because this meant
-     that gcc 3.0.1 generated identical results to the previous version of this file.
-     Otherwise, some pixels at the boundary appear to be treated differently
-     (probably due to different floating point rounding errors), at least
-     on Linux on x86.
-     A bit of a mistery that.
 
-     TODO this is maybe solved now by having more decent handling of 
-     start and end voxels.
-  */
-  if (!use_actual_detector_boundaries)
-  {
-    phi = proj_data_info_ptr->get_phi(bin);
-    //s_in_mm = proj_data_info_ptr->get_s(bin);
-  }
-  else
+  if (use_actual_detector_boundaries)
   {
     // can be static_cast later on
     const ProjDataInfoCylindricalNoArcCorr& proj_data_info_noarccor =
@@ -580,16 +565,16 @@ calculate_proj_matrix_elems_for_one_bin(
                                                  det_num2,
                                                  bin.view_num(),
                                                  bin.tangential_pos_num());
+
+    const float old_phi = phi;
     phi = static_cast<float>((det_num1+det_num2)*_PI/num_detectors-_PI/2);
-    const float old_phi=proj_data_info_ptr->get_phi(bin);
     if (fabs(phi-old_phi)>2*_PI/num_detectors)
       warning("view %d old_phi %g new_phi %g\n",bin.view_num(), old_phi, phi);
 
+    const float old_s_in_mm = s_in_mm;
     s_in_mm = static_cast<float>(ring_radius*sin((det_num1-det_num2)*_PI/num_detectors+_PI/2));
-    const float old_s_in_mm=proj_data_info_ptr->get_s(bin);
     if (fabs(s_in_mm-old_s_in_mm)>proj_data_info_ptr->get_sampling_in_s(bin)*.0001)
       warning("tangential_pos_num %d old_s_in_mm %g new_s_in_mm %g\n",bin.tangential_pos_num(), old_s_in_mm, s_in_mm);
-
   }
   
   const float cphi = cos(phi);

--- a/src/recon_buildblock/ProjMatrixByBinUsingRayTracing.cxx
+++ b/src/recon_buildblock/ProjMatrixByBinUsingRayTracing.cxx
@@ -389,7 +389,7 @@ static void
 ray_trace_one_lor(ProjMatrixElemsForOneBin& lor, 
                   const float s_in_mm, const float m_in_mm, 
                   const float cphi, const float sphi, 
-                  const float costheta, const float tantheta, 
+                  const float tantheta, 
                   const float offset_in_z,
                   const float fovrad_in_mm,
                   const CartesianCoordinate3D<float>& voxel_size,
@@ -666,7 +666,7 @@ calculate_proj_matrix_elems_for_one_bin(
   if (num_tangential_LORs == 1)
   {
     ray_trace_one_lor(lor, s_in_mm, m_in_mm,
-                        cphi, sphi, costheta, tantheta, 
+                        cphi, sphi, tantheta,
                         offset_in_z, fovrad_in_mm, 
                         voxel_size,
                         restrict_to_cylindrical_FOV,
@@ -687,7 +687,7 @@ calculate_proj_matrix_elems_for_one_bin(
     {
       ray_traced_lor.erase();
       ray_trace_one_lor(ray_traced_lor, current_s_in_mm, m_in_mm,
-                          cphi, sphi, costheta, tantheta, 
+                          cphi, sphi, tantheta,
                           offset_in_z, fovrad_in_mm, 
                           voxel_size,
                           restrict_to_cylindrical_FOV,

--- a/src/test/test_VoxelsOnCartesianGrid.cxx
+++ b/src/test/test_VoxelsOnCartesianGrid.cxx
@@ -199,7 +199,18 @@ VoxelsOnCartesianGridTests::run_tests()
                                                 scanner_ptr->get_default_bin_size()/zoom,
                                                 scanner_ptr->get_default_bin_size()/zoom),
                    "test on grid spacing");
-    check_if_equal(ob5.get_origin(), origin);
+    check_if_equal(// image centre
+                   ob5.get_origin()
+                   + CartesianCoordinate3D<float>((z_size-1)
+                                                  * ob5.get_grid_spacing()[1] / 2,
+                                                  0, 0),
+                   // gantry cenre
+                   origin
+                   + CartesianCoordinate3D<float>((scanner_ptr->get_num_rings() - 1)
+                                                  * scanner_ptr->get_ring_spacing()
+                                                  / 2,
+                                                  0, 0),
+                   "test on origin");
     
     {
       cerr << "Tests get_empty_voxels_on_cartesian_grid\n";

--- a/src/test/test_VoxelsOnCartesianGrid.cxx
+++ b/src/test/test_VoxelsOnCartesianGrid.cxx
@@ -204,7 +204,7 @@ VoxelsOnCartesianGridTests::run_tests()
                    + CartesianCoordinate3D<float>((z_size-1)
                                                   * ob5.get_grid_spacing()[1] / 2,
                                                   0, 0),
-                   // gantry cenre
+                   // offset from gantry centre
                    origin
                    + CartesianCoordinate3D<float>((scanner_ptr->get_num_rings() - 1)
                                                   * scanner_ptr->get_ring_spacing()

--- a/src/test/test_VoxelsOnCartesianGrid.cxx
+++ b/src/test/test_VoxelsOnCartesianGrid.cxx
@@ -170,7 +170,7 @@ VoxelsOnCartesianGridTests::run_tests()
                                                 scanner_ptr->get_default_bin_size()/zoom,
                                                 scanner_ptr->get_default_bin_size()/zoom),
                    "test on grid spacing");
-    check_if_equal(ob4.get_origin(), origin);
+    check_if_equal(ob4.get_origin(), origin, "test on origin");
   }
   {
     

--- a/src/test/test_coordinates.cxx
+++ b/src/test/test_coordinates.cxx
@@ -110,6 +110,12 @@ coordinateTests::run_tests()
     {
       BasicCoordinate<3, float> a1;
       a1 = b;
+      check_if_zero(norm(a1 + -a1), "testing unary operator-");
+    }
+
+    {
+      BasicCoordinate<3, float> a1;
+      a1 = b;
       a1 *= 3;
       a1 += a;
       a1 -= 4;


### PR DESCRIPTION
Progress to implement a change of origin.

# Features

- [X] `Scanner` now has a field specifying where the origin is defined with respect to
    - for mMR, this is redefined to middle of gantry
    - defaults for other scanners to middle of first ring
- [X] `ProjMatrixByBinUsingRayTracing` generates consistent projections regardless of origin by leveraging DiscretisedDensity to convert between gantry and bed/index space.
- [ ] Allow for shifts in origin
- [ ] Bed position
- [ ] Hard code mMR offset
  - And verify between two scanners.
- [ ] ITK IO to take into account patient position.