### PR TITLE
ProjDataFromStream should use is_null_ptr

### DIFF
--- a/src/buildblock/ProjDataFromStream.cxx
+++ b/src/buildblock/ProjDataFromStream.cxx
@@ -214,7 +214,7 @@ ProjDataFromStream::get_viewgram(const int view_num, const int segment_num,
 float
 ProjDataFromStream::get_bin_value(const Bin& this_bin) const
 {
-    if (sino_stream == 0)
+    if (is_null_ptr(sino_stream))
     {
         error("ProjDataFromStream::get_viewgram: stream ptr is 0\n");
     }


### PR DESCRIPTION
Current code gives the following error:

```
Building CXX object src/buildblock/CMakeFiles/buildblock.dir/ProjDataFromStream.cxx.o
/Users/rich/Documents/Code/STIR/Source/src/buildblock/ProjDataFromStream.cxx:217:21: error: use of overloaded operator '==' is ambiguous (with operand types 'const shared_ptr<std::iostream>' (aka 'const shared_ptr<basic_iostream<char> >') and 'int')
    if (sino_stream == 0)
        ~~~~~~~~~~~ ^  ~
```
Instead the following should be used:
```
if (is_null_ptr(sino_stream))
```