### PR TITLE
[TRAVIS] use different gcc versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,10 @@ matrix:
    python: 3
    env: EXTRA_BUILD_FLAGS="-DDISABLE_CERN_ROOT=1 -DSTIR_OPENMP:BOOL=OFF" CC=clang-5.0 CXX=clang++-5.0
    # note: cannot use OpenMP yet with Clang on Travis apparently. See https://github.com/travis-ci/travis-ci/issues/8613
+ - os: linux
+   python: 3
+   env: EXTRA_BUILD_FLAGS="-DDISABLE_CERN_ROOT=1 -DSTIR_OPENMP:BOOL=ON" CC=clang-6.0 CXX=clang++-6.0
+
 
    ####  osx
    # note: cannot use OpenMP on OSX yet, see https://github.com/UCL/STIR/issues/117
@@ -58,6 +62,7 @@ addons:
   apt:
     sources:
       - llvm-toolchain-trusty-5.0
+      - llvm-toolchain-trusty-6.0
       - ubuntu-toolchain-r-test
    packages:
       - g++-5
@@ -71,6 +76,7 @@ addons:
       - python3-pytest
       - libgomp1
       - clang-5.0
+      - clang-6.0
       - root-system-bin
       - libroot-tree-dev
       - libroot-tree-treeplayer-dev
@@ -116,7 +122,10 @@ before_install:
       ${PY_EXE} -m pip install pytest numpy
     else
       PY_EXE=`which python3`
-    fi
+      # needed for OPENMP support on Travis
+      # see https://github.com/travis-ci/travis-ci/issues/8613
+      export LD_LIBRARY_PATH=/usr/local/clang/lib:$LD_LIBRARY_PATH
+fi
     ${PY_EXE} --version  
     BUILD_FLAGS="$BUILD_FLAGS -DPYTHON_EXECUTABLE=${PY_EXE}"
       

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,11 +26,10 @@ matrix:
  - os: linux
    python: 3
    env: EXTRA_BUILD_FLAGS="-DDISABLE_CERN_ROOT=1 -DSTIR_OPENMP:BOOL=OFF" CC=clang-5.0 CXX=clang++-5.0
-   # note: cannot use OpenMP yet with Clang on Travis apparently. See https://github.com/travis-ci/travis-ci/issues/8613
  - os: linux
    python: 3
-   env: EXTRA_BUILD_FLAGS="-DDISABLE_CERN_ROOT=1 -DSTIR_OPENMP:BOOL=ON" CC=clang-6.0 CXX=clang++-6.0
-
+   # OPENMP on Travis seemed to be version 1 (???), so don't build it
+   env: EXTRA_BUILD_FLAGS="-DDISABLE_CERN_ROOT=1 -DSTIR_OPENMP:BOOL=OFF" CC=clang-6.0 CXX=clang++-6.0
 
    ####  osx
    # note: cannot use OpenMP on OSX yet, see https://github.com/UCL/STIR/issues/117

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,10 +26,11 @@ matrix:
  - os: linux
    python: 3
    env: EXTRA_BUILD_FLAGS="-DDISABLE_CERN_ROOT=1 -DSTIR_OPENMP:BOOL=OFF" CC=clang-5.0 CXX=clang++-5.0
- - os: linux
-   python: 3
-   # OPENMP on Travis seemed to be version 1 (???), so don't build it
-   env: EXTRA_BUILD_FLAGS="-DDISABLE_CERN_ROOT=1 -DSTIR_OPENMP:BOOL=OFF" CC=clang-6.0 CXX=clang++-6.0
+ #- os: linux
+ #  python: 3
+ #  # OPENMP on Travis seemed to be version 1 (???), so don't build it
+ #  # This gives loads of warnings about auto_ptr, exceeding the log size limit
+ #  env: EXTRA_BUILD_FLAGS="-DDISABLE_CERN_ROOT=1 -DSTIR_OPENMP:BOOL=OFF"  -DCMAKE_CXX_STANDARD=11 CC=clang-6.0 CXX=clang++-6.0
 
    ####  osx
    # note: cannot use OpenMP on OSX yet, see https://github.com/UCL/STIR/issues/117
@@ -61,7 +62,7 @@ addons:
   apt:
     sources:
       - llvm-toolchain-trusty-5.0
-      - llvm-toolchain-trusty-6.0
+      # - llvm-toolchain-trusty-6.0
       - ubuntu-toolchain-r-test
     packages:
       - g++-5
@@ -75,7 +76,7 @@ addons:
       - python3-pytest
       - libgomp1
       - clang-5.0
-      - clang-6.0
+      # - clang-6.0
       - root-system-bin
       - libroot-tree-dev
       - libroot-tree-treeplayer-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,13 +10,16 @@ matrix:
    #### linux
  - os: linux
    python: 3
-   env: EXTRA_BUILD_FLAGS="-DDISABLE_CERN_ROOT=0 -DSTIR_OPENMP:BOOL=OFF" CC=gcc-5 CXX=g++-5
+   env: EXTRA_BUILD_FLAGS="-DDISABLE_CERN_ROOT=0 -DSTIR_OPENMP:BOOL=OFF" CC=gcc-6 CXX=g++-6
  - os: linux
    python: 3
    env: EXTRA_BUILD_FLAGS="-DDISABLE_CERN_ROOT=1 -DSTIR_OPENMP:BOOL=OFF" CC=gcc-5 CXX=g++-5
  - os: linux
    python: 3
-   env: EXTRA_BUILD_FLAGS="-DDISABLE_CERN_ROOT=0 -DSTIR_OPENMP:BOOL=ON" CC=gcc-5 CXX=g++-5
+   env: EXTRA_BUILD_FLAGS="-DDISABLE_CERN_ROOT=0 -DSTIR_OPENMP:BOOL=ON" CC=gcc-7 CXX=g++-7
+ - os: linux
+   python: 3
+   env: EXTRA_BUILD_FLAGS="-DDISABLE_CERN_ROOT=0 -DSTIR_OPENMP:BOOL=ON" CC=gcc-8 CXX=g++-8
  - os: linux
    python: 3
    env: EXTRA_BUILD_FLAGS="-DDISABLE_CERN_ROOT=0 -DSTIR_OPENMP:BOOL=ON" -DCMAKE_CXX_STANDARD=11 CC=gcc-5 CXX=g++-5
@@ -55,7 +58,12 @@ addons:
   apt:
     sources:
       - llvm-toolchain-trusty-5.0
-    packages:
+      - ubuntu-toolchain-r-test
+   packages:
+      - g++-5
+      - g++-6
+      - g++-7
+      - g++-8
       - libboost-dev
       - swig3.0
       - python3-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,7 +64,7 @@ addons:
       - llvm-toolchain-trusty-5.0
       - llvm-toolchain-trusty-6.0
       - ubuntu-toolchain-r-test
-   packages:
+    packages:
       - g++-5
       - g++-6
       - g++-7
@@ -125,7 +125,7 @@ before_install:
       # needed for OPENMP support on Travis
       # see https://github.com/travis-ci/travis-ci/issues/8613
       export LD_LIBRARY_PATH=/usr/local/clang/lib:$LD_LIBRARY_PATH
-fi
+    fi
     ${PY_EXE} --version  
     BUILD_FLAGS="$BUILD_FLAGS -DPYTHON_EXECUTABLE=${PY_EXE}"
       


### PR DESCRIPTION
- explicitly install gcc-5 (seems to be needed now)
- use gcc-6, 7 and 8 for some cases