### PR TITLE
change behaviour of get_scale_factor_per_sinogram

### DIFF
--- a/documentation/release_3.1.htm
+++ b/documentation/release_3.1.htm
@@ -202,7 +202,14 @@ HFS, FFS, HFP or FFP).
   It has a new switch <tt>--NOPMRT</tt> which reverts to the previous behaviour (i.e. using
   the old ray tracer on-the-fly projector).
   </li>
-  <li><tt>InterfileDynamicDiscretisedDensityOutputFileFormat::</tt> changed start/end key from <tt>Interfile Output File Format</tt> to <tt>Interfile Output File Format Parameters</tt> to match other Interfile types.
+<li><code>upsample_and_fit_single_scatter</code> previously aborted if there were not enough counts
+  (after weighting with the masking used for the tail-fit) in the scatter estimate for one sinogram.
+  Now we just write a warning and set it to 1. For consistency, we now use scale factor 1 if all
+  sinograms had zero counts (after weighting), while we were setting it 0 before. As this should never occur,
+  and the scale factor should be irrelevant then, this should not affect any results.<br />
+  (Actual change is in <code>get_scale_factors_per_sinogram</code>).
+  </li>
+<li><tt>InterfileDynamicDiscretisedDensityOutputFileFormat::</tt> changed start/end key from <tt>Interfile Output File Format</tt> to <tt>Interfile Output File Format Parameters</tt> to match other Interfile types.
   </li>
   <li>Renamed <tt>InterfileParametricDensityOutputFileFormat</tt> to <tt>InterfileParametricDiscretisedDensityOutputFileFormat</tt> and the corresponding keys.
   </li>

--- a/src/buildblock/scale_sinograms.cxx
+++ b/src/buildblock/scale_sinograms.cxx
@@ -2,6 +2,7 @@
 //
 /*
   Copyright (C) 2004- 2009, Hammersmith Imanet Ltd
+  Copyright (C) 2019, University College London
   This file is free software; you can redistribute it and/or modify
   it under the terms of the GNU Lesser General Public License as published by
   the Free Software Foundation; either version 2.1 of the License, or
@@ -76,7 +77,10 @@ get_scale_factors_per_sinogram(const ProjData& numerator_proj_data,
     (*weights_proj_data.get_proj_data_info_ptr());
 
   Bin bin;
-	
+
+  // scale factor to use when the denominator is zero
+  const float default_scale = 1.F;
+
   IndexRange2D sinogram_range(proj_data_info.get_min_segment_num(),proj_data_info.get_max_segment_num(),0,0);
   for (int segment_num=proj_data_info.get_min_segment_num();
        segment_num<=proj_data_info.get_max_segment_num();
@@ -109,7 +113,7 @@ get_scale_factors_per_sinogram(const ProjData& numerator_proj_data,
       
 	if (denominator_sinogram.sum()==0)
 	  {  
-	    scale_factors[bin.segment_num()][bin.axial_pos_num()] = 0;
+	    scale_factors[bin.segment_num()][bin.axial_pos_num()] = default_scale;
 	  }
 	else
 	  {
@@ -118,17 +122,23 @@ get_scale_factors_per_sinogram(const ProjData& numerator_proj_data,
 		(proj_data_info.get_num_views() * proj_data_info.get_num_tangential_poss()) * .001
 		)
 	      {
-		error("Problem at segment %d, axial pos %d in finding sinogram scaling factor.\n"
-		      "Weighted data in denominator %g too small compared to total in sinogram %g.\n"
-		      "Adjust weights?",
-		      bin.segment_num(),bin.axial_pos_num(),
-		      total_in_denominator[bin.segment_num()][bin.axial_pos_num()],
-		      denominator_sinogram.sum()
+		warning("Problem at segment %d, axial pos %d in finding sinogram scaling factor.\n"
+                        "Weighted data in denominator %g is very small compared to total in sinogram %g.\n"
+                        "Adjust weights?.\n"
+                        "I will use scale factor %g",
+                        bin.segment_num(),bin.axial_pos_num(),
+                        total_in_denominator[bin.segment_num()][bin.axial_pos_num()],
+                        denominator_sinogram.sum(),
+                        default_scale
 		      );
+                scale_factors[bin.segment_num()][bin.axial_pos_num()] = default_scale;
 	      }
-	    scale_factors[bin.segment_num()][bin.axial_pos_num()] = 
-	      total_in_numerator[bin.segment_num()][bin.axial_pos_num()]/
-	      total_in_denominator[bin.segment_num()][bin.axial_pos_num()];
+            else
+              {
+                scale_factors[bin.segment_num()][bin.axial_pos_num()] =
+                  total_in_numerator[bin.segment_num()][bin.axial_pos_num()]/
+                  total_in_denominator[bin.segment_num()][bin.axial_pos_num()];
+              }
 	  }
       }
   

--- a/src/include/stir/scale_sinograms.h
+++ b/src/include/stir/scale_sinograms.h
@@ -56,7 +56,8 @@ Succeeded scale_sinograms(ProjData& output_proj_data,
     scale_factor = sum(numerator * weights) / sum(denominator * weights)
   \endcode
 
-  \todo currently this function calls error() when the denominator gets too small
+  Currently this function sets the scale factor or a sinogram to 1 (and calls warning())
+  when the denominator gets too small.
 */
 Array<2,float>
   get_scale_factors_per_sinogram(const ProjData& numerator_proj_data,


### PR DESCRIPTION
upsample_and_fit_single_scatter previously aborted if there were not enough counts
(after weighting with the masking used for the tail-fit) in the scatter estimate for one sinogram.
Now we just write a warning and set it to 1. For consistency, we now use scale factor 1 if all
sinograms had zero counts (after weighting), while we were setting it 0 before. As this should never occur,
and the scale factor should be irrelevant then, this should not affect any results.