### PR TITLE
fix a bug in upsample_and_fit_single_scatter

### DIFF
--- a/src/scatter_utilities/upsample_and_fit_single_scatter.cxx
+++ b/src/scatter_utilities/upsample_and_fit_single_scatter.cxx
@@ -188,8 +188,8 @@ int main(int argc, const char *argv[])
 
   if (stir::is_null_ptr(normalisation_sptr))
     {
-	  normalisation_sptr.reset(new stir::TrivialBinNormalisation);
-    normalisation_sptr->set_up(data_to_fit_proj_data_sptr->get_proj_data_info_ptr()->create_shared_clone());
+       normalisation_sptr.reset(new stir::TrivialBinNormalisation);
+       normalisation_sptr->set_up(data_to_fit_proj_data_sptr->get_proj_data_info_ptr()->create_shared_clone());
     }
   stir::shared_ptr<stir::ProjDataInfo> data_to_fit_proj_data_info_sptr =
     data_to_fit_proj_data_sptr->get_proj_data_info_ptr()->create_shared_clone();

--- a/src/scatter_utilities/upsample_and_fit_single_scatter.cxx
+++ b/src/scatter_utilities/upsample_and_fit_single_scatter.cxx
@@ -189,6 +189,7 @@ int main(int argc, const char *argv[])
   if (stir::is_null_ptr(normalisation_sptr))
     {
 	  normalisation_sptr.reset(new stir::TrivialBinNormalisation);
+    normalisation_sptr->set_up(data_to_fit_proj_data_sptr->get_proj_data_info_ptr()->create_shared_clone());
     }
   stir::shared_ptr<stir::ProjDataInfo> data_to_fit_proj_data_info_sptr =
     data_to_fit_proj_data_sptr->get_proj_data_info_ptr()->create_shared_clone();


### PR DESCRIPTION
In recent updates of normalisation classes, normalisation shared-pointer need to be set_up before usage