### PR TITLE
[FIX] New GCC didn't like redeclaring static.

### DIFF
--- a/src/IO/ITKImageInputFileFormat.cxx
+++ b/src/IO/ITKImageInputFileFormat.cxx
@@ -214,7 +214,6 @@ convert_ITK_to_STIR(const ITKImageMulti::Pointer itk_image_orig)
 
 //To read any file format via ITK
 template<>
-static
 STIRImageSingle*
 read_file_itk(const std::string &filename)
 {
@@ -300,7 +299,6 @@ read_file_itk(const std::string &filename)
 
 //To read any file format via ITK
 template<>
-static
 STIRImageMulti*
 read_file_itk(const std::string &filename)
 {


### PR DESCRIPTION
See "Explicit template specialization cannot have a storage class" in https://www.gnu.org/software/gcc/gcc-4.3/porting_to.html

```
/home/gil2a4/dev/UCL@github.com/STIR/src/IO/ITKOutputFileFormat.cxx: In member function ‘virtual stir::Succeeded stir::ITKOutputFileFormat::actual_write_to_
file(std::__cxx11::string&, const stir::DiscretisedDensity<3, float>&) const’:                                                                 
/home/gil2a4/dev/UCL@github.com/STIR/src/IO/ITKOutputFileFormat.cxx:166:27: warning: ‘itk::ImageRegionIterator<TImage> itk::ImageRegionIterator<TImage>::Beg
in() const [with TImage = itk::Image<float, 3>]’ is deprecated [-Wdeprecated-declarations]                                                 
       for ( it = it.Begin(); !it.IsAtEnd(); ++it, ++stir_iter  ){                                                                                          
                           ^                                                                                                                              
In file included from /nix/store/wj4jv1plps6hs0bm4p658cgm3gwgdfas-itk-4.13.0/include/ITK-4.13/itkImageRegionIterator.h:144:0,                               
                 from /nix/store/wj4jv1plps6hs0bm4p658cgm3gwgdfas-itk-4.13.0/include/ITK-4.13/itkImageFileWriter.hxx:28,
                 from /nix/store/wj4jv1plps6hs0bm4p658cgm3gwgdfas-itk-4.13.0/include/ITK-4.13/itkImageFileWriter.h:226,
                 from /home/gil2a4/dev/UCL@github.com/STIR/src/IO/ITKOutputFileFormat.cxx:32:                                                               
/nix/store/wj4jv1plps6hs0bm4p658cgm3gwgdfas-itk-4.13.0/include/ITK-4.13/itkImageRegionIterator.hxx:61:1: note: declared here                                 ImageRegionIterator< TImage >                                                                                    
 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~                                                                                               
/home/gil2a4/dev/UCL@github.com/STIR/src/IO/ITKImageInputFileFormat.cxx:217:1: error: explicit template specialization cannot have a storage class
 static                                                                                                                   
 ^~~~~~                                                                                                                   
/home/gil2a4/dev/UCL@github.com/STIR/src/IO/ITKImageInputFileFormat.cxx:303:1: error: explicit template specialization cannot have a storage class
 static    
```