### PR TITLE
SPECT-related fixes

### DIFF
--- a/documentation/release_3.1.htm
+++ b/documentation/release_3.1.htm
@@ -160,6 +160,11 @@ These are only minimally documented at the present stage unfortunately.
   </li>
 <li>Extract single images from dynamic image with executable <code>extract_dynamic_images</code>.
 </li>
+<li>Reconstruction parameter files now can use a new optional keyword <code>z zoom</code> to llow
+  changing the spacing from the default. However, results of this have not been checked yet.
+  It is currently only recommended for SPECT (where it should be set to <code>0.5</code> due
+  current work-arounds on how to read SPECT dat into STIR).
+  </li>
   </ul>
 
 

--- a/documentation/release_3.1.htm
+++ b/documentation/release_3.1.htm
@@ -7,8 +7,7 @@
   <body>
     <h1>Summary of changes in STIR release 3.1 (dated 15/01/2018)</h1>
 
-<p>This version is 95% backwards compatible with STIR 3.0 for the user aside from minor changes 
-when using Python/MATLAB and when changed image orientation when reading/writing images via ITK (see below).
+<p>This version is 95% backwards compatible with STIR 3.0 for the user (see below).
 Developers might need to make code changes as 
 detailed below.
 </p>
@@ -75,6 +74,17 @@ Benjamin Thomas (CIRC ASTAR and UCL), Yu-jung Tsai, Vesna Cuplov).
 </p>
 
 <h2> Summary for end users (also to be read by developers)</h2>
+
+<h3>Changes breaking backwards compatibility from a user-perspective</h3>
+<ul>
+  <li> minor changes when using Python/MATLAB</li>
+  <li> the need for a new <code>z zoom</code> keyword for SPECT reconstructions (see the updated sample .par files)</li>
+  <li> changed image orientation when reading/writing images via ITK</li>
+</ul>
+
+It is now highly recommended to specify imaging modality and patient orientation in your Interfile headers. If you don't,
+STIR will assume you know what you're doing and write a warning (but we might not cover all cases). For
+patient orientation, we will assume HFS.
 
 <h3>Bug fixes</h3>
 <ul>

--- a/examples/samples/FBP2D_SPECT.par
+++ b/examples/samples/FBP2D_SPECT.par
@@ -12,8 +12,10 @@ zoom := 1
 xy output image size (in pixels) := 180
 
 ; you NEED to set this to the number of z-position in your data.
-; otherwise, things will currently go wrong
+; otherwise, the current projector will abort
 Z output image size (in pixels):=64
+; currently NEED to set this to 0.5 to get same z-spacing as in the data
+z zoom := 0.5
 
 ; filter parameters, default to pure ramp
 ; choose alpha < 1 for a Hamming window

--- a/recon_test_pack/SPECT/FBP2D.par
+++ b/recon_test_pack/SPECT/FBP2D.par
@@ -2,6 +2,7 @@ FBP2DParameters :=
 output filename prefix := out/FBP
 input file := input.hs
 Z output image size (in pixels):=64
+z zoom:=.5
 Back Projector type:= matrix
   Back Projector Using Matrix Parameters :=
 	Matrix type := SPECT UB

--- a/src/IO/InterfileHeader.cxx
+++ b/src/IO/InterfileHeader.cxx
@@ -69,7 +69,7 @@ MinimalInterfileHeader::MinimalInterfileHeader()
 {
   exam_info_sptr.reset(new ExamInfo);
   // need to default to PET for backwards compatibility
-  this->exam_info_sptr->imaging_modality = ImagingModality::PT;
+  //this->exam_info_sptr->imaging_modality = ImagingModality::PT;
 
   add_start_key("INTERFILE");
   add_key("imaging modality",

--- a/src/IO/InterfilePDFSHeaderSPECT.cxx
+++ b/src/IO/InterfilePDFSHeaderSPECT.cxx
@@ -139,19 +139,19 @@ bool InterfilePDFSHeaderSPECT::post_processing()
   // somewhat strange values to be compatible with PET
   VectorWithOffset<int> sorted_min_ring_diff(0,0);
   VectorWithOffset<int> sorted_max_ring_diff(0,0);
-  VectorWithOffset<int> sorted_num_rings_per_segment(0,0);
+  VectorWithOffset<int> sorted_num_axial_poss_per_segment(0,0);
   sorted_min_ring_diff[0]=0;
   sorted_max_ring_diff[0]=0;
-  sorted_num_rings_per_segment[0]=num_axial_poss;
+  sorted_num_axial_poss_per_segment[0]=num_axial_poss;
 
   // we construct a new scanner object with
   // data from the Interfile header (or the guessed scanner).
   // Initialize the scanner values (most are not used in SPECT reconstruction)
 
-  const int num_rings = sorted_num_rings_per_segment[0];
+  const int num_rings = sorted_num_axial_poss_per_segment[0];
   const int num_detectors_per_ring = -1;//num_views*2;  
   const double average_depth_of_interaction_in_cm = 0;
-  const double distance_between_rings_in_cm = z_spacing_in_cm*2; // need to do times 2  such that default z-spacing of reconstruction is z_spacing
+  const double distance_between_rings_in_cm = z_spacing_in_cm;
   double default_bin_size_in_cm = bin_size_in_cm ;
   const double view_offset_in_degrees = start_angle;
   const int max_num_non_arccorrected_bins = num_bins;
@@ -198,7 +198,7 @@ bool InterfilePDFSHeaderSPECT::post_processing()
     new ProjDataInfoCylindricalArcCorr (
                                         scanner_ptr_from_file,
                                         float(bin_size_in_cm*10.),
-                                        sorted_num_rings_per_segment,
+                                        sorted_num_axial_poss_per_segment,
                                         sorted_min_ring_diff,
                                         sorted_max_ring_diff,
                                         num_views,num_bins);

--- a/src/buildblock/CMakeLists.txt
+++ b/src/buildblock/CMakeLists.txt
@@ -29,6 +29,7 @@ set(${dir_LIB_SOURCES}
   extend_projdata 
   DiscretisedDensity 
   VoxelsOnCartesianGrid 
+  ParseDiscretisedDensityParameters
   utilities 
   interfile_keyword_functions 
   zoom 

--- a/src/buildblock/ParseDiscretisedDensityParameters.cxx
+++ b/src/buildblock/ParseDiscretisedDensityParameters.cxx
@@ -43,6 +43,7 @@ set_defaults()
   output_image_size_xy=-1;
   output_image_size_z=-1;
   zoom=1.F;
+  Zzoom=1.F;
   Xoffset=0.F;
   Yoffset=0.F;
   Zoffset=0.F;
@@ -54,6 +55,7 @@ add_to_keymap(KeyParser& parser)
 {
   //base_type::initialise_keymap();
   parser.add_key("zoom", &zoom);
+  parser.add_key("Z zoom", &Zzoom);
   parser.add_key("XY output image size (in pixels)",&output_image_size_xy);
   parser.add_key("Z output image size (in pixels)",&output_image_size_z);
   //parser.add_key("X offset (in mm)", &Xoffset); // KT 10122001 added spaces
@@ -100,7 +102,10 @@ ParseDiscretisedDensityParameters::
 check_values() const
 {
   if (zoom <= 0)
-  { error("zoom should be positive"); }  
+  { error("zoom should be positive"); }
+  if (Zzoom <= 0)
+  { error("z zoom should be positive"); }
+  
   if (output_image_size_xy!=-1 && output_image_size_xy<1) // KT 10122001 appended_xy
   { error("output image size xy must be positive (or -1 as default)"); }
   if (output_image_size_z!=-1 && output_image_size_z<1) // KT 10122001 new

--- a/src/buildblock/ParseDiscretisedDensityParameters.cxx
+++ b/src/buildblock/ParseDiscretisedDensityParameters.cxx
@@ -1,0 +1,110 @@
+/*
+    Copyright (C) 2000 PARAPET partners
+    Copyright (C) 2000- 2007, Hammersmith Imanet Ltd 
+    Copyright (C) 2019, University College London
+    This file is part of STIR. 
+ 
+    This file is free software; you can redistribute it and/or modify 
+    it under the terms of the GNU Lesser General Public License as published by 
+    the Free Software Foundation; either version 2.1 of the License, or 
+    (at your option) any later version. 
+ 
+    This file is distributed in the hope that it will be useful, 
+    but WITHOUT ANY WARRANTY; without even the implied warranty of 
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
+    GNU Lesser General Public License for more details. 
+ 
+    See STIR/LICENSE.txt for details
+*/
+/*!
+  \file
+  \ingroup densitydata 
+  
+  \brief  Implementation of the stir::ParseDiscretisedDensityParameters class
+    
+  \author Kris Thielemans
+  \author Matthew Jacobson
+  \author Claire Labbe
+  \author PARAPET project
+      
+*/
+#include "stir/KeyParser.h"
+#include "stir/ParseDiscretisedDensityParameters.h"
+#include "stir/CartesianCoordinate3D.h"
+#include "stir/error.h"
+
+START_NAMESPACE_STIR
+
+void 
+ParseDiscretisedDensityParameters::
+set_defaults()
+{
+  //base_type::set_defaults();
+  output_image_size_xy=-1;
+  output_image_size_z=-1;
+  zoom=1.F;
+  Xoffset=0.F;
+  Yoffset=0.F;
+  Zoffset=0.F;
+}
+
+void
+ParseDiscretisedDensityParameters::
+add_to_keymap(KeyParser& parser)
+{
+  //base_type::initialise_keymap();
+  parser.add_key("zoom", &zoom);
+  parser.add_key("XY output image size (in pixels)",&output_image_size_xy);
+  parser.add_key("Z output image size (in pixels)",&output_image_size_z);
+  //parser.add_key("X offset (in mm)", &Xoffset); // KT 10122001 added spaces
+  //parser.add_key("Y offset (in mm)", &Yoffset);
+  
+  parser.add_key("Z offset (in mm)", &Zoffset); 
+}
+
+#if 0
+// disable ask_parameters
+void ParseDiscretisedDensityParameters::
+ask_parameters()
+{
+
+  zoom=  ask_num("Specify a zoom factor as magnification effect ? ",0.1,10.,1.);
+
+
+  output_image_size_xy =  
+    ask_num("Final image size (-1 for default)? ",
+	    -1,
+	    4*static_cast<int>(proj_data_ptr->get_num_tangential_poss()*zoom),
+	    -1);
+    
+#if 0    
+    // This section enables you to position a reconstructed image
+    // along x (horizontal), y (vertical) and/or z (transverse) axes
+    // The default values is in the center of the FOV,
+    // the positve direction is
+    // for x-axis, toward the patient's left side (assuming typical spinal, head first position)
+    // for y-axis, toward the top of the FOV
+    // for z-axis, toward the patient's feet (assuming typical spinal, head first position)
+    
+    cout << endl << "    Enter offset  Xoff, Yoff (in pixels) :";
+    Xoffset = ask_num("   X offset  ",-old_size/2, old_size/2, 0);
+    Yoffset = ask_num("   Y offset  ",-old_size/2, old_size/2, 0);
+#endif
+
+}
+#endif // ask_parameters disabled
+
+
+void
+ParseDiscretisedDensityParameters::
+check_values() const
+{
+  if (zoom <= 0)
+  { error("zoom should be positive"); }  
+  if (output_image_size_xy!=-1 && output_image_size_xy<1) // KT 10122001 appended_xy
+  { error("output image size xy must be positive (or -1 as default)"); }
+  if (output_image_size_z!=-1 && output_image_size_z<1) // KT 10122001 new
+  { error("output image size z must be positive (or -1 as default)"); }
+}
+
+END_NAMESPACE_STIR

--- a/src/include/stir/ParseAndCreateFrom.h
+++ b/src/include/stir/ParseAndCreateFrom.h
@@ -1,0 +1,113 @@
+/*
+    Copyright (C) 2019, University College London
+    This file is part of STIR. 
+ 
+    This file is free software; you can redistribute it and/or modify 
+    it under the terms of the GNU Lesser General Public License as published by 
+    the Free Software Foundation; either version 2.1 of the License, or 
+    (at your option) any later version. 
+ 
+    This file is distributed in the hope that it will be useful, 
+    but WITHOUT ANY WARRANTY; without even the implied warranty of 
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
+    GNU Lesser General Public License for more details. 
+ 
+    See STIR/LICENSE.txt for details
+*/
+/*!
+  \file
+  \ingroup densitydata 
+  
+  \brief  Definition of the stir::ParseAndCreateFrom class
+    
+  \author Kris Thielemans
+*/
+
+#ifndef __stir_ParseAndCreateFrom_H__
+#define __stir_ParseAndCreateFrom_H__
+
+#include "stir/VoxelsOnCartesianGrid.h"
+#include "stir/ParseDiscretisedDensityParameters.h"
+START_NAMESPACE_STIR
+
+class KeyParser;
+
+//! template for adding keywords to a parser and creating an object
+/*!
+  \ingroup buildblock
+
+  The idea is that a reconstructor needs to be able to create an image based
+  on some parameters and the current input data. However, this needs to be flexible
+  for different types, as for instance, many different reconstructors produce
+  a DiscretisedDensity object but from different input data, or vice versa.
+
+  We do this using specialisations of this class. That way, 
+  PoissonLogLikelihoodWithLinearModelForMeanAndProjData etc can be templated
+  without having to know what the actual \c OutputT is.
+
+  This of course only works if a specialisation is created for the
+  \c OutputT and \InputT of interest.
+
+  A specialisation needs to define all four member functions as the reconstruction
+  code will otherwise break.
+
+  The default implementations don't do anything (aside from create()).
+
+  Check ParseAndCreateFrom<DiscretisedDensity<3, elemT>, ExamDataT> for an example
+  which might make sense.
+*/
+template <class OutputT, class InputT, class ParserT = KeyParser>
+class ParseAndCreateFrom
+{
+ public:
+ //! set default values for any parameters
+ void set_defaults() {}
+ //! add any relevant parameters to a parser
+ void add_to_keymap(ParserT&) {}
+  //! should call error() if something is wrong
+ void check_values() const {};
+
+ //! create a new object
+ /*! 
+   This can take any parsed parameters into account.
+
+   The default just calls \c new.
+
+   \todo Currently we're assuming this returns a bare pointer (to a new object).
+   This is due to limitations in the reconstruction classes. It will need to change
+   to a \c std::unique pointer.
+ */
+ OutputT* create(const InputT&) const
+ { return new OutputT(); }
+};
+
+
+//! parse keywords for creating a VoxelsOnCartesianGrid from ProjData etc
+/*!
+  \ingroup densitydata 
+
+  This specialisation adds keywords like size etc to the parser, and calls
+  the VoxelsOnCartesianGrid constructor with ExamInfo and ProjDataInfo arguments
+  to obtain an image that is suitable to store the reconstruction.
+
+  Assumes that \c ExamDataT has \c get_exam_info_sptr() and \c get_proj_data_info_ptr()
+  members.
+
+  \todo Currently only supports VoxelsOnCartesianGrid parameters (we could introduce
+  another keyword to differentiate between types).
+*/
+template <class elemT, class ExamDataT>
+  class ParseAndCreateFrom<DiscretisedDensity<3, elemT>, ExamDataT>
+  : public ParseDiscretisedDensityParameters
+{
+ public:
+  typedef DiscretisedDensity<3, elemT> output_type;
+  inline
+  output_type*
+    create(const ExamDataT&) const;
+};
+
+END_NAMESPACE_STIR
+
+#include "stir/ParseAndCreateFrom.inl"
+#endif

--- a/src/include/stir/ParseAndCreateFrom.inl
+++ b/src/include/stir/ParseAndCreateFrom.inl
@@ -1,0 +1,55 @@
+/*
+    Copyright (C) 2019, University College London
+    This file is part of STIR. 
+ 
+    This file is free software; you can redistribute it and/or modify 
+    it under the terms of the GNU Lesser General Public License as published by 
+    the Free Software Foundation; either version 2.1 of the License, or 
+    (at your option) any later version. 
+ 
+    This file is distributed in the hope that it will be useful, 
+    but WITHOUT ANY WARRANTY; without even the implied warranty of 
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
+    GNU Lesser General Public License for more details. 
+ 
+    See STIR/LICENSE.txt for details
+*/
+/*!
+  \file
+  \ingroup densitydata
+
+  \brief  implementation of the stir::ParseAndCreateFrom class for stir:DiscretisedDensity
+
+  \author Kris Thielemans      
+*/
+
+#include "stir/VoxelsOnCartesianGrid.h"
+//#include "stir/IO/ExamData.h"
+#include "stir/CartesianCoordinate3D.h"
+
+START_NAMESPACE_STIR
+
+
+
+template <class elemT, class ExamDataT>
+DiscretisedDensity<3, elemT>*
+ParseAndCreateFrom<DiscretisedDensity<3, elemT>, ExamDataT>::
+create(const ExamDataT& exam_data) const
+{
+  return
+    new VoxelsOnCartesianGrid<elemT> (exam_data.get_exam_info_sptr(),
+                                      *exam_data.get_proj_data_info_ptr(),
+                                      CartesianCoordinate3D<float>(static_cast<float>(1),
+                                                                   static_cast<float>(this->zoom),
+                                                                   static_cast<float>(this->zoom)),
+                                      CartesianCoordinate3D<float>(static_cast<float>(this->Zoffset),
+                                                                   static_cast<float>(this->Yoffset),
+                                                                   static_cast<float>(this->Xoffset)),
+                                      CartesianCoordinate3D<int>(this->output_image_size_z,
+                                                                 this->output_image_size_xy,
+                                                                 this->output_image_size_xy)
+                                      );
+}
+
+END_NAMESPACE_STIR
+

--- a/src/include/stir/ParseAndCreateFrom.inl
+++ b/src/include/stir/ParseAndCreateFrom.inl
@@ -39,7 +39,7 @@ create(const ExamDataT& exam_data) const
   return
     new VoxelsOnCartesianGrid<elemT> (exam_data.get_exam_info_sptr(),
                                       *exam_data.get_proj_data_info_ptr(),
-                                      CartesianCoordinate3D<float>(static_cast<float>(1),
+                                      CartesianCoordinate3D<float>(static_cast<float>(this->Zzoom),
                                                                    static_cast<float>(this->zoom),
                                                                    static_cast<float>(this->zoom)),
                                       CartesianCoordinate3D<float>(static_cast<float>(this->Zoffset),

--- a/src/include/stir/ParseDiscretisedDensityParameters.h
+++ b/src/include/stir/ParseDiscretisedDensityParameters.h
@@ -1,0 +1,88 @@
+/*
+    Copyright (C) 2000 PARAPET partners
+    Copyright (C) 2000- 2007, Hammersmith Imanet Ltd 
+    Copyright (C) 2019, University College London
+    This file is part of STIR. 
+ 
+    This file is free software; you can redistribute it and/or modify 
+    it under the terms of the GNU Lesser General Public License as published by 
+    the Free Software Foundation; either version 2.1 of the License, or 
+    (at your option) any later version. 
+ 
+    This file is distributed in the hope that it will be useful, 
+    but WITHOUT ANY WARRANTY; without even the implied warranty of 
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
+    GNU Lesser General Public License for more details. 
+ 
+    See STIR/LICENSE.txt for details
+*/
+/*!
+  \file
+  \ingroup densitydata 
+  
+  \brief  Definition of the stir::ParseDiscretisedDensityParameters class
+    
+  \author Kris Thielemans
+  \author Matthew Jacobson
+  \author Claire Labbe
+  \author PARAPET project
+      
+*/
+
+#ifndef __ParseDiscretisedDensityParameters_H__
+#define __ParseDiscretisedDensityParameters_H__
+
+#include "stir/common.h"
+
+START_NAMESPACE_STIR
+
+class KeyParser;
+
+/*!
+ \ingroup densitydata 
+  
+ \brief Class for adding parameters relevant to DiscretisedDensity to a parser
+
+ This class is not very safe. It is only used by ParseAndCreateFrom specialisations.
+*/
+class ParseDiscretisedDensityParameters
+{
+ public:
+  void
+    set_defaults();
+  void
+    add_to_keymap(KeyParser& parser);
+
+  //! calls error() if something is wrong
+  void
+    check_values() const;
+
+ protected:
+ 
+  //! the output image size in x and y direction
+  /*! convention: if -1, use a size such that the whole FOV is covered
+  */
+  int output_image_size_xy;
+
+  //! the output image size in z direction
+  /*! convention: if -1, use default as provided by VoxelsOnCartesianGrid constructor
+  */
+  int output_image_size_z; 
+
+  //! the zoom factor
+  double zoom;
+
+  //! offset in the x-direction
+  double Xoffset;
+
+  //! offset in the y-direction
+  double Yoffset;
+
+  //! offset in the z-direction
+  double Zoffset;
+
+};
+
+END_NAMESPACE_STIR
+
+#endif

--- a/src/include/stir/ParseDiscretisedDensityParameters.h
+++ b/src/include/stir/ParseDiscretisedDensityParameters.h
@@ -72,6 +72,9 @@ class ParseDiscretisedDensityParameters
   //! the zoom factor
   double zoom;
 
+  //! the zoom factor in z-direction
+  double Zzoom;
+
   //! offset in the x-direction
   double Xoffset;
 

--- a/src/include/stir/VoxelsOnCartesianGrid.h
+++ b/src/include/stir/VoxelsOnCartesianGrid.h
@@ -3,7 +3,7 @@
 /*
     Copyright (C) 2000 PARAPET partners
     Copyright (C) 2000- 2007, Hammersmith Imanet Ltd
-    Copyright (C) 2018, University College London
+    Copyright (C) 2018-2019, University College London
     This file is part of STIR.
 
     This file is free software; you can redistribute it and/or modify
@@ -128,6 +128,17 @@ VoxelsOnCartesianGrid(const shared_ptr < ExamInfo > & exam_info_sptr,
 		      const CartesianCoordinate3D<float>& origin = CartesianCoordinate3D<float>(0.F,0.F,0.F),
 		      const CartesianCoordinate3D<int>& sizes = CartesianCoordinate3D<int>(-1,-1,-1));
 
+//! Constructor from exam_info and proj_data_info
+/*! \see VoxelsOnCartesianGrid(const ProjDataInfo&,
+		      const float zoom,
+		      const CartesianCoordinate3D<float>&,
+		      const CartesianCoordinate3D<int>& );
+*/
+VoxelsOnCartesianGrid(const shared_ptr < ExamInfo > & exam_info_sptr_v,
+                      const ProjDataInfo& proj_data_info,
+                      const CartesianCoordinate3D<float>& zooms,
+		      const CartesianCoordinate3D<float>& origin = CartesianCoordinate3D<float>(0.F,0.F,0.F),
+		      const CartesianCoordinate3D<int>& sizes = CartesianCoordinate3D<int>(-1,-1,-1));
 
 //! Definition of the pure virtual defined in DiscretisedDensity
 #ifdef STIR_NO_COVARIANT_RETURN_TYPES
@@ -189,6 +200,14 @@ void grow_z_range(const int min_z, const int max_z);
   BasicCoordinate<3,int> get_max_indices() const;
 
   //@}
+
+private:
+  void
+    construct_from_projdata_info(const shared_ptr < ExamInfo > & exam_info_sptr_v,
+                                 const ProjDataInfo& proj_data_info,
+                                 const CartesianCoordinate3D<float>& zooms,
+                                 const CartesianCoordinate3D<float>& origin,
+                                 const CartesianCoordinate3D<int>& sizes);
 
 };
 

--- a/src/include/stir/listmode/CListModeData.h
+++ b/src/include/stir/listmode/CListModeData.h
@@ -233,6 +233,11 @@ public:
 
   virtual shared_ptr<ProjDataInfo> get_proj_data_info_sptr() const;
 
+  const ProjDataInfo* get_proj_data_info_ptr() const
+  {
+    return this->get_proj_data_info_sptr().get();
+  }
+
 protected:
 
   void set_proj_data_info_sptr(shared_ptr<ProjDataInfo>);

--- a/src/include/stir/modelling/ParseAndCreateParametricDiscretisedDensityFrom.h
+++ b/src/include/stir/modelling/ParseAndCreateParametricDiscretisedDensityFrom.h
@@ -1,0 +1,56 @@
+/*
+    Copyright (C) 2019, University College London
+    This file is part of STIR. 
+ 
+    This file is free software; you can redistribute it and/or modify 
+    it under the terms of the GNU Lesser General Public License as published by 
+    the Free Software Foundation; either version 2.1 of the License, or 
+    (at your option) any later version. 
+ 
+    This file is distributed in the hope that it will be useful, 
+    but WITHOUT ANY WARRANTY; without even the implied warranty of 
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
+    GNU Lesser General Public License for more details. 
+ 
+    See STIR/LICENSE.txt for details
+*/
+/*!
+  \file
+  \ingroup modelling
+
+  \brief  Definition of the stir::ParseAndCreateFrom class for stir::ParametricDiscretisedDensity
+
+  \author Kris Thielemans
+*/
+
+#ifndef __stir_ParseAndCreateParametricDiscretisedDensityFrom_H__
+#define __stir_ParseAndCreateParametricDiscretisedDensityFrom_H__
+
+#include "stir/VoxelsOnCartesianGrid.h"
+#include "stir/modelling/ParametricDiscretisedDensity.h"
+#include "stir/ParseDiscretisedDensityParameters.h"
+START_NAMESPACE_STIR
+
+class KeyParser;
+
+//! parse keywords for creating a parametric VoxelsOnCartesianGrid from DynamicProjData etc
+/*!
+  \ingroup modelling
+  \see ParseAndCreateFrom<DiscretisedDensity<3, elemT>, ExamDataT>
+*/
+template <class elemT, class ExamDataT>
+  class ParseAndCreateFrom<ParametricDiscretisedDensity<VoxelsOnCartesianGrid<elemT> >,
+                           ExamDataT>
+  : public ParseDiscretisedDensityParameters
+{
+ public:
+  typedef ParametricDiscretisedDensity<VoxelsOnCartesianGrid<elemT> > output_type;
+  inline
+    output_type*
+    create(const ExamDataT&) const;
+};
+
+END_NAMESPACE_STIR
+
+#include "stir/modelling/ParseAndCreateParametricDiscretisedDensityFrom.inl"
+#endif

--- a/src/include/stir/modelling/ParseAndCreateParametricDiscretisedDensityFrom.inl
+++ b/src/include/stir/modelling/ParseAndCreateParametricDiscretisedDensityFrom.inl
@@ -1,0 +1,58 @@
+/*
+    Copyright (C) 2019, University College London
+    This file is part of STIR. 
+ 
+    This file is free software; you can redistribute it and/or modify 
+    it under the terms of the GNU Lesser General Public License as published by 
+    the Free Software Foundation; either version 2.1 of the License, or 
+    (at your option) any later version. 
+ 
+    This file is distributed in the hope that it will be useful, 
+    but WITHOUT ANY WARRANTY; without even the implied warranty of 
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
+    GNU Lesser General Public License for more details. 
+ 
+    See STIR/LICENSE.txt for details
+*/
+/*!
+  \file
+  \ingroup densitydata
+
+  \brief  implementation of the stir::ParseAndCreateFrom class for stir:ParametricDiscretisedDensity
+
+  \author Kris Thielemans      
+*/
+
+#include "stir/VoxelsOnCartesianGrid.h"
+//#include "stir/IO/ExamData.h"
+#include "stir/CartesianCoordinate3D.h"
+
+START_NAMESPACE_STIR
+
+
+template <class elemT, class ExamDataT>
+ParametricDiscretisedDensity<VoxelsOnCartesianGrid<elemT> >*
+ParseAndCreateFrom<ParametricDiscretisedDensity<VoxelsOnCartesianGrid<elemT> >, ExamDataT>::
+create(const ExamDataT& exam_data) const
+{
+
+    return
+      new ParametricDiscretisedDensity<VoxelsOnCartesianGrid<elemT> >
+      (VoxelsOnCartesianGrid<elemT>
+       (exam_data.get_exam_info_sptr(),
+        *exam_data.get_proj_data_info_ptr(),
+        CartesianCoordinate3D<float>(static_cast<float>(1),
+                                     static_cast<float>(this->zoom),
+                                     static_cast<float>(this->zoom)),
+        CartesianCoordinate3D<float>(static_cast<float>(this->Zoffset),
+                                     static_cast<float>(this->Yoffset),
+                                     static_cast<float>(this->Xoffset)),
+        CartesianCoordinate3D<int>(this->output_image_size_z,
+                                   this->output_image_size_xy,
+                                   this->output_image_size_xy)
+        )
+       );
+}
+
+END_NAMESPACE_STIR
+

--- a/src/include/stir/modelling/ParseAndCreateParametricDiscretisedDensityFrom.inl
+++ b/src/include/stir/modelling/ParseAndCreateParametricDiscretisedDensityFrom.inl
@@ -41,7 +41,7 @@ create(const ExamDataT& exam_data) const
       (VoxelsOnCartesianGrid<elemT>
        (exam_data.get_exam_info_sptr(),
         *exam_data.get_proj_data_info_ptr(),
-        CartesianCoordinate3D<float>(static_cast<float>(1),
+        CartesianCoordinate3D<float>(static_cast<float>(this->Zzoom),
                                      static_cast<float>(this->zoom),
                                      static_cast<float>(this->zoom)),
         CartesianCoordinate3D<float>(static_cast<float>(this->Zoffset),

--- a/src/include/stir/recon_buildblock/AnalyticReconstruction.h
+++ b/src/include/stir/recon_buildblock/AnalyticReconstruction.h
@@ -3,7 +3,7 @@
 /*
     Copyright (C) 2000 PARAPET partners
     Copyright (C) 2000- 2007, Hammersmith Imanet Ltd 
-    Copyright (C) 2018, University College London
+    Copyright (C) 2016, 2018, 2019 University College London
     This file is part of STIR. 
  
     This file is free software; you can redistribute it and/or modify 
@@ -27,21 +27,16 @@
   \brief declares the stir::AnalyticReconstruction class
 
   \author Kris Thielemans
-  \author Matthew Jacobson
-  \author Claire Labbe
+  \author Nikos Efthimiou
   \author PARAPET project
 
-*/
-/* Modification history
-
-   KT 10122001
-   - added construct_target_image_ptr and 0 argument reconstruct()
 */
 
 #include "stir/recon_buildblock/Reconstruction.h"
 #include "stir/DiscretisedDensity.h"
 #include "stir/ProjData.h"
 #include "stir/RegisteredParsingObject.h"
+#include "stir/ParseAndCreateFrom.h"
 #include <string>
 
 #include "stir/IO/ExamData.h"
@@ -103,29 +98,6 @@ public:
   // parameters
  protected:
 
-  //! the output image size in x and y direction
-  /*! convention: if -1, use a size such that the whole FOV is covered
-  */
-  int output_image_size_xy;
-
-  //! the output image size in z direction
-  /*! convention: if -1, use default as provided by VoxelsOnCartesianGrid constructor
-  */
-  int output_image_size_z; 
-
-  //! the zoom factor
-  double zoom;
-
-  //! offset in the x-direction
-  double Xoffset;
-
-  //! offset in the y-direction
-  double Yoffset;
-
-  //! offset in the z-direction
-  double Zoffset;
-
-
   //! the input projection data file name
   std::string input_filename;
   //! the maximum absolute ring difference number to use in the reconstruction
@@ -143,6 +115,8 @@ public:
 
 
 protected:
+  ParseAndCreateFrom<TargetT, ProjData> target_parameter_parser;
+
   //! executes the reconstruction storing result in \c target_image_sptr
   /*!
     \return Succeeded::yes if everything was alright.

--- a/src/include/stir/recon_buildblock/PoissonLogLikelihoodWithLinearKineticModelAndDynamicProjectionData.h
+++ b/src/include/stir/recon_buildblock/PoissonLogLikelihoodWithLinearKineticModelAndDynamicProjectionData.h
@@ -36,6 +36,7 @@
 #include "stir/VectorWithOffset.h"
 #include "stir/DynamicProjData.h"
 #include "stir/DynamicDiscretisedDensity.h"
+#include "stir/modelling/ParseAndCreateParametricDiscretisedDensityFrom.h"
 #include "stir/modelling/ParametricDiscretisedDensity.h"
 #include "stir/modelling/KineticParameters.h"
 #include "stir/modelling/PatlakPlot.h"
@@ -146,30 +147,7 @@ public  RegisteredParsingObject<PoissonLogLikelihoodWithLinearKineticModelAndDyn
   int _max_segment_num_to_process;
 
   /**********************/
-  // image stuff
-  // TODO to be replaced with single class or so (TargetT obviously)
-  //! the output image size in x and y direction
-  /*! convention: if -1, use a size such that the whole FOV is covered
-  */
-  int _output_image_size_xy; // KT 10122001 appended _xy
-
-  //! the output image size in z direction
-  /*! convention: if -1, use default as provided by VoxelsOnCartesianGrid constructor
-  */
-  int _output_image_size_z; // KT 10122001 new
-
-  //! the zoom factor
-  double _zoom;
-
-  //! offset in the x-direction
-  double _Xoffset;
-
-  //! offset in the y-direction
-  double _Yoffset;
-
-  // KT 20/06/2001 new
-  //! offset in the z-direction
-  double _Zoffset;
+  ParseAndCreateFrom<TargetT, DynamicProjData> target_parameter_parser;
 
   /********************************/
   //! name of file in which additive projection data are stored

--- a/src/include/stir/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMeanAndGatedProjDataWithMotion.h
+++ b/src/include/stir/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMeanAndGatedProjDataWithMotion.h
@@ -31,6 +31,7 @@
 #include "stir/shared_ptr.h"
 #include "stir/RegisteredObject.h"
 #include "stir/RegisteredParsingObject.h"
+#include "stir/ParseAndCreateFrom.h"
 #include "stir/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMeanAndProjData.h"
 #include "stir/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMean.h"
 #include "stir/VectorWithOffset.h"
@@ -160,31 +161,7 @@ public  RegisteredParsingObject<PoissonLogLikelihoodWithLinearModelForMeanAndGat
     get_time_gate_definitions() const ;
 
   /**********************/
-  // image stuff
-  // TODO to be replaced with single class or so (TargetT obviously)
-  //! the output image size in x and y direction
-  /*! convention: if -1, use a size such that the whole FOV is covered
-   */
-  int _output_image_size_xy; // KT 10122001 appended _xy
-
-  //! the output image size in z direction
-  /*! convention: if -1, use default as provided by VoxelsOnCartesianGrid constructor
-   */
-  int _output_image_size_z; // KT 10122001 new
-
-  //! the zoom factor
-  double _zoom;
-
-  //! offset in the x-direction
-  double _Xoffset;
-
-  //! offset in the y-direction
-  double _Yoffset;
-
-  // KT 20/06/2001 new
-  //! offset in the z-direction
-  double _Zoffset;
-
+  ParseAndCreateFrom<TargetT, GatedProjData> target_parameter_parser;
   /********************************/
   //! name of file in which additive projection data are stored
   std::string _additive_gated_proj_data_filename;

--- a/src/include/stir/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMeanAndListModeData.h
+++ b/src/include/stir/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMeanAndListModeData.h
@@ -35,6 +35,7 @@
 //#include "stir/RegisteredParsingObject.h"
 #include "stir/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMean.h"
 #include "stir/listmode/CListModeData.h"
+#include "stir/ParseAndCreateFrom.h"
 #include "stir/TimeFrameDefinitions.h"
 
 START_NAMESPACE_STIR
@@ -135,26 +136,8 @@ protected:
    //! will be called when a new time frame starts
    /*! The frame numbers start from 1. */
    virtual void start_new_time_frame(const unsigned int new_frame_num);
- 
-  int output_image_size_xy;  
- 
-  //! the output image size in z direction 
-  /*! convention: if -1, use default as provided by VoxelsOnCartesianGrid constructor 
-  */ 
-  int output_image_size_z;  
- 
-  //! the zoom factor 
-  double zoom; 
- 
-  //! offset in the x-direction 
-  double Xoffset; 
- 
-  //! offset in the y-direction 
-  double Yoffset; 
- 
-  // KT 20/06/2001 new 
-  //! offset in the z-direction 
-  double Zoffset;
+
+   ParseAndCreateFrom<TargetT, CListModeData> target_parameter_parser;
 };
 
 END_NAMESPACE_STIR

--- a/src/include/stir/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMeanAndProjData.h
+++ b/src/include/stir/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMeanAndProjData.h
@@ -30,6 +30,7 @@
 
 #include "stir/RegisteredParsingObject.h"
 #include "stir/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMean.h"
+#include "stir/ParseAndCreateFrom.h"
 //#include "stir/ProjData.h"
 #include "stir/recon_buildblock/ProjectorByBinPair.h"
 //#include "stir/recon_buildblock/BinNormalisation.h"
@@ -282,30 +283,7 @@ protected:
   int max_segment_num_to_process;
 
   /**********************/
-  // image stuff
-  // TODO to be replaced with single class or so (TargetT obviously)
-  //! the output image size in x and y direction
-  /*! convention: if -1, use a size such that the whole FOV is covered
-  */
-  int output_image_size_xy; // KT 10122001 appended _xy
-
-  //! the output image size in z direction
-  /*! convention: if -1, use default as provided by VoxelsOnCartesianGrid constructor
-  */
-  int output_image_size_z; // KT 10122001 new
-
-  //! the zoom factor
-  double zoom;
-
-  //! offset in the x-direction
-  double Xoffset;
-
-  //! offset in the y-direction
-  double Yoffset;
-
-  // KT 20/06/2001 new
-  //! offset in the z-direction
-  double Zoffset;
+   ParseAndCreateFrom<TargetT, ProjData> target_parameter_parser;
   /********************************/
 
 

--- a/src/recon_buildblock/AnalyticReconstruction.cxx
+++ b/src/recon_buildblock/AnalyticReconstruction.cxx
@@ -1,7 +1,7 @@
 /*
     Copyright (C) 2000 PARAPET partners
     Copyright (C) 2000 - 2006,  Hammersmith Imanet Ltd 
-    Copyright (C) 2018, University College London
+    Copyright (C) 2016, 2018 - 2019 University College London
     This file is part of STIR. 
  
     This file is free software; you can redistribute it and/or modify 
@@ -23,18 +23,16 @@
   
   \brief  implementation of the stir::AnalyticReconstruction class 
     
-  \author Matthew Jacobson
   \author Kris Thielemans
-  \author Sanida Mustafovic
+  \author Matthew Jacobson
+  \author Nikos Efthimiou
   \author PARAPET project
       
 */
 
 #include "stir/recon_buildblock/AnalyticReconstruction.h"
 #include "stir/VoxelsOnCartesianGrid.h"
-#include "stir/CartesianCoordinate3D.h"
 #include "stir/Succeeded.h"
-#include "stir/utilities.h"
 #include "stir/is_null_ptr.h"
 #include "stir/info.h"
 #include <iostream>
@@ -53,12 +51,7 @@ AnalyticReconstruction::set_defaults()
   input_filename="";
   max_segment_num_to_process=-1;
   proj_data_ptr.reset(); 
-  output_image_size_xy=-1;
-  output_image_size_z=-1;
-  zoom=1.F;
-  Xoffset=0.F;
-  Yoffset=0.F;
-  Zoffset=0.F;
+  target_parameter_parser.set_defaults();
 }
 
 
@@ -72,13 +65,7 @@ AnalyticReconstruction::initialise_keymap()
 
   parser.add_key("maximum absolute segment number to process", &max_segment_num_to_process);
 
-  parser.add_key("zoom", &zoom);
-  parser.add_key("XY output image size (in pixels)",&output_image_size_xy);
-  parser.add_key("Z output image size (in pixels)",&output_image_size_z);
-  //parser.add_key("X offset (in mm)", &Xoffset); // KT 10122001 added spaces
-  //parser.add_key("Y offset (in mm)", &Yoffset);
-  
-  parser.add_key("Z offset (in mm)", &Zoffset);
+  this->target_parameter_parser.add_to_keymap(parser);
 
 //  parser.add_key("END", &KeyParser::stop_parsing);
  
@@ -120,29 +107,6 @@ void AnalyticReconstruction::ask_parameters()
 
   output_filename_prefix=output_filename_prefix_char;
 
-  zoom=  ask_num("Specify a zoom factor as magnification effect ? ",0.1,10.,1.);
-
-
-  output_image_size_xy =  
-    ask_num("Final image size (-1 for default)? ",
-	    -1,
-	    4*static_cast<int>(proj_data_ptr->get_num_tangential_poss()*zoom),
-	    -1);
-    
-#if 0    
-    // This section enables you to position a reconstructed image
-    // along x (horizontal), y (vertical) and/or z (transverse) axes
-    // The default values is in the center of the FOV,
-    // the positve direction is
-    // for x-axis, toward the patient's left side (assuming typical spinal, head first position)
-    // for y-axis, toward the top of the FOV
-    // for z-axis, toward the patient's feet (assuming typical spinal, head first position)
-    
-    cout << endl << "    Enter offset  Xoff, Yoff (in pixels) :";
-    Xoffset = ask_num("   X offset  ",-old_size/2, old_size/2, 0);
-    Yoffset = ask_num("   Y offset  ",-old_size/2, old_size/2, 0);
-#endif
-
 }
 #endif // ask_parameters disabled
 
@@ -161,15 +125,8 @@ bool AnalyticReconstruction::post_processing()
  
   proj_data_ptr= ProjData::read_from_file(input_filename);
 
-  if (zoom <= 0)
-  { warning("zoom should be positive\n"); return true; }
-  
-  if (output_image_size_xy!=-1 && output_image_size_xy<1) // KT 10122001 appended_xy
-  { warning("output image size xy must be positive (or -1 as default)\n"); return true; }
-  if (output_image_size_z!=-1 && output_image_size_z<1) // KT 10122001 new
-  { warning("output image size z must be positive (or -1 as default)\n"); return true; }
+  target_parameter_parser.check_values();
 
-  
   return false;
 }
 
@@ -181,16 +138,7 @@ AnalyticReconstruction::
 construct_target_image_ptr() const
 {
   return
-      new VoxelsOnCartesianGrid<float> (this->get_input_data().get_exam_info_sptr(),
-                                        *this->proj_data_ptr->get_proj_data_info_ptr(),
-					static_cast<float>(this->zoom),
-					CartesianCoordinate3D<float>(static_cast<float>(this->Zoffset),
-								     static_cast<float>(this->Yoffset),
-								     static_cast<float>(this->Xoffset)),
-					CartesianCoordinate3D<int>(this->output_image_size_z,
-                                                                   this->output_image_size_xy,
-                                                                   this->output_image_size_xy)
-                                       );
+    this->target_parameter_parser.create(this->get_input_data());
 }
 
 

--- a/src/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMeanAndListModeData.cxx
+++ b/src/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMeanAndListModeData.cxx
@@ -57,12 +57,7 @@ set_defaults()
   this->current_frame_num = 1;
   this->num_events_to_use = 0L;
  
-  this->output_image_size_xy=-1; 
-  this->output_image_size_z=-1; 
-  this->zoom=1.F; 
-  this->Xoffset=0.F; 
-  this->Yoffset=0.F; 
-  this->Zoffset=0.F; 
+  this->target_parameter_parser.set_defaults();
  
 } 
 
@@ -73,13 +68,7 @@ initialise_keymap()
 { 
   base_type::initialise_keymap(); 
   this->parser.add_key("list mode filename", &this->list_mode_filename); 
-  this->parser.add_key("zoom", &this->zoom); 
-  this->parser.add_key("XY output image size (in pixels)",&this->output_image_size_xy); 
-  this->parser.add_key("Z output image size (in pixels)",&this->output_image_size_z); 
-  //parser.add_key("X offset (in mm)", &Xoffset); // KT 10122001 added spaces 
-  //parser.add_key("Y offset (in mm)", &Yoffset); 
-   
-  //this->parser.add_key("Z offset (in mm)", &Zoffset); 
+  this->target_parameter_parser.add_to_keymap(this->parser);
   this->parser.add_key("time frame definition filename", &this->frame_defs_filename);
   // SM TODO -- later do not parse
   this->parser.add_key("time frame number", &this->current_frame_num);
@@ -107,17 +96,9 @@ PoissonLogLikelihoodWithLinearModelForMeanAndListModeData<TargetT>::post_process
       vector<pair<double, double> > frame_times(1, pair<double,double>(0,0));
       this->frame_defs = TimeFrameDefinitions(frame_times);
     } 
-  // image stuff 
-  if (this->zoom <= 0) 
-  { warning("zoom should be positive\n"); return true; } 
-   
-  if (this->output_image_size_xy!=-1 && this->output_image_size_xy<1) // KT 10122001 appended_xy 
-  { warning("output image size xy must be positive (or -1 as default)\n"); return true; } 
-  if (this->output_image_size_z!=-1 && this->output_image_size_z<1) // KT 10122001 new 
-  { warning("output image size z must be positive (or -1 as default)\n"); return true; } 
-   
+  target_parameter_parser.check_values();
 
-   return false;
+  return false;
 } 
 
 template <typename TargetT>
@@ -172,26 +153,6 @@ set_up(shared_ptr <TargetT > const& target_sptr)
  
     return Succeeded::yes;
 }
-
-#if 0
-template <typename TargetT> 
-TargetT * 
-PoissonLogLikelihoodWithLinearModelForMeanAndListModeData<TargetT>:: 
-construct_target_ptr() const 
-{ 
-  return 
-    new VoxelsOnCartesianGrid<float> (this->get_input_data().get_exam_info_sptr(),
-                                      *this->proj_data_sptr->get_proj_data_info_ptr(),
-					this->zoom, 
-					CartesianCoordinate3D<float>(this->Zoffset, 
-								     this->Yoffset, 
-								     this->Xoffset), 
-					CartesianCoordinate3D<int>(this->output_image_size_z, 
-                                                                   this->output_image_size_xy, 
-                                                                   this->output_image_size_xy) 
-                                       );
-} 
-#endif
 
 #  ifdef _MSC_VER
 // prevent warning message on instantiation of abstract class 

--- a/src/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMeanAndListModeDataWithProjMatrixByBin.cxx
+++ b/src/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMeanAndListModeDataWithProjMatrixByBin.cxx
@@ -399,17 +399,7 @@ construct_target_ptr() const
 { 
 
  return 
-      new VoxelsOnCartesianGrid<float> (this->get_input_data().get_exam_info_sptr(),
-                                        *proj_data_info_sptr,
-                                        static_cast<float>(this->zoom), 
-                                        CartesianCoordinate3D<float>(static_cast<float>(this->Zoffset), 
-                                                                     static_cast<float>(this->Yoffset), 
-                                                                     static_cast<float>(this->Xoffset)), 
-                                        CartesianCoordinate3D<int>(this->output_image_size_z, 
-                                                                   this->output_image_size_xy, 
-                                                                   this->output_image_size_xy) 
-                                       ); 
-
+   this->target_parameter_parser.create(this->get_input_data());
 } 
  
 template <typename TargetT> 

--- a/src/recon_buildblock/ProjMatrixByBinSPECTUB.cxx
+++ b/src/recon_buildblock/ProjMatrixByBinSPECTUB.cxx
@@ -338,10 +338,10 @@ set_up(
 	//... projecction parameters ..........................................
 	prj.ang0 = this->proj_data_info_ptr->get_scanner_ptr()->get_default_intrinsic_tilt() * float(180/_PI);
 	prj.incr = proj_Data_Info_Cylindrical->get_azimuthal_angle_sampling() * float(180/_PI);
-	prj.thcm = vol.thcm;
+	prj.thcm = proj_Data_Info_Cylindrical->get_axial_sampling(0)/10;
 	
 	//.......geometrical and other derived parameters of projection structure...........
-	prj.Nsli    = vol.Nsli;					 // number of slices
+	prj.Nsli    = proj_Data_Info_Cylindrical->get_num_axial_poss(0);  // number of slices
 	prj.lngcm   = prj.Nbin * prj.szcm;        // length in cm of the detection line
 	prj.Nbp     = prj.Nbin * prj.Nsli;        // number of bins for each projection angle (2D-projection)
 	prj.Nbt     = prj.Nbp * prj.Nang;         // total number of bins considering all the projection angles 	
@@ -357,7 +357,13 @@ set_up(
 	
 	wmh.prj = prj;
 	// wmh.NpixAngOS = vol.Npix * prj.NangOS;
-	
+
+        if (abs(wmh.prj.thcm - vox.thcm)>.01F)
+          error(boost::format("SPECTUB Matrix (probably) only works with equal z-sampling for projection data (%1%) and image (%2%)")
+                % (wmh.prj.thcm*10) % (vol.thcm*10));
+        if (abs(wmh.prj.Nsli - vol.Nsli)>.01F)
+          error(boost::format("SPECTUB Matrix (probably) only works with equal number of slices for projection data (%1%) and image (%2%)")
+                % wmh.prj.Nsli % vol.Nsli);
 	//....rotation radius .................................................	
 	const VectorWithOffset<float> radius_all_views =
 	  proj_Data_Info_Cylindrical->get_ring_radii_for_all_views();
@@ -375,7 +381,7 @@ set_up(
 	
 	bin.szcm   = wmh.prj.szcm;
 	bin.szcmd2 = bin.szcm / (float)2.;
-	bin.thcm   = wmh.prj.thcm;
+	bin.thcm   = wmh.prj.thcm*10;
 	bin.thcmd2 = bin.thcm / (float)2.;
 	bin.szdx   = bin.szcm / wmh.psfres;
 	bin.thdx   = bin.thcm / wmh.psfres;
@@ -480,10 +486,10 @@ set_up(
 
 	//:: Control of read parameters
 	cout << "" << endl;
-	cout << "Parameters of SPECT UB matrix:" << endl;
-	cout << "Image grid side row: " << wmh.vol.Nrow << "\tcol: " << wmh.vol.Ncol << "\tvoxel_size: " << wmh.vol.szcm<< endl;
+	cout << "Parameters of SPECT UB matrix: (in cm)" << endl;
+	cout << "Image grid side row: " << wmh.vol.Nrow << "\tcol: " << wmh.vol.Ncol << "\ttransverse voxel_size: " << wmh.vol.szcm<< endl;
 	cout << "Number of slices: " << wmh.vol.Nsli << "\tslice_thickness: " << wmh.vol.thcm << endl;
-	cout << "Number of bins: " << wmh.prj.Nbin << "\tbin size: " << wmh.prj.szcm << endl;
+	cout << "Number of bins: " << wmh.prj.Nbin << "\tbin size: " << wmh.prj.szcm << "\taxial size: " << wmh.prj.thcm << endl;
 	cout << "Number of angles: " << wmh.prj.Nang << "\tAngle increment: " << wmh.prj.incr << "\tFirst angle: " << wmh.prj.ang0 << endl;
 	cout << "Number of subsets: " << wmh.prj.NOS << endl;
 	if ( wmh.do_att ){

--- a/src/test/test_VoxelsOnCartesianGrid.cxx
+++ b/src/test/test_VoxelsOnCartesianGrid.cxx
@@ -5,6 +5,7 @@
     Copyright (C) 2000- 2011,  Hammersmith Imanet Ltd 
     Copyright (C) 2018, Commonwealth Scientific and Industrial Research Organisation
                         Australian eHealth Research Centre
+    Copyright (C) 2019, University College London
     This file is part of STIR. 
  
     This file is free software; you can redistribute it and/or modify 
@@ -203,7 +204,21 @@ VoxelsOnCartesianGridTests::run_tests()
                                                 scanner_ptr->get_default_bin_size()/zoom),
                    "test on grid spacing");
     check_if_equal(ob5.get_origin(), origin);
-    
+
+    {
+      // with different zooms
+      shared_ptr<ExamInfo> exam_info_sptr(new ExamInfo());
+      CartesianCoordinate3D<float> zooms(1.1F,1.2F,1.3F);
+      VoxelsOnCartesianGrid<float>
+        ob6(exam_info_sptr, *proj_data_info_ptr,zooms,origin,CartesianCoordinate3D<int>(z_size,xy_size,xy_size));
+      check_if_equal(ob6.get_grid_spacing(),
+                     CartesianCoordinate3D<float>(scanner_ptr->get_ring_spacing()/2/zooms[1],
+                                                  scanner_ptr->get_default_bin_size()/zooms[2],
+                                                  scanner_ptr->get_default_bin_size()/zooms[3]),
+                     "test on grid spacing (3 different zooms)");
+      check_if_equal(ob6.get_origin(), origin);
+    }
+
     {
       cerr << "Tests get_empty_voxels_on_cartesian_grid\n";
       

--- a/src/test/test_VoxelsOnCartesianGrid.cxx
+++ b/src/test/test_VoxelsOnCartesianGrid.cxx
@@ -3,6 +3,8 @@
 /*
     Copyright (C) 2000 PARAPET partners
     Copyright (C) 2000- 2011,  Hammersmith Imanet Ltd 
+    Copyright (C) 2018, Commonwealth Scientific and Industrial Research Organisation
+                        Australian eHealth Research Centre
     This file is part of STIR. 
  
     This file is free software; you can redistribute it and/or modify 
@@ -23,9 +25,10 @@
   
   \brief Test program for stir::VoxelsOnCartesianGrid and image hierarchy
     
-   \author Sanida Mustafovic
-   \author Kris Thielemans
-   \author PARAPET project
+  \author Ashley Gillman
+  \author Sanida Mustafovic
+  \author Kris Thielemans
+  \author PARAPET project
       
 */
 


### PR DESCRIPTION
- fixes an issue that the axial spacing in SPECT data was reported twice too large (therefore resulting in wrong information in projdata files written by the forward projector)
- let the `SPECTUBMatrix` `set_up` abort if z-voxel-size and number of slices in the images is not what the code assumes it to be (possibly this condition could be relaxed, but I didn't check)
- introduce new `z zoom` parameter in reconstruction `.par` files such that we can tell STIR to use z-voxel-size compatible with SPECT data. **Warning**: this breaks backwards compatibility.
- remove duplication between many different classes (`AnalyticReconstruction` and all `PoissonLogLikelihood*`) for image keywords.

Note that before this PR
- SPECT reconstruction were fine if you set the number of image slices equal to the number of sinograms and z-spacing equal to the axial spacing when passing an initial image.
- output projection data (e.g., of `forward_project) was written with an incorrect header. This was hidden by 2 bugs (in reading the interfile header, and in ignoring axial spacing by the SPECT UB matrix)
with the result that subsequent reconstructions were still fine.

fixes #323 