### PR TITLE
No longer require the user to supply a pre-existing parametric image

### DIFF
--- a/documentation/release_3.1.htm
+++ b/documentation/release_3.1.htm
@@ -176,6 +176,8 @@ These are only minimally documented at the present stage unfortunately.
   It is currently only recommended for SPECT (where it should be set to <code>0.5</code> due
   current work-arounds on how to read SPECT dat into STIR).
   </li>
+<li>Indirect parametric reconstruction (Patlak) no longer requires you to pass a pre-existing template file. If one is supplied, it will be used; else the parametric image will be created based on the dynamic image.
+  </li>
   </ul>
 
 

--- a/src/buildblock/DynamicDiscretisedDensity.cxx
+++ b/src/buildblock/DynamicDiscretisedDensity.cxx
@@ -111,12 +111,12 @@ get_densities() const
 const DiscretisedDensity<3,float> & 
 DynamicDiscretisedDensity::
 get_density(const unsigned int frame_num) const 
-{  return *this->_densities[frame_num-1] ; }
+{  return *this->_densities.at(frame_num-1) ; }
 
 DiscretisedDensity<3,float> & 
 DynamicDiscretisedDensity::
 get_density(const unsigned int frame_num)
-{  return *this->_densities[frame_num-1] ; }
+{  return *this->_densities.at(frame_num-1) ; }
 
 const float 
 DynamicDiscretisedDensity::

--- a/src/include/stir/DynamicDiscretisedDensity.h
+++ b/src/include/stir/DynamicDiscretisedDensity.h
@@ -167,7 +167,7 @@ class DynamicDiscretisedDensity: public ExamData
   { return this->get_density(frame_num); }
 
   //! at method
-  const singleDiscDensT & at(const unsigned int frame_num)
+  singleDiscDensT & at(const unsigned int frame_num)
   { return this->get_density(frame_num); }
 
   //! Return time of start of scan

--- a/src/include/stir/DynamicDiscretisedDensity.h
+++ b/src/include/stir/DynamicDiscretisedDensity.h
@@ -162,6 +162,14 @@ class DynamicDiscretisedDensity: public ExamData
 
   const float get_calibration_factor() const;
 
+  //! at method
+  const singleDiscDensT & at(const unsigned int frame_num) const
+  { return this->get_density(frame_num); }
+
+  //! at method
+  const singleDiscDensT & at(const unsigned int frame_num)
+  { return this->get_density(frame_num); }
+
   //! Return time of start of scan
   /*! \return the time in seconds since 1 Jan 1970 00:00 UTC, i.e. independent
     of your local time zone.

--- a/src/include/stir/modelling/ParametricDiscretisedDensity.h
+++ b/src/include/stir/modelling/ParametricDiscretisedDensity.h
@@ -4,6 +4,7 @@
 #define __stir_modelling_ParametricDiscretisedDensity_H__
 /*
     Copyright (C) 2006 - 2011, Hammersmith Imanet Ltd
+    Copyright (C) 2019, University College London
     This file is part of STIR.
 
     This file is free software; you can redistribute it and/or modify
@@ -23,6 +24,7 @@
   \ingroup modelling
   \brief Declaration of class stir::ParametricDiscretisedDensity
   \author Kris Thielemans
+  \author Richard Brown
  
 */
 
@@ -34,6 +36,9 @@
 START_NAMESPACE_STIR
 template <typename DiscDensT>
 class ParametricDiscretisedDensity;
+
+/// Forward declaration of dynamic image
+class DynamicDiscretisedDensity;
 
 //! A helper class to find the type of a 'single' image for a corresponding parametric image.
 template <typename DiscDensT>
@@ -93,6 +98,9 @@ public DiscDensT
   ParametricDiscretisedDensity(const base_type& density)
     : base_type(density)
     {}
+
+  /// Create blank parametric image from a dynamic image
+  ParametricDiscretisedDensity(const DynamicDiscretisedDensity& dyn_im);
 
   // implementation works, although only for VoxelsOnCartesianGrid , but not needed for now
   // ParametricDiscretisedDensity(const VectorWithOffset<shared_ptr<SingleDiscretisedDensityType> > & densities);

--- a/src/modelling_buildblock/ParametricDiscretisedDensity.cxx
+++ b/src/modelling_buildblock/ParametricDiscretisedDensity.cxx
@@ -2,7 +2,7 @@
 //
 /*
     Copyright (C) 2006 - 2011, Hammersmith Imanet Ltd
-    Copyright (C) 2018, University College London
+    Copyright (C) 2018 - 2019, University College London
     This file is part of STIR.
 
     This file is free software; you can redistribute it and/or modify
@@ -24,6 +24,7 @@
   \brief Declaration of class stir::ParametricDiscretisedDensity
 
   \author Kris Thielemans
+  \author Richard Brown
  
 */
 
@@ -51,6 +52,25 @@ get_num_params()
   typedef typename DiscDensityT::full_value_type KinParsT;
   const KinParsT dummy;
   return dummy.size();
+}
+
+TEMPLATE
+ParamDiscDensity::
+ParametricDiscretisedDensity(const DynamicDiscretisedDensity& dyn_im)
+    : base_type(dyn_im[1].get_index_range(),
+      dyn_im[1].get_origin(),
+      dynamic_cast<const VoxelsOnCartesianGrid<float>&>(dyn_im[1]).get_grid_spacing())
+{
+    // Copy exam info
+    this->set_exam_info(*dyn_im[1].get_exam_info_sptr());
+
+    // Get the time frame definition (from start of first frame to end of last)
+    TimeFrameDefinitions tdefs = dyn_im.get_exam_info().get_time_frame_definitions();
+    const double start = tdefs.get_start_time(1);
+    const double end   = tdefs.get_end_time(tdefs.get_num_frames());
+    tdefs.set_num_time_frames(1);
+    tdefs.set_time_frame(1,start,end);
+    this->get_exam_info_sptr()->set_time_frame_definitions(tdefs);
 }
 
 #if 0

--- a/src/modelling_buildblock/ParametricDiscretisedDensity.cxx
+++ b/src/modelling_buildblock/ParametricDiscretisedDensity.cxx
@@ -57,12 +57,12 @@ get_num_params()
 TEMPLATE
 ParamDiscDensity::
 ParametricDiscretisedDensity(const DynamicDiscretisedDensity& dyn_im)
-    : base_type(dyn_im[1].get_index_range(),
-      dyn_im[1].get_origin(),
-      dynamic_cast<const VoxelsOnCartesianGrid<float>&>(dyn_im[1]).get_grid_spacing())
+    : base_type(dyn_im.get_density(1).get_index_range(),
+      dyn_im.get_density(1).get_origin(),
+      dynamic_cast<const VoxelsOnCartesianGrid<float>&>(dyn_im.get_density(1)).get_grid_spacing())
 {
     // Copy exam info
-    this->set_exam_info(*dyn_im[1].get_exam_info_sptr());
+    this->set_exam_info(dyn_im.get_density(1).get_exam_info());
 
     // Get the time frame definition (from start of first frame to end of last)
     TimeFrameDefinitions tdefs = dyn_im.get_exam_info().get_time_frame_definitions();

--- a/src/modelling_utilities/apply_patlak_to_images.cxx
+++ b/src/modelling_utilities/apply_patlak_to_images.cxx
@@ -82,33 +82,34 @@ USING_NAMESPACE_STIR
       shared_ptr<DynamicDiscretisedDensity> 
 	dyn_image_sptr(read_from_file<DynamicDiscretisedDensity>(argv[2]));
       const DynamicDiscretisedDensity & dyn_image= *dyn_image_sptr;
-#if 1
-      shared_ptr<ParametricVoxelsOnCartesianGrid> 
-	par_image_sptr(ParametricVoxelsOnCartesianGrid::read_from_file(argv[1]));
-      ParametricVoxelsOnCartesianGrid par_image = *par_image_sptr;
-#else
-      ParametricVoxelsOnCartesianGrid par_image(dyn_image[1]);
-#endif
-
-      // Get exam info from input. Input is dynamic with multiple time frames. The
-      // output parametric image is going to be a single time frame that goes from
-      // the start of the first dynamic image to the end of the last.
-      TimeFrameDefinitions tdefs = dyn_image.get_exam_info().get_time_frame_definitions();
-      const double start = tdefs.get_start_time();
-      const double end   = tdefs.get_end_time();
-      tdefs.set_num_time_frames(1);
-      tdefs.set_time_frame(1,start,end);
-      // Set the time frame defintions
-      par_image.get_exam_info_sptr()->set_time_frame_definitions(tdefs);
+      shared_ptr<ParametricVoxelsOnCartesianGrid> par_image_sptr;
+      // If the file already exists, use it as a template
+      std::ifstream file(argv[1]);
+      if (file) {
+          warning("The output file already exists, so using this as a template.");
+          par_image_sptr = shared_ptr<ParametricVoxelsOnCartesianGrid>(ParametricVoxelsOnCartesianGrid::read_from_file(argv[1]));
+          // Modify template by getting exam info from input. Input is dynamic with multiple time frames. The
+          // output parametric image is going to be a single time frame that goes from
+          // the start of the first dynamic image to the end of the last.
+          TimeFrameDefinitions tdefs = dyn_image.get_exam_info().get_time_frame_definitions();
+          const double start = tdefs.get_start_time();
+          const double end   = tdefs.get_end_time();
+          tdefs.set_num_time_frames(1);
+          tdefs.set_time_frame(1,start,end);
+          // Set the time frame defintions
+          par_image_sptr->get_exam_info_sptr()->set_time_frame_definitions(tdefs);
+      }
+      else
+          par_image_sptr = std::make_shared<ParametricVoxelsOnCartesianGrid>(dyn_image);
 
       //ToDo: Assertion for the dyn-par images, sizes I have to create from one to the other image, so then it should be OK...      
       assert(indirect_patlak.get_time_frame_definitions().get_num_frames()==dyn_image.get_time_frame_definitions().get_num_frames());
-      indirect_patlak.apply_linear_regression(par_image,dyn_image);
+      indirect_patlak.apply_linear_regression(*par_image_sptr,dyn_image);
 
       // Writing image
       std::cerr << "Writing parametric-image in '"<< argv[1] << "'\n";
       const Succeeded writing_succeeded=OutputFileFormat<ParametricVoxelsOnCartesianGrid>::default_sptr()->  
-	write_to_file(argv[1], par_image); 
+	write_to_file(argv[1], *par_image_sptr);
       std::cerr << "Total time for Image-Based Patlak in sec: " << timer.value() <<"\n";
       timer.stop();  
       

--- a/src/modelling_utilities/apply_patlak_to_images.cxx
+++ b/src/modelling_utilities/apply_patlak_to_images.cxx
@@ -100,7 +100,7 @@ USING_NAMESPACE_STIR
           par_image_sptr->get_exam_info_sptr()->set_time_frame_definitions(tdefs);
       }
       else
-          par_image_sptr = std::make_shared<ParametricVoxelsOnCartesianGrid>(dyn_image);
+          par_image_sptr = MAKE_SHARED<ParametricVoxelsOnCartesianGrid>(dyn_image);
 
       //ToDo: Assertion for the dyn-par images, sizes I have to create from one to the other image, so then it should be OK...      
       assert(indirect_patlak.get_time_frame_definitions().get_num_frames()==dyn_image.get_time_frame_definitions().get_num_frames());


### PR DESCRIPTION
the changes concern `apply_patlak_to_images`

- If the output file already exists (first argument), use it as a template (same behaviour as before, doesn't break backwards compatibility)
- If the output does not exist, create the template based on the dynamic image