### PR TITLE
Relax DICOM series reading restrictions

### DIFF
--- a/documentation/STIR-UsersGuide.tex
+++ b/documentation/STIR-UsersGuide.tex
@@ -665,7 +665,8 @@ assumes the patient is in HFS position}. Only if DICOM is used and the correct D
 (0018, 5100) will the orientation be correct.
 
 Note that as DICOM files often store only a single slice, \textit{STIR} attempts to find
-other slices belonging to the same series/time frame/gate.
+other slices belonging to the same series. When there are multiple time frames/gates in a folder, 
+these may be incorrectly treated as a single volume.
 
 \subsubsection{SimSET files}
 There are some preliminary files to make it easier to use SimSET and \textit{STIR} together in the

--- a/documentation/release_3.1.htm
+++ b/documentation/release_3.1.htm
@@ -211,6 +211,10 @@ HFS, FFS, HFP or FFP).
   </li>
   <li>Code that was hosted in <tt>src/local</tt> and <tt>include/local/stir</tt> is now in <tt>src/experimental</tt> and <tt>include/stir_experimental</tt>, respectively. An extra CMake parameter has also been added, <tt>STIR_ENABLE_EXPERIMENTAL</tt>, which is <tt>OFF</tt> by default. Enabling this parameter will include the experimental code in the build.
   </li>
+  <li>The DICOM series reading restrictions in <tt>read_file_itk</tt> have been relaxed. The requirement for the same acquisition, 
+    trigger or frame times in a series is no longer enforced. This allows 3-D DICOM volumes to be read correctly but may cause
+    issues for dynamic PET or CT data.
+  </li>
 </ul>
 <h4>Python (and MATLAB) interface</h4>
 <ul>

--- a/src/IO/ITKImageInputFileFormat.cxx
+++ b/src/IO/ITKImageInputFileFormat.cxx
@@ -442,9 +442,9 @@ read_file_itk(const std::string &filename)
           nameGenerator->SetUseSeriesDetails( true );
           // Make sure we read only data from a single frame and gate
           nameGenerator->AddSeriesRestriction("0008|0022" ); // AcquisitionDate
-          nameGenerator->AddSeriesRestriction("0008|0032" ); // AcquisitionTime
-          nameGenerator->AddSeriesRestriction("0018|1060" ); // TriggerTime
-          nameGenerator->AddSeriesRestriction("0018|1063" ); // FrameTime
+          //nameGenerator->AddSeriesRestriction("0008|0032" ); // AcquisitionTime
+          //nameGenerator->AddSeriesRestriction("0018|1060" ); // TriggerTime
+          //nameGenerator->AddSeriesRestriction("0018|1063" ); // FrameTime
 
           const std::string dir_name = get_directory_name(filename);
           nameGenerator->SetDirectory( dir_name.c_str() );

--- a/src/IO/ITKImageInputFileFormat.cxx
+++ b/src/IO/ITKImageInputFileFormat.cxx
@@ -440,7 +440,7 @@ read_file_itk(const std::string &filename)
           typedef itk::GDCMSeriesFileNames NamesGeneratorType;
           typename NamesGeneratorType::Pointer nameGenerator = NamesGeneratorType::New();
           nameGenerator->SetUseSeriesDetails( true );
-          // Make sure we read only data from a single frame and gate
+          // Reads complete series.
           nameGenerator->AddSeriesRestriction("0008|0022" ); // AcquisitionDate
           //nameGenerator->AddSeriesRestriction("0008|0032" ); // AcquisitionTime
           //nameGenerator->AddSeriesRestriction("0018|1060" ); // TriggerTime


### PR DESCRIPTION
Disables series restrictions for Acquisition, Trigger and Frame times while reading DICOM data. This fixes #332 for data where all slices genuinely belong to a 3D volume, despite having different timing information per slice. However, disabling these restrictions will likely cause issues when reading dynamic PET or CT data from DICOM. One way to avoid this would be to sort the data into sub-folders according to the appropriate tag and read each folder independently. Alternatively, a utility could  be written along these lines.