### PR TITLE
[FIX] PostionValue defined in wrong order, breaks get_position()

### DIFF
--- a/src/include/stir/PatientPosition.h
+++ b/src/include/stir/PatientPosition.h
@@ -52,10 +52,10 @@ class PatientPosition
     HFP, //!< Head First-Prone 	
     HFDR, //!< Head First-Decubitus Right 	
     HFDL, //!< Head First-Decubitus Left
-    FFDR, //!< Feet First-Decubitus Right 	
+    FFS, //!< Feet First-Supine
+    FFP, //!< Feet First-Prone
+    FFDR, //!< Feet First-Decubitus Right
     FFDL, //!< Feet First-Decubitus Left
-    FFP, //!< Feet First-Prone 	
-    FFS, //!< Feet First-Supine 
     unknown_position
   };
 


### PR DESCRIPTION
https://github.com/UCL/STIR/blob/master/src/buildblock/PatientPosition.cxx#L62 Assumes a certain order