### PR TITLE
Swig Priors

### DIFF
--- a/src/swig/stir.i
+++ b/src/swig/stir.i
@@ -1672,3 +1672,7 @@ namespace stir {
 %include "stir/recon_buildblock/QuadraticPrior.h"
 #define elemT float
 %template (QuadraticPrior3DFloat) stir::QuadraticPrior<elemT >;
+
+%include "stir/recon_buildblock/PLSPrior.h"
+#define elemT float
+%template (PLSPrior3DFloat) stir::PLSPrior<elemT >;

--- a/src/swig/stir.i
+++ b/src/swig/stir.i
@@ -1668,3 +1668,7 @@ namespace stir {
   stir::RegisteredParsingObject<stir::BackProjectorByBinUsingProjMatrixByBin,
      stir::BackProjectorByBin>;
 %include "stir/recon_buildblock/BackProjectorByBinUsingProjMatrixByBin.h"
+
+%include "stir/recon_buildblock/QuadraticPrior.h"
+#define elemT float
+%template (QuadraticPrior3DFloat) stir::QuadraticPrior<elemT >;


### PR DESCRIPTION
Allows for the Quadratical and Parallel Level Sets prior objects to be called from MatLab and Python.

I have used this when investigating values of a prior throughout reconstruction.