### PR TITLE
target_include_directories for boost

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,7 +77,6 @@ set(ConfigPackageLocation lib/cmake/)
 #### we need the boost library from boost.org
 set(BOOST_ROOT CACHE PATH "root of Boost")
 find_package( Boost 1.36.0 REQUIRED )
-include_directories(${Boost_INCLUDE_DIRS})
 
 #### optional external libraries. 
 # Listed here such that we know if we should compile extra utilities

--- a/src/cmake/STIRConfig.cmake.in
+++ b/src/cmake/STIRConfig.cmake.in
@@ -46,16 +46,8 @@ set(STIR_REGISTRIES @STIR_REGISTRIES@)
 # to set ITK_DIR etc first before calling find_package
 # to make sure we pick the same version of the external library
 
-if (@BOOST_ROOT@)
-  set(BOOST_ROOT "@BOOST_ROOT@")
-endif()
-set (BOOST_INCLUDEDIR "@Boost_INCLUDE_DIRS@")
-find_package(Boost REQUIRED)
-
 if (@ITK_FOUND@)
   message(STATUS "ITK support in STIR enabled.")
-  set(ITK_DIR "@ITK_DIR@")
-  find_package(ITK REQUIRED)
   set(STIR_BUILT_WITH_ITK TRUE)
 endif()
 

--- a/src/cmake/STIRConfig.cmake.in
+++ b/src/cmake/STIRConfig.cmake.in
@@ -48,6 +48,8 @@ set(STIR_REGISTRIES @STIR_REGISTRIES@)
 
 if (@ITK_FOUND@)
   message(STATUS "ITK support in STIR enabled.")
+  set(ITK_DIR "@ITK_DIR@")
+  find_package(ITK REQUIRED)
   set(STIR_BUILT_WITH_ITK TRUE)
 endif()
 

--- a/src/cmake/stir_exe_targets.cmake
+++ b/src/cmake/stir_exe_targets.cmake
@@ -31,6 +31,7 @@ foreach(executable ${${dir_EXE_SOURCES}})
    add_executable(${executable} ${ALL_HEADERS} ${ALL_INLINES}  ${ALL_TXXS} ${executable} ${STIR_REGISTRIES})
    target_link_libraries(${executable} ${STIR_LIBRARIES})
    SET_PROPERTY(TARGET ${executable} PROPERTY FOLDER "Executables")
+   target_include_directories(${executable} PUBLIC ${Boost_INCLUDE_DIR})
   endif()
 endforeach()
 

--- a/src/cmake/stir_lib_target.cmake
+++ b/src/cmake/stir_lib_target.cmake
@@ -25,7 +25,7 @@ target_include_directories(${dir} PUBLIC
   $<BUILD_INTERFACE:${STIR_INCLUDE_DIR}>
   $<INSTALL_INTERFACE:include>)
 
-target_include_directories(${dir} PUBLIC Boost::boost)
+target_include_directories(${dir} PUBLIC ${Boost_INCLUDE_DIR})
 
 SET_PROPERTY(TARGET ${dir} PROPERTY FOLDER "Libs")
 

--- a/src/cmake/stir_lib_target.cmake
+++ b/src/cmake/stir_lib_target.cmake
@@ -25,6 +25,8 @@ target_include_directories(${dir} PUBLIC
   $<BUILD_INTERFACE:${STIR_INCLUDE_DIR}>
   $<INSTALL_INTERFACE:include>)
 
+target_include_directories(${dir} PUBLIC Boost::boost)
+
 SET_PROPERTY(TARGET ${dir} PROPERTY FOLDER "Libs")
 
 install(TARGETS ${dir} EXPORT STIRTargets DESTINATION lib)

--- a/src/cmake/stir_test_exe_targets.cmake
+++ b/src/cmake/stir_test_exe_targets.cmake
@@ -63,6 +63,7 @@ macro (create_stir_involved_test source  libraries dependencies)
    add_executable(${executable} ${source} ${dependencies})
    target_link_libraries(${executable} ${libraries})
    SET_PROPERTY(TARGET ${executable} PROPERTY FOLDER "Tests")
+   target_include_directories(${executable} PUBLIC ${Boost_INCLUDE_DIR})
 
    add_dependencies(BUILD_TESTS ${executable})
   endif()


### PR DESCRIPTION
This avoids having to use find_package(boost), which should be avoided as much as possible. 

The ITK files were already linked privately, and so the find_package(ITK) can be removed from the STIRConfig.cmake file (which is good because the findITK.cmake prepends all its paths, which is a little naughty).