### PR TITLE
Number of time frames in wrong position in interfile header fix

### DIFF
--- a/src/IO/interfile.cxx
+++ b/src/IO/interfile.cxx
@@ -515,7 +515,7 @@ static void interfile_create_filenames(const std::string& filename, std::string&
 
   header_name=filename;
   replace_extension(header_name, ".hv");
-}
+}output_header << "number of time frames := 1\n";
 
 ////// end static functions
 
@@ -593,7 +593,6 @@ write_basic_interfile_image_header(const string& header_file_name,
     {
       output_header << "!PET STUDY (General) :=\n";
     }
-  write_interfile_time_frame_definitions(output_header, exam_info);
   write_interfile_energy_windows(output_header, exam_info);
   write_interfile_image_data_descriptions(output_header, data_type_descriptions);
   if (!is_spect)
@@ -628,6 +627,8 @@ write_basic_interfile_image_header(const string& header_file_name,
 		<< dimensions.z()<< endl;
   output_header << "scaling factor (mm/pixel) [3] := " 
 		<< voxel_size.z() << endl;
+
+  write_interfile_time_frame_definitions(output_header, exam_info);
 
   if (origin.z() != InterfileHeader::double_value_not_set)
     {

--- a/src/IO/interfile.cxx
+++ b/src/IO/interfile.cxx
@@ -593,8 +593,6 @@ write_basic_interfile_image_header(const string& header_file_name,
     {
       output_header << "!PET STUDY (General) :=\n";
     }
-  write_interfile_energy_windows(output_header, exam_info);
-  write_interfile_image_data_descriptions(output_header, data_type_descriptions);
   if (!is_spect)
     {
       output_header << "!PET data type := Image\n";
@@ -628,8 +626,6 @@ write_basic_interfile_image_header(const string& header_file_name,
   output_header << "scaling factor (mm/pixel) [3] := " 
 		<< voxel_size.z() << endl;
 
-  write_interfile_time_frame_definitions(output_header, exam_info);
-
   if (origin.z() != InterfileHeader::double_value_not_set)
     {
       const CartesianCoordinate3D<float> first_pixel_offsets =
@@ -642,6 +638,11 @@ write_basic_interfile_image_header(const string& header_file_name,
 		    << first_pixel_offsets.z() << '\n';
     }
   
+
+  write_interfile_time_frame_definitions(output_header, exam_info);
+  write_interfile_energy_windows(output_header, exam_info);
+  write_interfile_image_data_descriptions(output_header, data_type_descriptions);
+
   for (int i=1; i<=scaling_factors.get_length();i++)
     {
       // only write scaling factors and offset if more than 1 frame or they are not default values

--- a/src/IO/interfile.cxx
+++ b/src/IO/interfile.cxx
@@ -515,7 +515,7 @@ static void interfile_create_filenames(const std::string& filename, std::string&
 
   header_name=filename;
   replace_extension(header_name, ".hv");
-}output_header << "number of time frames := 1\n";
+}
 
 ////// end static functions
 


### PR DESCRIPTION
Moved the method call "write_interfile_time_frame_definitions(output_header, exam_info);" to be in the correct place when creating interfile headers.

This is to fix issue #320: Number of time frames in wrong position in interfile header