### PR TITLE
Two list mode functions to get and set position in list mode data stream

### DIFF
--- a/src/include/stir/IO/InputStreamFromROOTFile.h
+++ b/src/include/stir/IO/InputStreamFromROOTFile.h
@@ -104,6 +104,10 @@ public:
     //! Set current position
     inline
     Succeeded set_get_position(const SavedPosition&);
+
+    //! Go to an event number
+//    Succeeded set_listmode_position(unsigned long pos);
+
     //! Get the vector with the saved positions
     inline
     std::vector<unsigned long int> get_saved_get_positions() const;

--- a/src/include/stir/IO/InputStreamFromROOTFile.h
+++ b/src/include/stir/IO/InputStreamFromROOTFile.h
@@ -105,8 +105,9 @@ public:
     inline
     Succeeded set_get_position(const SavedPosition&);
 
-    //! Go to an event number
-//    Succeeded set_listmode_position(unsigned long pos);
+    //! Go to event number [pos]
+    inline
+    Succeeded set_listmode_position(unsigned long pos);
 
     //! Get the vector with the saved positions
     inline

--- a/src/include/stir/IO/InputStreamFromROOTFile.h
+++ b/src/include/stir/IO/InputStreamFromROOTFile.h
@@ -109,6 +109,10 @@ public:
     inline
     Succeeded set_listmode_position(unsigned long pos);
 
+    //! Return the current event position
+    inline
+    unsigned long get_list_mode_position();
+
     //! Get the vector with the saved positions
     inline
     std::vector<unsigned long int> get_saved_get_positions() const;

--- a/src/include/stir/IO/InputStreamFromROOTFile.h
+++ b/src/include/stir/IO/InputStreamFromROOTFile.h
@@ -107,7 +107,7 @@ public:
 
     //! Go to event number [pos]
     inline
-    Succeeded set_listmode_position(unsigned long pos);
+    Succeeded set_list_mode_position(unsigned long pos);
 
     //! Return the current event position
     inline

--- a/src/include/stir/IO/InputStreamFromROOTFile.inl
+++ b/src/include/stir/IO/InputStreamFromROOTFile.inl
@@ -86,12 +86,13 @@ set_listmode_position(unsigned long pos)
     }
 }
 
-//Succeeded
-//InputStreamFromROOTFile::
-//get_current_position()
-//{
-
-//}
+//get the current position
+unsigned long
+InputStreamFromROOTFile::
+get_list_mode_position()
+{
+    return current_position;
+}
 
 std::vector<unsigned long int>
 InputStreamFromROOTFile::

--- a/src/include/stir/IO/InputStreamFromROOTFile.inl
+++ b/src/include/stir/IO/InputStreamFromROOTFile.inl
@@ -52,18 +52,37 @@ save_get_position()
     return saved_get_positions.size()-1;
 }
 
-Succeeded
-InputStreamFromROOTFile::
-set_get_position(const InputStreamFromROOTFile::SavedPosition& pos)
-{
-    assert(pos < saved_get_positions.size());
-    if (saved_get_positions[pos] > nentries)
-        current_position = nentries; // go to eof
-    else
-        current_position = saved_get_positions[pos];
+//Succeeded
+//InputStreamFromROOTFile::
+//set_get_position(const InputStreamFromROOTFile::SavedPosition& pos)
+//{
+//    assert(pos < saved_get_positions.size());
+//    if (saved_get_positions[pos] > nentries)
+//        current_position = nentries; // go to eof
+//    else
+//        current_position = saved_get_positions[pos];
 
-    return Succeeded::yes;
-}
+//    return Succeeded::yes;
+//}
+
+//Succeeded
+//InputStreamFromROOTFile::
+//set_listmode_position(unsigned long pos)
+//{
+//    if (pos > nentries)
+//        current_position = nentries;
+//    else
+//        current_position = pos;
+
+//    return Succeeded::yes;
+//}
+
+//Succeeded
+//InputStreamFromROOTFile::
+//get_current_position()
+//{
+
+//}
 
 std::vector<unsigned long int>
 InputStreamFromROOTFile::

--- a/src/include/stir/IO/InputStreamFromROOTFile.inl
+++ b/src/include/stir/IO/InputStreamFromROOTFile.inl
@@ -65,17 +65,26 @@ set_get_position(const InputStreamFromROOTFile::SavedPosition& pos)
     return Succeeded::yes;
 }
 
-//Succeeded
-//InputStreamFromROOTFile::
-//set_listmode_position(unsigned long pos)
-//{
-//    if (pos > nentries)
-//        current_position = nentries;
-//    else
-//        current_position = pos;
 
-//    return Succeeded::yes;
-//}
+//! Set current position
+Succeeded
+InputStreamFromROOTFile::
+set_listmode_position(unsigned long pos)
+{
+    if (pos > nentries){
+        current_position = nentries;
+        }
+    else
+    {
+        current_position = pos;
+    }
+
+    if (current_position == pos)
+        return Succeeded::yes;
+    else {
+        return Succeeded::no;
+    }
+}
 
 //Succeeded
 //InputStreamFromROOTFile::

--- a/src/include/stir/IO/InputStreamFromROOTFile.inl
+++ b/src/include/stir/IO/InputStreamFromROOTFile.inl
@@ -52,18 +52,18 @@ save_get_position()
     return saved_get_positions.size()-1;
 }
 
-//Succeeded
-//InputStreamFromROOTFile::
-//set_get_position(const InputStreamFromROOTFile::SavedPosition& pos)
-//{
-//    assert(pos < saved_get_positions.size());
-//    if (saved_get_positions[pos] > nentries)
-//        current_position = nentries; // go to eof
-//    else
-//        current_position = saved_get_positions[pos];
+Succeeded
+InputStreamFromROOTFile::
+set_get_position(const InputStreamFromROOTFile::SavedPosition& pos)
+{
+    assert(pos < saved_get_positions.size());
+    if (saved_get_positions[pos] > nentries)
+        current_position = nentries; // go to eof
+    else
+        current_position = saved_get_positions[pos];
 
-//    return Succeeded::yes;
-//}
+    return Succeeded::yes;
+}
 
 //Succeeded
 //InputStreamFromROOTFile::

--- a/src/include/stir/IO/InputStreamFromROOTFile.inl
+++ b/src/include/stir/IO/InputStreamFromROOTFile.inl
@@ -69,7 +69,7 @@ set_get_position(const InputStreamFromROOTFile::SavedPosition& pos)
 //! Set current position
 Succeeded
 InputStreamFromROOTFile::
-set_listmode_position(unsigned long pos)
+set_list_mode_position(unsigned long pos)
 {
     if (pos > nentries){
         current_position = nentries;

--- a/src/include/stir/IO/InputStreamFromROOTFile.inl
+++ b/src/include/stir/IO/InputStreamFromROOTFile.inl
@@ -57,12 +57,7 @@ InputStreamFromROOTFile::
 set_get_position(const InputStreamFromROOTFile::SavedPosition& pos)
 {
     assert(pos < saved_get_positions.size());
-    if (saved_get_positions[pos] > nentries)
-        current_position = nentries; // go to eof
-    else
-        current_position = saved_get_positions[pos];
-
-    return Succeeded::yes;
+    return set_list_mode_position(saved_get_positions[pos]);
 }
 
 
@@ -71,19 +66,15 @@ Succeeded
 InputStreamFromROOTFile::
 set_list_mode_position(unsigned long pos)
 {
-    if (pos > nentries){
+    if (pos >= nentries)
+    {
         current_position = nentries;
-        }
+    }
     else
     {
         current_position = pos;
     }
-
-    if (current_position == pos)
-        return Succeeded::yes;
-    else {
-        return Succeeded::no;
-    }
+    return Succeeded::yes;
 }
 
 //get the current position

--- a/src/include/stir/IO/InputStreamWithRecords.h
+++ b/src/include/stir/IO/InputStreamWithRecords.h
@@ -111,7 +111,11 @@ public:
 
   //! set current position to pos
   inline
-  Succeeded set_listmode_position(unsigned long pos);
+  Succeeded set_list_mode_position(unsigned long pos);
+
+  //! Return the current position
+  inline
+  unsigned long get_list_mode_position();
 
   //! Function that enables the user to store the saved get_positions
   /*! Together with set_saved_get_positions(), this allows 

--- a/src/include/stir/IO/InputStreamWithRecords.h
+++ b/src/include/stir/IO/InputStreamWithRecords.h
@@ -109,8 +109,9 @@ public:
   inline
   Succeeded set_get_position(const SavedPosition&);
 
-//  inline
-//  Succeeded set_listmode_position(unsigned long pos);
+  //! set current position to pos
+  inline
+  Succeeded set_listmode_position(unsigned long pos);
 
   //! Function that enables the user to store the saved get_positions
   /*! Together with set_saved_get_positions(), this allows 

--- a/src/include/stir/IO/InputStreamWithRecords.h
+++ b/src/include/stir/IO/InputStreamWithRecords.h
@@ -109,6 +109,9 @@ public:
   inline
   Succeeded set_get_position(const SavedPosition&);
 
+//  inline
+//  Succeeded set_listmode_position(unsigned long pos);
+
   //! Function that enables the user to store the saved get_positions
   /*! Together with set_saved_get_positions(), this allows 
       reinstating the saved get_positions when 

--- a/src/include/stir/IO/InputStreamWithRecords.inl
+++ b/src/include/stir/IO/InputStreamWithRecords.inl
@@ -171,13 +171,13 @@ set_get_position(const typename InputStreamWithRecords<RecordT, OptionsT>::Saved
     return Succeeded::yes;
 }
 
-//template <class RecordT, class OptionsT>
-//Succeeded
-//InputStreamWithRecords<RecordT, OptionsT>::
-//set_listmode_position(const unsigned long pos)
-//{
-//    return Succeeded::no;
-//}
+template <class RecordT, class OptionsT>
+Succeeded
+InputStreamWithRecords<RecordT, OptionsT>::
+set_listmode_position(const unsigned long pos)
+{
+    return Succeeded::no;
+}
 
 template <class RecordT, class OptionsT>
 std::vector<std::streampos> 

--- a/src/include/stir/IO/InputStreamWithRecords.inl
+++ b/src/include/stir/IO/InputStreamWithRecords.inl
@@ -171,6 +171,14 @@ set_get_position(const typename InputStreamWithRecords<RecordT, OptionsT>::Saved
     return Succeeded::yes;
 }
 
+//template <class RecordT, class OptionsT>
+//Succeeded
+//InputStreamWithRecords<RecordT, OptionsT>::
+//set_listmode_position(const unsigned long pos)
+//{
+//    return Succeeded::no;
+//}
+
 template <class RecordT, class OptionsT>
 std::vector<std::streampos> 
 InputStreamWithRecords<RecordT, OptionsT>::

--- a/src/include/stir/IO/InputStreamWithRecords.inl
+++ b/src/include/stir/IO/InputStreamWithRecords.inl
@@ -159,16 +159,8 @@ set_get_position(const typename InputStreamWithRecords<RecordT, OptionsT>::Saved
     return Succeeded::no;
 
   assert(pos < saved_get_positions.size());
-  stream_ptr->clear();
-  if (saved_get_positions[pos] == std::streampos(-1))
-    stream_ptr->seekg(0, std::ios::end); // go to eof
-  else
-    stream_ptr->seekg(saved_get_positions[pos]);
-    
-  if (!stream_ptr->good())
-    return Succeeded::no;
-  else
-    return Succeeded::yes;
+
+  return set_list_mode_position(saved_get_positions[pos]);
 }
 
 template <class RecordT, class OptionsT>

--- a/src/include/stir/IO/InputStreamWithRecords.inl
+++ b/src/include/stir/IO/InputStreamWithRecords.inl
@@ -155,9 +155,6 @@ Succeeded
 InputStreamWithRecords<RecordT, OptionsT>::
 set_get_position(const typename InputStreamWithRecords<RecordT, OptionsT>::SavedPosition& pos)
 {
-  if (is_null_ptr(stream_ptr))
-    return Succeeded::no;
-
   assert(pos < saved_get_positions.size());
 
   return set_list_mode_position(saved_get_positions[pos]);
@@ -168,8 +165,21 @@ Succeeded
 InputStreamWithRecords<RecordT, OptionsT>::
 set_list_mode_position(const unsigned long pos)
 {
-    return Succeeded::no;
+    if (is_null_ptr(stream_ptr))
+      return Succeeded::no;
+
+    stream_ptr->clear();
+    if (pos >= std::streampos(-1))
+      stream_ptr->seekg(0, std::ios::end); // go to eof
+    else
+      stream_ptr->seekg(pos);
+
+    if (!stream_ptr->good())
+      return Succeeded::no;
+    else
+      return Succeeded::yes;
 }
+
 
 template <class RecordT, class OptionsT>
 unsigned long
@@ -180,7 +190,6 @@ get_list_mode_position()
     pos = stream_ptr->tellg();
     return pos;
 }
-
 
 
 template <class RecordT, class OptionsT>

--- a/src/include/stir/IO/InputStreamWithRecords.inl
+++ b/src/include/stir/IO/InputStreamWithRecords.inl
@@ -174,10 +174,22 @@ set_get_position(const typename InputStreamWithRecords<RecordT, OptionsT>::Saved
 template <class RecordT, class OptionsT>
 Succeeded
 InputStreamWithRecords<RecordT, OptionsT>::
-set_listmode_position(const unsigned long pos)
+set_list_mode_position(const unsigned long pos)
 {
     return Succeeded::no;
 }
+
+template <class RecordT, class OptionsT>
+unsigned long
+InputStreamWithRecords<RecordT, OptionsT>::
+get_list_mode_position()
+{
+    std::streampos pos;
+    pos = stream_ptr->tellg();
+    return pos;
+}
+
+
 
 template <class RecordT, class OptionsT>
 std::vector<std::streampos> 

--- a/src/include/stir/listmode/CListModeData.h
+++ b/src/include/stir/listmode/CListModeData.h
@@ -214,7 +214,7 @@ public:
   virtual
     Succeeded set_get_position(const SavedPosition&) = 0;
 
-   //! Go to a position in the listmode data
+   //! Set the position for reading to a integer position
   virtual
     Succeeded set_listmode_position(unsigned long pos) = 0;
     //Succeeded set_listmode_position(unsigned long pos) {return Succeeded::no;}//= 0;

--- a/src/include/stir/listmode/CListModeData.h
+++ b/src/include/stir/listmode/CListModeData.h
@@ -215,8 +215,9 @@ public:
     Succeeded set_get_position(const SavedPosition&) = 0;
 
    //! Go to a position in the listmode data
-//  virtual
-//    Succeeded set_listmode_position(unsigned long pos) {return Succeeded::no;}//= 0;
+  virtual
+    Succeeded set_listmode_position(unsigned long pos) = 0;
+    //Succeeded set_listmode_position(unsigned long pos) {return Succeeded::no;}//= 0;
 
   //! Get scanner pointer  
   /*! Returns a pointer to a scanner object that is appropriate for the 

--- a/src/include/stir/listmode/CListModeData.h
+++ b/src/include/stir/listmode/CListModeData.h
@@ -31,6 +31,7 @@
 #include "stir/ProjDataInfo.h"
 #include "stir/IO/ExamData.h"
 #include "stir/RegisteredParsingObject.h"
+#include "stir/Succeeded.h"
 
 # ifdef BOOST_NO_STDC_NAMESPACE
 namespace std { using ::time_t; }
@@ -212,6 +213,10 @@ public:
   
   virtual
     Succeeded set_get_position(const SavedPosition&) = 0;
+
+   //! Go to a position in the listmode data
+//  virtual
+//    Succeeded set_listmode_position(unsigned long pos) {return Succeeded::no;}//= 0;
 
   //! Get scanner pointer  
   /*! Returns a pointer to a scanner object that is appropriate for the 

--- a/src/include/stir/listmode/CListModeData.h
+++ b/src/include/stir/listmode/CListModeData.h
@@ -216,8 +216,11 @@ public:
 
    //! Set the position for reading to a integer position
   virtual
-    Succeeded set_listmode_position(unsigned long pos) = 0;
-    //Succeeded set_listmode_position(unsigned long pos) {return Succeeded::no;}//= 0;
+    Succeeded set_list_mode_position(unsigned long pos) = 0;
+
+    //! get current position position
+  virtual
+    unsigned long get_list_mode_position() = 0;
 
   //! Get scanner pointer  
   /*! Returns a pointer to a scanner object that is appropriate for the 

--- a/src/include/stir/listmode/CListModeDataECAT8_32bit.h
+++ b/src/include/stir/listmode/CListModeDataECAT8_32bit.h
@@ -70,6 +70,9 @@ public:
   virtual
     Succeeded set_get_position(const SavedPosition&);
 
+//  virtual
+//    Succeeded set_listmode_position(unsigned long pos);
+
   //! returns \c true, as ECAT listmode data stores delayed events (and prompts)
   /*! \todo this might depend on the acquisition parameters */
   virtual bool has_delayeds() const { return true; }

--- a/src/include/stir/listmode/CListModeDataECAT8_32bit.h
+++ b/src/include/stir/listmode/CListModeDataECAT8_32bit.h
@@ -70,8 +70,8 @@ public:
   virtual
     Succeeded set_get_position(const SavedPosition&);
 
-//  virtual
-//    Succeeded set_listmode_position(unsigned long pos);
+ virtual
+    Succeeded set_listmode_position(unsigned long pos);
 
   //! returns \c true, as ECAT listmode data stores delayed events (and prompts)
   /*! \todo this might depend on the acquisition parameters */

--- a/src/include/stir/listmode/CListModeDataECAT8_32bit.h
+++ b/src/include/stir/listmode/CListModeDataECAT8_32bit.h
@@ -71,7 +71,9 @@ public:
     Succeeded set_get_position(const SavedPosition&);
 
  virtual
-    Succeeded set_listmode_position(unsigned long pos);
+    Succeeded set_list_mode_position(unsigned long pos);
+ virtual
+    unsigned long get_list_mode_position();
 
   //! returns \c true, as ECAT listmode data stores delayed events (and prompts)
   /*! \todo this might depend on the acquisition parameters */

--- a/src/include/stir/listmode/CListModeDataECAT8_32bit.h
+++ b/src/include/stir/listmode/CListModeDataECAT8_32bit.h
@@ -72,6 +72,7 @@ public:
 
  virtual
     Succeeded set_list_mode_position(unsigned long pos);
+
  virtual
     unsigned long get_list_mode_position();
 

--- a/src/include/stir/listmode/CListModeDataROOT.h
+++ b/src/include/stir/listmode/CListModeDataROOT.h
@@ -133,7 +133,10 @@ public:
     Succeeded set_get_position(const SavedPosition&);
 
    virtual
-    Succeeded set_listmode_position(const unsigned long pos);
+    Succeeded set_list_mode_position(const unsigned long pos);
+
+   virtual
+    unsigned long get_list_mode_position();
 
     virtual
     bool has_delayeds() const { return true; }

--- a/src/include/stir/listmode/CListModeDataROOT.h
+++ b/src/include/stir/listmode/CListModeDataROOT.h
@@ -132,8 +132,8 @@ public:
     virtual
     Succeeded set_get_position(const SavedPosition&);
 
-//    virtual
-//    Succeeded set_listmode_position(const unsigned long pos);
+   virtual
+    Succeeded set_listmode_position(const unsigned long pos);
 
     virtual
     bool has_delayeds() const { return true; }

--- a/src/include/stir/listmode/CListModeDataROOT.h
+++ b/src/include/stir/listmode/CListModeDataROOT.h
@@ -132,6 +132,9 @@ public:
     virtual
     Succeeded set_get_position(const SavedPosition&);
 
+//    virtual
+//    Succeeded set_listmode_position(const unsigned long pos);
+
     virtual
     bool has_delayeds() const { return true; }
 

--- a/src/include/stir/listmode/CListModeDataSAFIR.h
+++ b/src/include/stir/listmode/CListModeDataSAFIR.h
@@ -81,8 +81,12 @@ public:
 
     //! Set current position in the input file to pos
    virtual
-    Succeeded set_listmode_position(unsigned long pos)
-    { return current_lm_data_ptr->set_listmode_position(pos);}
+    Succeeded set_list_mode_position(unsigned long pos)
+    { return current_lm_data_ptr->set_list_mode_position(pos);}
+
+   virtual
+    unsigned long get_list_mode_position()
+    {return current_lm_data_ptr->get_list_mode_position();}
 
 
 	/*! 

--- a/src/include/stir/listmode/CListModeDataSAFIR.h
+++ b/src/include/stir/listmode/CListModeDataSAFIR.h
@@ -79,6 +79,10 @@ public:
 	virtual Succeeded set_get_position(const SavedPosition& pos)
 	{ return current_lm_data_ptr->set_get_position(pos); }
 
+//    virtual
+//    Succeeded set_listmode_position(unsigned long pos)
+//    { /*return current_lm_data_ptr->set_listmode_position(pos);*/ return Succeeded::no;}
+
 	/*! 
 	Returns just false in the moment.
 	\todo Implement this properly to check for delayed events in LM files.

--- a/src/include/stir/listmode/CListModeDataSAFIR.h
+++ b/src/include/stir/listmode/CListModeDataSAFIR.h
@@ -79,10 +79,11 @@ public:
 	virtual Succeeded set_get_position(const SavedPosition& pos)
 	{ return current_lm_data_ptr->set_get_position(pos); }
 
+    //! Set current position in the input file to pos
    virtual
     Succeeded set_listmode_position(unsigned long pos)
-    { /*return current_lm_data_ptr->set_listmode_position(pos);*/
-        return Succeeded::no;}
+    { return current_lm_data_ptr->set_listmode_position(pos);}
+
 
 	/*! 
 	Returns just false in the moment.

--- a/src/include/stir/listmode/CListModeDataSAFIR.h
+++ b/src/include/stir/listmode/CListModeDataSAFIR.h
@@ -79,9 +79,10 @@ public:
 	virtual Succeeded set_get_position(const SavedPosition& pos)
 	{ return current_lm_data_ptr->set_get_position(pos); }
 
-//    virtual
-//    Succeeded set_listmode_position(unsigned long pos)
-//    { /*return current_lm_data_ptr->set_listmode_position(pos);*/ return Succeeded::no;}
+   virtual
+    Succeeded set_listmode_position(unsigned long pos)
+    { /*return current_lm_data_ptr->set_listmode_position(pos);*/
+        return Succeeded::no;}
 
 	/*! 
 	Returns just false in the moment.

--- a/src/listmode_buildblock/CListModeDataECAT8_32bit.cxx
+++ b/src/listmode_buildblock/CListModeDataECAT8_32bit.cxx
@@ -136,11 +136,18 @@ set_get_position(const CListModeDataECAT8_32bit::SavedPosition& pos)
     current_lm_data_ptr->set_get_position(pos);
 }
 
+unsigned long
+CListModeDataECAT8_32bit::
+get_list_mode_position()
+{
+    return current_lm_data_ptr->get_list_mode_position();
+}
+
 Succeeded
 CListModeDataECAT8_32bit::
-set_listmode_position(const unsigned long pos)
+set_list_mode_position(const unsigned long pos)
 {
-    return current_lm_data_ptr->set_listmode_position(pos);
+    return current_lm_data_ptr->set_list_mode_position(pos);
     //return Succeeded::no;
 }
 

--- a/src/listmode_buildblock/CListModeDataECAT8_32bit.cxx
+++ b/src/listmode_buildblock/CListModeDataECAT8_32bit.cxx
@@ -136,5 +136,12 @@ set_get_position(const CListModeDataECAT8_32bit::SavedPosition& pos)
     current_lm_data_ptr->set_get_position(pos);
 }
 
+//Succeeded
+//CListModeDataECAT8_32bit::
+//set_listmode_position(const unsigned long pos)
+//{
+//    /*return current_lm_data_ptr->set_listmode_position(pos);*/ return Succeeded::no;
+//}
+
 } // namespace ecat
 END_NAMESPACE_STIR

--- a/src/listmode_buildblock/CListModeDataECAT8_32bit.cxx
+++ b/src/listmode_buildblock/CListModeDataECAT8_32bit.cxx
@@ -140,8 +140,8 @@ Succeeded
 CListModeDataECAT8_32bit::
 set_listmode_position(const unsigned long pos)
 {
-//    /*return current_lm_data_ptr->set_listmode_position(pos);*/
-    return Succeeded::no;
+    return current_lm_data_ptr->set_listmode_position(pos);
+    //return Succeeded::no;
 }
 
 } // namespace ecat

--- a/src/listmode_buildblock/CListModeDataECAT8_32bit.cxx
+++ b/src/listmode_buildblock/CListModeDataECAT8_32bit.cxx
@@ -136,12 +136,13 @@ set_get_position(const CListModeDataECAT8_32bit::SavedPosition& pos)
     current_lm_data_ptr->set_get_position(pos);
 }
 
-//Succeeded
-//CListModeDataECAT8_32bit::
-//set_listmode_position(const unsigned long pos)
-//{
-//    /*return current_lm_data_ptr->set_listmode_position(pos);*/ return Succeeded::no;
-//}
+Succeeded
+CListModeDataECAT8_32bit::
+set_listmode_position(const unsigned long pos)
+{
+//    /*return current_lm_data_ptr->set_listmode_position(pos);*/
+    return Succeeded::no;
+}
 
 } // namespace ecat
 END_NAMESPACE_STIR

--- a/src/listmode_buildblock/CListModeDataROOT.cxx
+++ b/src/listmode_buildblock/CListModeDataROOT.cxx
@@ -219,9 +219,16 @@ set_get_position(const CListModeDataROOT::SavedPosition& pos)
 
 Succeeded
 CListModeDataROOT::
-set_listmode_position(const unsigned long pos)
+set_list_mode_position(const unsigned long pos)
 {
     return root_file_sptr->set_listmode_position(pos);
+}
+
+unsigned long
+CListModeDataROOT::
+get_list_mode_position()
+{
+    return root_file_sptr->get_list_mode_position();
 }
 
 void

--- a/src/listmode_buildblock/CListModeDataROOT.cxx
+++ b/src/listmode_buildblock/CListModeDataROOT.cxx
@@ -217,13 +217,12 @@ set_get_position(const CListModeDataROOT::SavedPosition& pos)
     return root_file_sptr->set_get_position(pos);
 }
 
-//Succeeded
-//CListModeDataROOT::
-//set_listmode_position(const unsigned long pos)
-//{
-//    root_file_sptr->set_listmode_position(pos);
-//    return Succeeded::yes;
-//}
+Succeeded
+CListModeDataROOT::
+set_listmode_position(const unsigned long pos)
+{
+    return root_file_sptr->set_listmode_position(pos);
+}
 
 void
 CListModeDataROOT::

--- a/src/listmode_buildblock/CListModeDataROOT.cxx
+++ b/src/listmode_buildblock/CListModeDataROOT.cxx
@@ -217,6 +217,14 @@ set_get_position(const CListModeDataROOT::SavedPosition& pos)
     return root_file_sptr->set_get_position(pos);
 }
 
+//Succeeded
+//CListModeDataROOT::
+//set_listmode_position(const unsigned long pos)
+//{
+//    root_file_sptr->set_listmode_position(pos);
+//    return Succeeded::yes;
+//}
+
 void
 CListModeDataROOT::
 set_defaults()

--- a/src/listmode_buildblock/CListModeDataROOT.cxx
+++ b/src/listmode_buildblock/CListModeDataROOT.cxx
@@ -221,7 +221,7 @@ Succeeded
 CListModeDataROOT::
 set_list_mode_position(const unsigned long pos)
 {
-    return root_file_sptr->set_listmode_position(pos);
+    return root_file_sptr->set_list_mode_position(pos);
 }
 
 unsigned long


### PR DESCRIPTION
Added functions: `get_list_mode_position()` and `set_list_mode_position(pos)`

`get_list_mode_position()` returns an unsigned long with the current position in the list mode data

`set_list_mode_position(pos)` set the current position to `pos`

These are two functions I have developed for a _"block"_ subset sampling method for list mode.