### PR TITLE
[ENH] Add `make check` which will compile all tests then run them.

### DIFF
--- a/documentation/STIR-UsersGuide.tex
+++ b/documentation/STIR-UsersGuide.tex
@@ -249,6 +249,12 @@ When using \texttt{ccmake} as opposed to \texttt{cmake-gui}, the key presses are
 \texttt{c} to do additional configurations, \texttt{g} for generating
 your build files, \texttt{q} to quit}. After this step, you will have to run your build system (e.g.\ on Linux etc,
 type \texttt{make}, then \texttt{make test}, then \texttt{make install}).
+A helpful note: You can specify just to make a single ``target'',
+using \texttt{make <target>}. All executable names are targets that
+make just the required executable (e.g., \texttt{make FBP2D}). A
+useful target for developers is to just make the tests, using
+\texttt{make tests}. So \texttt{make tests && make test} would build
+then run the tests.
 
 On Windows or MacOSX, the procedure is essentially the same, except that you will likely have
 to specify more locations. When using Visual Studio, XCode or other IDEs as  your build system,

--- a/documentation/release_3.1.htm
+++ b/documentation/release_3.1.htm
@@ -214,6 +214,10 @@ You should normally not have to change these options.</li>
 <li> CMake now has a flag to create the target "doc" for building the Doxygen documentation
   thanks to Jannis Fischer.
 </li>
+<li> Added a <tt>tests</tt> build target so that <tt>make tests</tt>
+     (or whatever is appropriate for your build system) will build all
+     tests (not the other executables or Python etc libraries) .
+</li>
 </ul>
 
 <p><strong>WARNING</strong>: <code>fwdtest</code> and <code>bcktest</code> are now only installed when BUILD_TESTING is ON. Use <code>forward_project</code> and <code>backward_project</code> instead.</p>

--- a/src/cmake/stir_test_exe_targets.cmake
+++ b/src/cmake/stir_test_exe_targets.cmake
@@ -50,6 +50,11 @@
 #message(status dir_SIMPLE_TEST_EXE_SOURCES_NO_REGISTRIES: ${dir_SIMPLE_TEST_EXE_SOURCES_NO_REGISTRIES})
 #message(status dir_SIMPLE_TEST_EXE_SOURCES_NO_REGISTRIES: ${${dir_SIMPLE_TEST_EXE_SOURCES_NO_REGISTRIES}})
 
+
+if(NOT TARGET tests)
+  add_custom_target(tests)
+endif()
+
 #### define macros
 
 macro (create_stir_involved_test source  libraries dependencies)
@@ -58,6 +63,8 @@ macro (create_stir_involved_test source  libraries dependencies)
    add_executable(${executable} ${source} ${dependencies})
    target_link_libraries(${executable} ${libraries})
    SET_PROPERTY(TARGET ${executable} PROPERTY FOLDER "Tests")
+
+   add_dependencies(tests ${executable})
   endif()
 endmacro( create_stir_involved_test)
 


### PR DESCRIPTION
Currently there is no way (I am aware of?) to compile all of the testing targets. This provides it, with `make check`.