### PR TITLE
Back projection can accumulate into same image. 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,6 +119,9 @@ if(NOT DISABLE_RDF)
   find_package(RDF)
 endif()
 
+# Enable version 3 projectors
+option(STIR_PROJECTORS_AS_V3 "Enable STIR version 3 legacy code" OFF)
+
 #### enable support for ctest
 ENABLE_TESTING()
 

--- a/documentation/release_3.1.htm
+++ b/documentation/release_3.1.htm
@@ -80,11 +80,18 @@ Benjamin Thomas (CIRC ASTAR and UCL), Yu-jung Tsai, Vesna Cuplov).
   <li> minor changes when using Python/MATLAB</li>
   <li> the need for a new <code>z zoom</code> keyword for SPECT reconstructions (see the updated sample .par files)</li>
   <li> changed image orientation when reading/writing images via ITK</li>
-  <li> Images must be set prior to using the forward and back projectors. To tell the back projector 
-    to start projecting into a new image, <tt>start_accumulating_in_new_target</tt> must be used. 
-    The result of the back projection is then returned via <tt>get_output</tt>. Backwards compatibility 
-    can be maintained with the CMake switch, <tt>STIR_PROJECTORS_AS_V3</tt>. The user should not notice 
-  these changes unless they have developed their own projectors.</li>
+  <li> The resulting target must be set prior to using the forward and back projectors. 
+    For the forward projector this is done with <tt>set_input</tt>. 
+    For the back projector, this is done during the <tt>set_up</tt>, 
+    but then<tt>start_accumulating_in_new_target</tt> must be called each time the user
+    wishes to start back projecting into a zero-filled image. 
+    The result of the back projection is then returned via <tt>get_output</tt>. 
+    Backwards compatibility can be maintained with the CMake switch, 
+    <tt>STIR_PROJECTORS_AS_V3</tt>. The user should not notice 
+    these changes unless they have developed their own projectors. 
+    These changes were made so that using data processors (such as motion or 
+    smoothing) prior to the forwards projection or following the back 
+  projection will be more efficient.</li>
 </ul>
 
 It is now highly recommended to specify imaging modality and patient orientation in your Interfile headers. If you don't,
@@ -230,11 +237,6 @@ HFS, FFS, HFP or FFP).
     trigger or frame times in a series is no longer enforced. This allows 3-D DICOM volumes to be read correctly but may cause
     issues for dynamic PET or CT data.
   </li>
-  <li> As mentioned in the breaking of backwards compatibility, images must be set prior to using the forward 
-    and back projectors. To tell the back projector to start projecting into a new image, 
-    <tt>start_accumulating_in_new_target</tt> must be used. The result of the back projection is then 
-    returned via <tt>get_output</tt>. This was done so that using data processors (such as motion or 
-  smoothing) prior to the forwards projection or following the back projection will be more efficient.</li>
 </ul>
 <h4>Python (and MATLAB) interface</h4>
 <ul>

--- a/documentation/release_3.1.htm
+++ b/documentation/release_3.1.htm
@@ -80,6 +80,7 @@ Benjamin Thomas (CIRC ASTAR and UCL), Yu-jung Tsai, Vesna Cuplov).
   <li> minor changes when using Python/MATLAB</li>
   <li> the need for a new <code>z zoom</code> keyword for SPECT reconstructions (see the updated sample .par files)</li>
   <li> changed image orientation when reading/writing images via ITK</li>
+  <li> Images must be set prior to using the forward and back projectors. To tell the back projector to start projecting into a new image, <tt>reset_output</tt> must be used. The result of the back projection is then returned via <tt>get_output</tt>. Backwards compatibility can be maintained with the CMake switch, <tt>STIR_PROJECTORS_AS_V3</tt>. The user should not notice these changes unless they have developed their own projectors.</li>
 </ul>
 
 It is now highly recommended to specify imaging modality and patient orientation in your Interfile headers. If you don't,
@@ -137,7 +138,7 @@ These are only minimally documented at the present stage unfortunately.
 <li><tt>list_image_info</tt> now has options to list exam info, or only part of the information (as <tt>list_projdata_info</tt>).</li>
 <li><tt>list_lm_countrates</tt> is a new list mode utility to output total counts per specified time interval.</li>
 <li>List-mode classes for Siemens ECAT8 (32-bit).</li>
-<li>add Verbosity level (currently only to be set from interactive languages)</li
+<li>add Verbosity level (currently only to be set from interactive languages)</li>
 <li>Added the anatomical parallel level sets (PLS) prior. If an uniform anatomical image is provided it will work as a (smoothed) total variation (TV) prior </li>
 <li>New IO:
   <ul>
@@ -225,6 +226,7 @@ HFS, FFS, HFP or FFP).
     trigger or frame times in a series is no longer enforced. This allows 3-D DICOM volumes to be read correctly but may cause
     issues for dynamic PET or CT data.
   </li>
+  <li> As mentioned in the breaking of backwards compatibility, images must be set prior to using the forward and back projectors. To tell the back projector to start projecting into a new image, <tt>reset_output</tt> must be used. The result of the back projection is then returned via <tt>get_output</tt>. This was done so that using data processors (such as motion or smoothing) prior to the forwards projection or following the back projection will be more efficient.</li>
 </ul>
 <h4>Python (and MATLAB) interface</h4>
 <ul>

--- a/documentation/release_3.1.htm
+++ b/documentation/release_3.1.htm
@@ -80,7 +80,7 @@ Benjamin Thomas (CIRC ASTAR and UCL), Yu-jung Tsai, Vesna Cuplov).
   <li> minor changes when using Python/MATLAB</li>
   <li> the need for a new <code>z zoom</code> keyword for SPECT reconstructions (see the updated sample .par files)</li>
   <li> changed image orientation when reading/writing images via ITK</li>
-  <li> Images must be set prior to using the forward and back projectors. To tell the back projector to start projecting into a new image, <tt>reset_output</tt> must be used. The result of the back projection is then returned via <tt>get_output</tt>. Backwards compatibility can be maintained with the CMake switch, <tt>STIR_PROJECTORS_AS_V3</tt>. The user should not notice these changes unless they have developed their own projectors.</li>
+  <li> Images must be set prior to using the forward and back projectors. To tell the back projector to start projecting into a new image, <tt>start_accumulating_in_new_target</tt> must be used. The result of the back projection is then returned via <tt>get_output</tt>. Backwards compatibility can be maintained with the CMake switch, <tt>STIR_PROJECTORS_AS_V3</tt>. The user should not notice these changes unless they have developed their own projectors.</li>
 </ul>
 
 It is now highly recommended to specify imaging modality and patient orientation in your Interfile headers. If you don't,
@@ -226,7 +226,7 @@ HFS, FFS, HFP or FFP).
     trigger or frame times in a series is no longer enforced. This allows 3-D DICOM volumes to be read correctly but may cause
     issues for dynamic PET or CT data.
   </li>
-  <li> As mentioned in the breaking of backwards compatibility, images must be set prior to using the forward and back projectors. To tell the back projector to start projecting into a new image, <tt>reset_output</tt> must be used. The result of the back projection is then returned via <tt>get_output</tt>. This was done so that using data processors (such as motion or smoothing) prior to the forwards projection or following the back projection will be more efficient.</li>
+  <li> As mentioned in the breaking of backwards compatibility, images must be set prior to using the forward and back projectors. To tell the back projector to start projecting into a new image, <tt>start_accumulating_in_new_target</tt> must be used. The result of the back projection is then returned via <tt>get_output</tt>. This was done so that using data processors (such as motion or smoothing) prior to the forwards projection or following the back projection will be more efficient.</li>
 </ul>
 <h4>Python (and MATLAB) interface</h4>
 <ul>

--- a/documentation/release_3.1.htm
+++ b/documentation/release_3.1.htm
@@ -80,7 +80,11 @@ Benjamin Thomas (CIRC ASTAR and UCL), Yu-jung Tsai, Vesna Cuplov).
   <li> minor changes when using Python/MATLAB</li>
   <li> the need for a new <code>z zoom</code> keyword for SPECT reconstructions (see the updated sample .par files)</li>
   <li> changed image orientation when reading/writing images via ITK</li>
-  <li> Images must be set prior to using the forward and back projectors. To tell the back projector to start projecting into a new image, <tt>start_accumulating_in_new_target</tt> must be used. The result of the back projection is then returned via <tt>get_output</tt>. Backwards compatibility can be maintained with the CMake switch, <tt>STIR_PROJECTORS_AS_V3</tt>. The user should not notice these changes unless they have developed their own projectors.</li>
+  <li> Images must be set prior to using the forward and back projectors. To tell the back projector 
+    to start projecting into a new image, <tt>start_accumulating_in_new_target</tt> must be used. 
+    The result of the back projection is then returned via <tt>get_output</tt>. Backwards compatibility 
+    can be maintained with the CMake switch, <tt>STIR_PROJECTORS_AS_V3</tt>. The user should not notice 
+  these changes unless they have developed their own projectors.</li>
 </ul>
 
 It is now highly recommended to specify imaging modality and patient orientation in your Interfile headers. If you don't,
@@ -226,7 +230,11 @@ HFS, FFS, HFP or FFP).
     trigger or frame times in a series is no longer enforced. This allows 3-D DICOM volumes to be read correctly but may cause
     issues for dynamic PET or CT data.
   </li>
-  <li> As mentioned in the breaking of backwards compatibility, images must be set prior to using the forward and back projectors. To tell the back projector to start projecting into a new image, <tt>start_accumulating_in_new_target</tt> must be used. The result of the back projection is then returned via <tt>get_output</tt>. This was done so that using data processors (such as motion or smoothing) prior to the forwards projection or following the back projection will be more efficient.</li>
+  <li> As mentioned in the breaking of backwards compatibility, images must be set prior to using the forward 
+    and back projectors. To tell the back projector to start projecting into a new image, 
+    <tt>start_accumulating_in_new_target</tt> must be used. The result of the back projection is then 
+    returned via <tt>get_output</tt>. This was done so that using data processors (such as motion or 
+  smoothing) prior to the forwards projection or following the back projection will be more efficient.</li>
 </ul>
 <h4>Python (and MATLAB) interface</h4>
 <ul>

--- a/src/analytic/FBP2D/FBP2DReconstruction.cxx
+++ b/src/analytic/FBP2D/FBP2DReconstruction.cxx
@@ -303,23 +303,14 @@ actual_reconstruct(shared_ptr<DiscretisedDensity<3,float> > const & density_ptr)
                     fft_size, 
                     float(alpha_ramp), float(fc_ramp));   
 
+  back_projector_sptr->start_accumulating_in_new_image();
 
-  density_ptr->fill(0);
-  
   shared_ptr<DataSymmetriesForViewSegmentNumbers> 
     symmetries_sptr(back_projector_sptr->get_symmetries_used()->clone());
     
   set_num_threads();
-#ifdef STIR_OPENMP
-  std::vector< shared_ptr<DiscretisedDensity<3,float> > > local_output_image_sptrs;
-#pragma omp parallel shared(symmetries_sptr, local_output_image_sptrs)
-#endif
   {
 #ifdef STIR_OPENMP
-#pragma omp single
-    {
-      local_output_image_sptrs.resize(omp_get_num_threads(), shared_ptr<DiscretisedDensity<3,float> >());
-    }
 #pragma omp for schedule(runtime)  
 #endif
     for (int view_num=proj_data_ptr->get_min_view_num(); view_num <= proj_data_ptr->get_max_view_num(); ++view_num) 
@@ -365,26 +356,12 @@ actual_reconstruct(shared_ptr<DiscretisedDensity<3,float> > const & density_ptr)
         if(display_level>1) 
           display( viewgrams,viewgrams.find_max(),"Ramp filter");
 
-#ifdef STIR_OPENMP 
-        const int thread_num=omp_get_thread_num();
-        if(is_null_ptr(local_output_image_sptrs[thread_num]))
-          local_output_image_sptrs[thread_num].reset(density_ptr->get_empty_copy());
-
-        back_projector_sptr->back_project(*(local_output_image_sptrs[thread_num]), viewgrams);	  
-#else
         //  and backproject
-        back_projector_sptr->back_project(*density_ptr, viewgrams);
-#endif
+        back_projector_sptr->back_project(viewgrams);
       } 
   } // end of OPENMP pragma
-#ifdef STIR_OPENMP
-  // "reduce" data constructed by threads
-  {
-    for (int i=0; i<static_cast<int>(local_output_image_sptrs.size()); ++i)
-      if(!is_null_ptr(local_output_image_sptrs[i])) // only accumulate if a thread filled something in
-        *density_ptr += *(local_output_image_sptrs[i]);
-  }
-#endif
+
+  back_projector_sptr->get_output(*density_ptr);
  
   // Normalise the image
   const ProjDataInfoCylindrical& proj_data_info_cyl =

--- a/src/analytic/FBP2D/FBP2DReconstruction.cxx
+++ b/src/analytic/FBP2D/FBP2DReconstruction.cxx
@@ -303,7 +303,7 @@ actual_reconstruct(shared_ptr<DiscretisedDensity<3,float> > const & density_ptr)
                     fft_size, 
                     float(alpha_ramp), float(fc_ramp));   
 
-  back_projector_sptr->reset_output();
+  back_projector_sptr->start_accumulating_in_new_target();
 
   shared_ptr<DataSymmetriesForViewSegmentNumbers> 
     symmetries_sptr(back_projector_sptr->get_symmetries_used()->clone());

--- a/src/analytic/FBP2D/FBP2DReconstruction.cxx
+++ b/src/analytic/FBP2D/FBP2DReconstruction.cxx
@@ -303,7 +303,7 @@ actual_reconstruct(shared_ptr<DiscretisedDensity<3,float> > const & density_ptr)
                     fft_size, 
                     float(alpha_ramp), float(fc_ramp));   
 
-  back_projector_sptr->start_accumulating_in_new_image();
+  back_projector_sptr->reset_output();
 
   shared_ptr<DataSymmetriesForViewSegmentNumbers> 
     symmetries_sptr(back_projector_sptr->get_symmetries_used()->clone());

--- a/src/analytic/FBP3DRP/FBP3DRPReconstruction.cxx
+++ b/src/analytic/FBP3DRP/FBP3DRPReconstruction.cxx
@@ -662,7 +662,7 @@ void FBP3DRPReconstruction::do_3D_Reconstruction(
 								  back_projector_sptr->get_symmetries_used()->clone());
 
   forward_projector_sptr->set_input(estimated_image());
-  back_projector_sptr->reset_output();
+  back_projector_sptr->start_accumulating_in_new_target();
 
   for (int seg_num= -max_segment_num_to_process; seg_num <= max_segment_num_to_process; seg_num++) 
   {

--- a/src/analytic/FBP3DRP/FBP3DRPReconstruction.cxx
+++ b/src/analytic/FBP3DRP/FBP3DRPReconstruction.cxx
@@ -662,7 +662,7 @@ void FBP3DRPReconstruction::do_3D_Reconstruction(
 								  back_projector_sptr->get_symmetries_used()->clone());
 
   forward_projector_sptr->set_input(estimated_image());
-  back_projector_sptr->start_accumulating_in_new_image();
+  back_projector_sptr->reset_output();
 
   for (int seg_num= -max_segment_num_to_process; seg_num <= max_segment_num_to_process; seg_num++) 
   {

--- a/src/analytic/FBP3DRP/FBP3DRPReconstruction.cxx
+++ b/src/analytic/FBP3DRP/FBP3DRPReconstruction.cxx
@@ -661,6 +661,9 @@ void FBP3DRPReconstruction::do_3D_Reconstruction(
   shared_ptr<DataSymmetriesForViewSegmentNumbers> symmetries_sptr(
 								  back_projector_sptr->get_symmetries_used()->clone());
 
+  forward_projector_sptr->set_input(estimated_image());
+  back_projector_sptr->start_accumulating_in_new_image();
+
   for (int seg_num= -max_segment_num_to_process; seg_num <= max_segment_num_to_process; seg_num++) 
   {
 
@@ -703,8 +706,7 @@ void FBP3DRPReconstruction::do_3D_Reconstruction(
         
       do_process_viewgrams(
 			   viewgrams,
-			   new_min_axial_pos_num, new_max_axial_pos_num, orig_min_axial_pos_num, orig_max_axial_pos_num,
-			   image);
+               new_min_axial_pos_num, new_max_axial_pos_num, orig_min_axial_pos_num, orig_max_axial_pos_num);
  
                  
     }    
@@ -721,12 +723,16 @@ void FBP3DRPReconstruction::do_3D_Reconstruction(
     if(save_intermediate_files && !_disable_output){
 	  char *file = new char[output_filename_prefix.size() + 20];
 	  sprintf(file,"%s_afterseg%d",output_filename_prefix.c_str(),seg_num);
+      back_projector_sptr->get_output(image);
 	  do_save_img(file, image);        
 	  delete[] file;
 	}
       }
 #endif 
   }
+
+  back_projector_sptr->get_output(image);
+
   // Normalise the image
   if (dynamic_cast<BackProjectorByBinUsingInterpolation const *>(back_projector_sptr.get()) == 0)
     {
@@ -817,7 +823,7 @@ void FBP3DRPReconstruction::do_forward_project_view(RelatedViewgrams<float> & vi
 	       << " to "
 	       << orig_min_axial_pos_num-1 << endl;
 
-      forward_projector_sptr->forward_project(viewgrams, estimated_image(),
+      forward_projector_sptr->forward_project(viewgrams,
 					     new_min_axial_pos_num ,orig_min_axial_pos_num-1);	    
 
     }
@@ -828,7 +834,7 @@ void FBP3DRPReconstruction::do_forward_project_view(RelatedViewgrams<float> & vi
 	       << orig_max_axial_pos_num+1
 	       << " to " << new_max_axial_pos_num << endl;
     
-      forward_projector_sptr->forward_project(viewgrams, estimated_image(),
+      forward_projector_sptr->forward_project(viewgrams,
 					     orig_max_axial_pos_num+1, new_max_axial_pos_num);
     
     }
@@ -956,12 +962,11 @@ void FBP3DRPReconstruction::do_colsher_filter_view( RelatedViewgrams<float> & vi
 
 
 void FBP3DRPReconstruction::do_3D_backprojection_view(const RelatedViewgrams<float> & viewgrams,
-                                                        VoxelsOnCartesianGrid<float> &image,
                                                         int new_min_axial_pos_num, int new_max_axial_pos_num)
 { 
     full_log << "  - Backproject the filtered Colsher complete sinograms" << endl;
 
-    back_projector_sptr->back_project(image, viewgrams,new_min_axial_pos_num, new_max_axial_pos_num);
+    back_projector_sptr->back_project(viewgrams,new_min_axial_pos_num, new_max_axial_pos_num);
         
 }
 
@@ -1004,8 +1009,7 @@ void FBP3DRPReconstruction::do_log_file(const VoxelsOnCartesianGrid<float> &imag
 
 void FBP3DRPReconstruction::do_process_viewgrams(RelatedViewgrams<float> & viewgrams, 
                                                    int new_min_axial_pos_num, int new_max_axial_pos_num,
-                                                   int orig_min_axial_pos_num, int orig_max_axial_pos_num,
-                                                   VoxelsOnCartesianGrid<float> &image)
+                                                   int orig_min_axial_pos_num, int orig_max_axial_pos_num)
 {
         do_arc_correction(viewgrams);
 
@@ -1035,7 +1039,6 @@ void FBP3DRPReconstruction::do_process_viewgrams(RelatedViewgrams<float> & viewg
 	}
    
         do_3D_backprojection_view(viewgrams,
-                                  image,
                                   new_min_axial_pos_num, new_max_axial_pos_num);
     
 }

--- a/src/cmake/STIRConfig.h.in
+++ b/src/cmake/STIRConfig.h.in
@@ -82,5 +82,6 @@ namespace stir {
 #define USE_PMRT
 #endif
 
+#cmakedefine STIR_PROJECTORS_AS_V3
 
 #endif //  __stir_config__H__

--- a/src/experimental/recon_buildblock/PostsmoothingForwardProjectorByBin.cxx
+++ b/src/experimental/recon_buildblock/PostsmoothingForwardProjectorByBin.cxx
@@ -126,7 +126,7 @@ get_symmetries_used() const
 {
   return original_forward_projector_ptr->get_symmetries_used();
 }
-
+#ifdef STIR_PROJECTORS_AS_V3
 void 
 PostsmoothingForwardProjectorByBin::
 actual_forward_project(RelatedViewgrams<float>& viewgrams, 
@@ -147,7 +147,27 @@ actual_forward_project(RelatedViewgrams<float>& viewgrams,
       }
 
 }
+#endif
+void
+PostsmoothingForwardProjectorByBin::
+actual_forward_project(RelatedViewgrams<float>& viewgrams,
+                  const int min_axial_pos_num, const int max_axial_pos_num,
+                  const int min_tangential_pos_num, const int max_tangential_pos_num)
+{
+    // No need to do the data processing since it was already done on set_input()
+    original_forward_projector_ptr->forward_project(viewgrams,
+                                                      min_axial_pos_num, max_axial_pos_num,
+                                                      min_tangential_pos_num, max_tangential_pos_num);
  
+    for(RelatedViewgrams<float>::iterator iter = viewgrams.begin();
+        iter != viewgrams.end();
+        ++iter)
+        {
+          smooth(*iter,
+                 min_axial_pos_num, max_axial_pos_num,
+                 min_tangential_pos_num, max_tangential_pos_num);
+        }
+}
 void 
 PostsmoothingForwardProjectorByBin::
 smooth(Viewgram<float>& v,

--- a/src/include/stir/analytic/FBP3DRP/FBP3DRPReconstruction.h
+++ b/src/include/stir/analytic/FBP3DRP/FBP3DRPReconstruction.h
@@ -173,7 +173,6 @@ protected:
     void do_colsher_filter_view( RelatedViewgrams<float> & viewgrams);
 //!  3D backprojection implentation for 8 viewgrams.
     void do_3D_backprojection_view(RelatedViewgrams<float> const & viewgrams,
-                                   VoxelsOnCartesianGrid<float> &image,
                                    int rmin, int rmax);
 //!  Saving CPU timing and values of reconstruction parameters into a log file.    
     void do_log_file(const VoxelsOnCartesianGrid<float> &image);
@@ -191,8 +190,7 @@ public:
     virtual void do_process_viewgrams(
                                   RelatedViewgrams<float> & viewgrams,
                                   int rmin, int rmax,
-                                  int orig_min_ring, int orig_max_ring,
-                                  VoxelsOnCartesianGrid<float> &image);
+                                  int orig_min_ring, int orig_max_ring);
 
     // parameters stuff
  public:

--- a/src/include/stir/recon_buildblock/BackProjectorByBin.h
+++ b/src/include/stir/recon_buildblock/BackProjectorByBin.h
@@ -113,38 +113,59 @@ public:
 		   const int min_axial_pos_num, const int max_axial_pos_num,
 		   const int min_tangential_pos_num, const int max_tangential_pos_num);
 #endif
- //! project whole proj_data into the volume
- /*! it overwrites the data already present in the volume */
+ /*! \brief projects the viewgrams into the volume
+   it adds to the data backprojected since start_accumulating_in_new_target() was last called. */
  virtual void back_project(const ProjData&, int subset_num = 0, int num_subsets = 1);
 
  /*! \brief projects the viewgrams into the volume
-  it adds to the data already present in the volume.*/
+  it adds to the data backprojected since start_accumulating_in_new_target() was last called. */
 void back_project(const RelatedViewgrams<float>&);
 
- /*! \brief projects the specified range of the viewgrams into the volume
-  it adds to the data already present in the volume.*/
+ /*! \brief projects the specified range of the viewgrams and axial positions into the volume
+  it adds to the data backprojected since start_accumulating_in_new_target() was last called. */
 void back_project(const RelatedViewgrams<float>&,
           const int min_axial_pos_num, const int max_axial_pos_num);
 
- /*! \brief projects the specified range of the viewgrams into the volume
-   it adds to the data already present in the volume.*/
+ /*! \brief projects the specified range of the viewgrams, axial positions and tangential positions into the volume
+   it adds to the data backprojected since start_accumulating_in_new_target() was last called. */
 void back_project(const RelatedViewgrams<float>&,
           const int min_axial_pos_num, const int max_axial_pos_num,
           const int min_tangential_pos_num, const int max_tangential_pos_num);
 
- /*! \brief tell the back projector to start accumulating into a new image*/
+ /*! \brief tell the back projector to start accumulating into a new target.
+   This function has to be called before any back-projection is initiated.*/
  virtual void start_accumulating_in_new_target();
 
- /// Get output
+ /*! \brief Get output
+  This will overwrite the array-content of the argument with the result of all backprojections since calling `start_accumulating_in_new_target()`. Note that the argument has to have the same characteristics as what was used when calling `set_up()`.
+ */
  virtual void get_output(DiscretisedDensity<3,float> &) const;
 
 protected:
 
+  /*! \brief This actually does the back projection.
+   There are two versions of this code to enable backwards compatibility.
+
+   This is the older version (in which the backprojected image is not a member variable).
+   In most cases, the new version (in which the backprojected image is a member variable) calls the old version.
+
+   If you are developing your own projector, one of these two needs to be overloaded. It doesn't matter which,
+   but it might as well be the new one in case we one day decide to remove the old ones.
+  */
   virtual void actual_back_project(DiscretisedDensity<3,float>&,
                                    const RelatedViewgrams<float>&,
 		                   const int min_axial_pos_num, const int max_axial_pos_num,
                            const int min_tangential_pos_num, const int max_tangential_pos_num);
 
+  /*! \brief This actually does the back projection.
+   There are two versions of this code to enable backwards compatibility.
+
+   This is the newer version (in which the backprojected image is a member variable).
+   In most cases, the new version calls the old version (in which the backprojected image is not a member variable).
+
+   If you are developing your own projector, one of these two needs to be overloaded. It doesn't matter which,
+   but it might as well be the new one in case we one day decide to remove the old ones.
+  */
  virtual void actual_back_project(const RelatedViewgrams<float>&,
                           const int min_axial_pos_num, const int max_axial_pos_num,
                           const int min_tangential_pos_num, const int max_tangential_pos_num);
@@ -156,7 +177,7 @@ protected:
   virtual void check(const ProjDataInfo& proj_data_info, const DiscretisedDensity<3,float>& density_info) const;
   bool _already_set_up;
 
-  //! The density ptr set with set_up()
+  //! Clone of the density sptr set with set_up()
   shared_ptr<DiscretisedDensity<3,float> > _density_sptr;
 
  private:
@@ -170,6 +191,7 @@ protected:
 	    const int start_view, const int end_view);
 
 #ifdef STIR_OPENMP
+  //! A vector of back projected images that will be used with openMP. There will be as many images as openMP threads
   std::vector< shared_ptr<DiscretisedDensity<3,float> > > _local_output_image_sptrs;
 #endif
 

--- a/src/include/stir/recon_buildblock/BackProjectorByBin.h
+++ b/src/include/stir/recon_buildblock/BackProjectorByBin.h
@@ -93,7 +93,7 @@ public:
     */
   void back_project(DiscretisedDensity<3,float>&,
 		const ProjData&, int subset_num = 0, int num_subsets = 1);
-
+#ifdef STIR_PROJECTORS_AS_V3
   /*! \brief projects the viewgrams into the volume
    it adds to the data already present in the volume.*/
  void back_project(DiscretisedDensity<3,float>&,
@@ -111,7 +111,7 @@ public:
 		   const RelatedViewgrams<float>&,
 		   const int min_axial_pos_num, const int max_axial_pos_num,
 		   const int min_tangential_pos_num, const int max_tangential_pos_num);
-
+#endif
  //! project whole proj_data into the volume
  /*! it overwrites the data already present in the volume */
  void back_project(const ProjData&, int subset_num = 0, int num_subsets = 1);
@@ -142,7 +142,7 @@ protected:
   virtual void actual_back_project(DiscretisedDensity<3,float>&,
                                    const RelatedViewgrams<float>&,
 		                   const int min_axial_pos_num, const int max_axial_pos_num,
-		                   const int min_tangential_pos_num, const int max_tangential_pos_num) = 0;
+                           const int min_tangential_pos_num, const int max_tangential_pos_num);
 
  virtual void actual_back_project(const RelatedViewgrams<float>&,
                           const int min_axial_pos_num, const int max_axial_pos_num,

--- a/src/include/stir/recon_buildblock/BackProjectorByBin.h
+++ b/src/include/stir/recon_buildblock/BackProjectorByBin.h
@@ -131,8 +131,8 @@ void back_project(const RelatedViewgrams<float>&,
           const int min_axial_pos_num, const int max_axial_pos_num,
           const int min_tangential_pos_num, const int max_tangential_pos_num);
 
- /*! \brief tell the back projector to start accumulating into a new image*/
- void start_accumulating_in_new_image();
+ /*! \brief tell the back projector to start accumulating into a new target/image*/
+ void reset_output();
 
  /// Get output
  virtual void get_output(DiscretisedDensity<3,float> &) const;

--- a/src/include/stir/recon_buildblock/BackProjectorByBin.h
+++ b/src/include/stir/recon_buildblock/BackProjectorByBin.h
@@ -9,12 +9,13 @@
   \author Kris Thielemans
   \author Sanida Mustafovic
   \author PARAPET project
+  \author Richard Brown
 
 */
 /*
     Copyright (C) 2000 PARAPET partners
     Copyright (C) 2000- 2011, Hammersmith Imanet Ltd
-    Copyright (C) 2018, University College London
+    Copyright (C) 2018-2019, University College London
     This file is part of STIR.
 
     This file is free software; you can redistribute it and/or modify

--- a/src/include/stir/recon_buildblock/BackProjectorByBin.h
+++ b/src/include/stir/recon_buildblock/BackProjectorByBin.h
@@ -112,6 +112,30 @@ public:
 		   const int min_axial_pos_num, const int max_axial_pos_num,
 		   const int min_tangential_pos_num, const int max_tangential_pos_num);
 
+ //! project whole proj_data into the volume
+ /*! it overwrites the data already present in the volume */
+ void back_project(const ProjData&);
+
+ /*! \brief projects the viewgrams into the volume
+  it adds to the data already present in the volume.*/
+void back_project(const RelatedViewgrams<float>&);
+
+ /*! \brief projects the specified range of the viewgrams into the volume
+  it adds to the data already present in the volume.*/
+void back_project(const RelatedViewgrams<float>&,
+          const int min_axial_pos_num, const int max_axial_pos_num);
+
+ /*! \brief projects the specified range of the viewgrams into the volume
+   it adds to the data already present in the volume.*/
+void back_project(const RelatedViewgrams<float>&,
+          const int min_axial_pos_num, const int max_axial_pos_num,
+          const int min_tangential_pos_num, const int max_tangential_pos_num);
+
+ /*! \brief tell the back projector to start accumulating into a new image*/
+ void start_accumulating_in_new_image();
+
+ /// Get output
+ virtual void get_output(DiscretisedDensity<3,float> &) const;
 
 protected:
 
@@ -119,6 +143,10 @@ protected:
                                    const RelatedViewgrams<float>&,
 		                   const int min_axial_pos_num, const int max_axial_pos_num,
 		                   const int min_tangential_pos_num, const int max_tangential_pos_num) = 0;
+
+ virtual void actual_back_project(const RelatedViewgrams<float>&,
+                          const int min_axial_pos_num, const int max_axial_pos_num,
+                          const int min_tangential_pos_num, const int max_tangential_pos_num);
   //! check if the argument is the same as what was used for set_up()
   /*! calls error() if anything is wrong.
 
@@ -127,11 +155,11 @@ protected:
   virtual void check(const ProjDataInfo& proj_data_info, const DiscretisedDensity<3,float>& density_info) const;
   bool _already_set_up;
 
+  //! The density ptr set with set_up()
+  shared_ptr<DiscretisedDensity<3,float> > _density_sptr;
+
  private:
   shared_ptr<ProjDataInfo> _proj_data_info_sptr;
-  //! The density ptr set with set_up()
-  /*! \todo it is wasteful to have to store the whole image as this uses memory that we don't need. */
-  shared_ptr<DiscretisedDensity<3,float> > _density_info_sptr;
 
   void do_segments(DiscretisedDensity<3,float>& image, 
             const ProjData& proj_data_org,

--- a/src/include/stir/recon_buildblock/BackProjectorByBin.h
+++ b/src/include/stir/recon_buildblock/BackProjectorByBin.h
@@ -132,8 +132,8 @@ void back_project(const RelatedViewgrams<float>&,
           const int min_axial_pos_num, const int max_axial_pos_num,
           const int min_tangential_pos_num, const int max_tangential_pos_num);
 
- /*! \brief tell the back projector to start accumulating into a new target/image*/
- void reset_output();
+ /*! \brief tell the back projector to start accumulating into a new image*/
+ void start_accumulating_in_new_target();
 
  /// Get output
  virtual void get_output(DiscretisedDensity<3,float> &) const;

--- a/src/include/stir/recon_buildblock/BackProjectorByBin.h
+++ b/src/include/stir/recon_buildblock/BackProjectorByBin.h
@@ -115,7 +115,7 @@ public:
 #endif
  //! project whole proj_data into the volume
  /*! it overwrites the data already present in the volume */
- void back_project(const ProjData&, int subset_num = 0, int num_subsets = 1);
+ virtual void back_project(const ProjData&, int subset_num = 0, int num_subsets = 1);
 
  /*! \brief projects the viewgrams into the volume
   it adds to the data already present in the volume.*/
@@ -133,7 +133,7 @@ void back_project(const RelatedViewgrams<float>&,
           const int min_tangential_pos_num, const int max_tangential_pos_num);
 
  /*! \brief tell the back projector to start accumulating into a new image*/
- void start_accumulating_in_new_target();
+ virtual void start_accumulating_in_new_target();
 
  /// Get output
  virtual void get_output(DiscretisedDensity<3,float> &) const;

--- a/src/include/stir/recon_buildblock/BackProjectorByBin.h
+++ b/src/include/stir/recon_buildblock/BackProjectorByBin.h
@@ -114,7 +114,7 @@ public:
 
  //! project whole proj_data into the volume
  /*! it overwrites the data already present in the volume */
- void back_project(const ProjData&);
+ void back_project(const ProjData&, int subset_num = 0, int num_subsets = 1);
 
  /*! \brief projects the viewgrams into the volume
   it adds to the data already present in the volume.*/
@@ -168,6 +168,9 @@ protected:
 	    const int start_tang_pos_num,const int end_tang_pos_num,
 	    const int start_view, const int end_view);
 
+#ifdef STIR_OPENMP
+  std::vector< shared_ptr<DiscretisedDensity<3,float> > > _local_output_image_sptrs;
+#endif
 
 };
 

--- a/src/include/stir/recon_buildblock/ForwardProjectorByBin.h
+++ b/src/include/stir/recon_buildblock/ForwardProjectorByBin.h
@@ -108,7 +108,28 @@ virtual void set_up(
 		  const int min_axial_pos_num, const int max_axial_pos_num,
 		  const int min_tangential_pos_num, const int max_tangential_pos_num);
 
+   //! project the volume into the whole proj_data
+   /*! it overwrites the data already present in the projection data */
+    void forward_project(ProjData&);
+
+   //! project the volume into the viewgrams
+   /*! it overwrites the data already present in the viewgram */
+    void forward_project(RelatedViewgrams<float>&);
+
+    void forward_project(RelatedViewgrams<float>&,
+          const int min_axial_pos_num, const int max_axial_pos_num);
+
+    void forward_project(RelatedViewgrams<float>&,
+          const int min_axial_pos_num, const int max_axial_pos_num,
+          const int min_tangential_pos_num, const int max_tangential_pos_num);
+
     virtual ~ForwardProjectorByBin();
+
+    /// Set input
+    virtual void set_input(const shared_ptr<DiscretisedDensity<3,float> >&);
+
+    /// Set input
+    void set_input(const DiscretisedDensity<3,float>*);
 
 protected:
   //! This virtual function has to be implemented by the derived class.
@@ -116,6 +137,10 @@ protected:
 		  const DiscretisedDensity<3,float>&,
 		  const int min_axial_pos_num, const int max_axial_pos_num,
 		  const int min_tangential_pos_num, const int max_tangential_pos_num) = 0;
+
+  virtual void actual_forward_project(RelatedViewgrams<float>& viewgrams,
+          const int min_axial_pos_num, const int max_axial_pos_num,
+          const int min_tangential_pos_num, const int max_tangential_pos_num);
 
   //! check if the argument is the same as what was used for set_up()
   /*! calls error() if anything is wrong.
@@ -125,11 +150,11 @@ protected:
   virtual void check(const ProjDataInfo& proj_data_info, const DiscretisedDensity<3,float>& density_info) const;
   bool _already_set_up;
 
+  //! The density ptr set with set_up()
+  shared_ptr<DiscretisedDensity<3,float> > _density_sptr;
+
 private:
   shared_ptr<ProjDataInfo> _proj_data_info_sptr;
-  //! The density ptr set with set_up()
-  /*! \todo it is wasteful to have to store the whole image as this uses memory that we don't need. */
-  shared_ptr<DiscretisedDensity<3,float> > _density_info_sptr;
 };
 
 END_NAMESPACE_STIR

--- a/src/include/stir/recon_buildblock/ForwardProjectorByBin.h
+++ b/src/include/stir/recon_buildblock/ForwardProjectorByBin.h
@@ -110,7 +110,8 @@ virtual void set_up(
 
    //! project the volume into the whole proj_data
    /*! it overwrites the data already present in the projection data */
-    void forward_project(ProjData&);
+    void forward_project(ProjData&,
+                         int subset_num = 0, int num_subsets = 1, bool zero = true);
 
    //! project the volume into the viewgrams
    /*! it overwrites the data already present in the viewgram */

--- a/src/include/stir/recon_buildblock/ForwardProjectorByBin.h
+++ b/src/include/stir/recon_buildblock/ForwardProjectorByBin.h
@@ -93,7 +93,7 @@ virtual void set_up(
     void forward_project(ProjData&, 
 			 const DiscretisedDensity<3,float>&, 
 			 int subset_num = 0, int num_subsets = 1, bool zero = true);
-
+#ifdef STIR_PROJECTORS_AS_V3
    //! project the volume into the viewgrams
    /*! it overwrites the data already present in the viewgram */
     void forward_project(RelatedViewgrams<float>&, 
@@ -107,7 +107,7 @@ virtual void set_up(
 		  const DiscretisedDensity<3,float>&,
 		  const int min_axial_pos_num, const int max_axial_pos_num,
 		  const int min_tangential_pos_num, const int max_tangential_pos_num);
-
+#endif
    //! project the volume into the whole proj_data
    /*! it overwrites the data already present in the projection data */
     void forward_project(ProjData&,
@@ -134,7 +134,7 @@ protected:
   virtual void actual_forward_project(RelatedViewgrams<float>&, 
 		  const DiscretisedDensity<3,float>&,
 		  const int min_axial_pos_num, const int max_axial_pos_num,
-		  const int min_tangential_pos_num, const int max_tangential_pos_num) = 0;
+          const int min_tangential_pos_num, const int max_tangential_pos_num);
 
   virtual void actual_forward_project(RelatedViewgrams<float>& viewgrams,
           const int min_axial_pos_num, const int max_axial_pos_num,

--- a/src/include/stir/recon_buildblock/ForwardProjectorByBin.h
+++ b/src/include/stir/recon_buildblock/ForwardProjectorByBin.h
@@ -12,12 +12,13 @@
   \author Kris Thielemans
   \author Sanida Mustafovic
   \author PARAPET project
+  \author Richard Brown
 
 */
 /*
     Copyright (C) 2000 PARAPET partners
     Copyright (C) 2000- 2011, Hammersmith Imanet Ltd
-    Copyright (C) 2018, University College London
+    Copyright (C) 2018-2019, University College London
     This file is part of STIR.
 
     This file is free software; you can redistribute it and/or modify

--- a/src/include/stir/recon_buildblock/ForwardProjectorByBin.h
+++ b/src/include/stir/recon_buildblock/ForwardProjectorByBin.h
@@ -111,7 +111,7 @@ virtual void set_up(
 #endif
    //! project the volume into the whole proj_data
    /*! it overwrites the data already present in the projection data */
-    void forward_project(ProjData&,
+    virtual void forward_project(ProjData&,
                          int subset_num = 0, int num_subsets = 1, bool zero = true);
 
    //! project the volume into the viewgrams

--- a/src/include/stir/recon_buildblock/ForwardProjectorByBin.h
+++ b/src/include/stir/recon_buildblock/ForwardProjectorByBin.h
@@ -127,10 +127,7 @@ virtual void set_up(
     virtual ~ForwardProjectorByBin();
 
     /// Set input
-    virtual void set_input(const shared_ptr<DiscretisedDensity<3,float> >&);
-
-    /// Set input
-    void set_input(const DiscretisedDensity<3,float>*);
+    virtual void set_input(const DiscretisedDensity<3,float>&);
 
 protected:
   //! This virtual function has to be implemented by the derived class.

--- a/src/include/stir/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMeanAndListModeDataWithProjMatrixByBin.h
+++ b/src/include/stir/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMeanAndListModeDataWithProjMatrixByBin.h
@@ -126,7 +126,7 @@ protected:
   virtual bool actual_subsets_are_approximately_balanced(std::string& warning_message) const;
 
   void
-    add_view_seg_to_sensitivity(TargetT& sensitivity, const ViewSegmentNumbers& view_seg_nums) const;
+    add_view_seg_to_sensitivity(const ViewSegmentNumbers& view_seg_nums) const;
 };
 
 END_NAMESPACE_STIR

--- a/src/include/stir/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMeanAndProjData.h
+++ b/src/include/stir/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMeanAndProjData.h
@@ -336,9 +336,10 @@ protected:
   bool actual_subsets_are_approximately_balanced(std::string& warning_message) const;
  private:
   shared_ptr<DataSymmetriesForViewSegmentNumbers> symmetries_sptr;
-
+#if 0
   void
     add_view_seg_to_sensitivity(TargetT& sensitivity, const ViewSegmentNumbers& view_seg_nums) const;
+#endif
 };
 
 #ifdef STIR_MPI

--- a/src/include/stir/recon_buildblock/PostsmoothingBackProjectorByBin.h
+++ b/src/include/stir/recon_buildblock/PostsmoothingBackProjectorByBin.h
@@ -92,12 +92,12 @@ private:
 
   shared_ptr<BackProjectorByBin> original_back_projector_ptr;
   shared_ptr<DataProcessor<DiscretisedDensity<3,float> > > image_processor_ptr;
-
+#ifdef STIR_PROJECTORS_AS_V3
   void actual_back_project(DiscretisedDensity<3,float>&,
                            const RelatedViewgrams<float>&,
                            const int min_axial_pos_num, const int max_axial_pos_num,
                            const int min_tangential_pos_num, const int max_tangential_pos_num);
-
+#endif
   void actual_back_project(const RelatedViewgrams<float>&,
                            const int min_axial_pos_num, const int max_axial_pos_num,
                            const int min_tangential_pos_num, const int max_tangential_pos_num);

--- a/src/include/stir/recon_buildblock/PostsmoothingBackProjectorByBin.h
+++ b/src/include/stir/recon_buildblock/PostsmoothingBackProjectorByBin.h
@@ -6,10 +6,12 @@
   \brief Declaration of class stir::PostsmoothingBackProjectorByBin
 
   \author Kris Thielemans
+  \author Richard Brown
 
 */
 /*
     Copyright (C) 2002- 2007, Hammersmith Imanet
+    Copyright (C) 2019, University College London
 
     This file is part of STIR.
 

--- a/src/include/stir/recon_buildblock/PostsmoothingBackProjectorByBin.h
+++ b/src/include/stir/recon_buildblock/PostsmoothingBackProjectorByBin.h
@@ -41,12 +41,22 @@ template <typename DataT> class DataProcessor;
 /*!
   \brief A very preliminary class that first smooths the image, then back projects.
 
+  \warning. It assumes that the DataProcessor does not change
+  the size of the image.
 */
 class PostsmoothingBackProjectorByBin : 
   public 
     RegisteredParsingObject<PostsmoothingBackProjectorByBin,
                             BackProjectorByBin>
 {
+#ifdef SWIG
+  // work-around swig problem. It gets confused when using a private (or protected)
+  // typedef in a definition of a public typedef/member
+public:
+#else
+ private:
+#endif
+  typedef BackProjectorByBin base_type;
 public:
   //! Name which will be used when parsing a PostsmoothingBackProjectorByBin object
   static const char * const registered_name; 
@@ -75,6 +85,8 @@ public:
   // class has other behaviour).
   const DataSymmetriesForViewSegmentNumbers * get_symmetries_used() const;
 
+  /// Get output
+  virtual void get_output(DiscretisedDensity<3,float> &) const;
 
 private:
 
@@ -86,6 +98,9 @@ private:
                            const int min_axial_pos_num, const int max_axial_pos_num,
                            const int min_tangential_pos_num, const int max_tangential_pos_num);
 
+  void actual_back_project(const RelatedViewgrams<float>&,
+                           const int min_axial_pos_num, const int max_axial_pos_num,
+                           const int min_tangential_pos_num, const int max_tangential_pos_num);
 
 
   virtual void set_defaults();

--- a/src/include/stir/recon_buildblock/PresmoothingForwardProjectorByBin.h
+++ b/src/include/stir/recon_buildblock/PresmoothingForwardProjectorByBin.h
@@ -39,7 +39,7 @@ template <typename DataT> class DataProcessor;
 /*!
   \brief A very preliminary class that first smooths the image, then forward projects.
 
-  \warning. It assumes that the ImageProcessor used to do the filtering does not change 
+  \warning. It assumes that the DataProcessor does not change
   the size of the image.
 */
 class PresmoothingForwardProjectorByBin : 
@@ -47,6 +47,14 @@ class PresmoothingForwardProjectorByBin :
     RegisteredParsingObject<PresmoothingForwardProjectorByBin,
                             ForwardProjectorByBin>
 {
+#ifdef SWIG
+  // work-around swig problem. It gets confused when using a private (or protected)
+  // typedef in a definition of a public typedef/member
+public:
+#else
+ private:
+#endif
+  typedef ForwardProjectorByBin base_type;
 public:
   //! Name which will be used when parsing a PresmoothingForwardProjectorByBin object
   static const char * const registered_name; 
@@ -75,6 +83,8 @@ public:
   // class has other behaviour).
   const DataSymmetriesForViewSegmentNumbers * get_symmetries_used() const;
 
+  /// Set input
+  virtual void set_input(const shared_ptr<DiscretisedDensity<3,float> >&);
 
 private:
 
@@ -86,6 +96,9 @@ private:
                               const int min_axial_pos_num, const int max_axial_pos_num,
                               const int min_tangential_pos_num, const int max_tangential_pos_num);
 
+  void actual_forward_project(RelatedViewgrams<float>&,
+                              const int min_axial_pos_num, const int max_axial_pos_num,
+                              const int min_tangential_pos_num, const int max_tangential_pos_num);
 
 
   virtual void set_defaults();

--- a/src/include/stir/recon_buildblock/PresmoothingForwardProjectorByBin.h
+++ b/src/include/stir/recon_buildblock/PresmoothingForwardProjectorByBin.h
@@ -90,12 +90,12 @@ private:
 
   shared_ptr<ForwardProjectorByBin> original_forward_projector_ptr;
   shared_ptr<DataProcessor<DiscretisedDensity<3,float> > > image_processor_ptr;
-
+#ifdef STIR_PROJECTORS_AS_V3
   void actual_forward_project(RelatedViewgrams<float>&, 
                               const DiscretisedDensity<3,float>&,
                               const int min_axial_pos_num, const int max_axial_pos_num,
                               const int min_tangential_pos_num, const int max_tangential_pos_num);
-
+#endif
   void actual_forward_project(RelatedViewgrams<float>&,
                               const int min_axial_pos_num, const int max_axial_pos_num,
                               const int min_tangential_pos_num, const int max_tangential_pos_num);

--- a/src/include/stir/recon_buildblock/PresmoothingForwardProjectorByBin.h
+++ b/src/include/stir/recon_buildblock/PresmoothingForwardProjectorByBin.h
@@ -4,10 +4,12 @@
   \brief Declaration of class stir::PresmoothingForwardProjectorByBin
 
   \author Kris Thielemans
+  \author Richard Brown
 
 */
 /*
     Copyright (C) 2002- 2007, Hammersmith Imanet
+    Copyright (C) 2019, University College London
 
     This file is part of STIR.
 

--- a/src/include/stir/recon_buildblock/distributable.h
+++ b/src/include/stir/recon_buildblock/distributable.h
@@ -96,8 +96,6 @@ void end_distributable_computation();
 typedef  void RPC_process_related_viewgrams_type (
                                                   const shared_ptr<ForwardProjectorByBin>& forward_projector_sptr,
                                                   const shared_ptr<BackProjectorByBin>& back_projector_sptr,
-                                                  DiscretisedDensity<3,float>* output_image_ptr, 
-                                                  const DiscretisedDensity<3,float>* input_image_ptr, 
                                                   RelatedViewgrams<float>* measured_viewgrams_ptr,
                                                   int& count, int& count2, double* log_likelihood_ptr,
                                                   const RelatedViewgrams<float>* additive_binwise_correction_ptr,

--- a/src/include/stir_experimental/recon_buildblock/PostsmoothingForwardProjectorByBin.h
+++ b/src/include/stir_experimental/recon_buildblock/PostsmoothingForwardProjectorByBin.h
@@ -7,10 +7,12 @@
   \brief Declaration of class PostsmoothingForwardProjectorByBin
 
   \author Kris Thielemans
+  \author Richard Brown
 
 */
 /*
     Copyright (C) 2000- 2001, IRSL
+    Copyright (C) 2019, University College London
     See STIR/LICENSE.txt for details
 */
 #ifndef __stir_recon_buildblock_PostsmoothingForwardProjectorByBin__H__

--- a/src/include/stir_experimental/recon_buildblock/PostsmoothingForwardProjectorByBin.h
+++ b/src/include/stir_experimental/recon_buildblock/PostsmoothingForwardProjectorByBin.h
@@ -74,11 +74,16 @@ private:
   std::vector<double> tang_kernel_double;
   std::vector<double> ax_kernel_double;
 
+#ifdef STIR_PROJECTORS_AS_V3
   void actual_forward_project(RelatedViewgrams<float>&, 
 		  const DiscretisedDensity<3,float>&,
 		  const int min_axial_pos_num, const int max_axial_pos_num,
 		  const int min_tangential_pos_num, const int max_tangential_pos_num);
-
+#endif
+  /// Actual forward project where input has already been set.
+  void actual_forward_project(RelatedViewgrams<float>&,
+          const int min_axial_pos_num, const int max_axial_pos_num,
+          const int min_tangential_pos_num, const int max_tangential_pos_num);
   void smooth(Viewgram<float>&,
               const int min_axial_pos_num, const int max_axial_pos_num,
               const int min_tangential_pos_num, const int max_tangential_pos_num) const;

--- a/src/recon_buildblock/BackProjectorByBin.cxx
+++ b/src/recon_buildblock/BackProjectorByBin.cxx
@@ -91,7 +91,7 @@ void
 BackProjectorByBin::back_project(DiscretisedDensity<3,float>& image,
 const ProjData& proj_data, int subset_num, int num_subsets)
 {
-  reset_output();
+  start_accumulating_in_new_target();
   back_project(proj_data, subset_num, num_subsets);
   get_output(image);
 }
@@ -162,7 +162,7 @@ back_project(DiscretisedDensity<3,float>& density,
 }
 #endif
 // -------------------------------------------------------------------------------------------------------------------- //
-// The following are repetition of above, where the DiscretisedDensity has already been set with reset_output()
+// The following are repetition of above, where the DiscretisedDensity has already been set with start_accumulating_in_new_target()
 // -------------------------------------------------------------------------------------------------------------------- //
 void
 BackProjectorByBin::back_project(const ProjData& proj_data, int subset_num, int num_subsets)
@@ -285,11 +285,11 @@ back_project(const RelatedViewgrams<float>& viewgrams,
 
 void
 BackProjectorByBin::
-reset_output()
+start_accumulating_in_new_target()
 {
 #ifdef STIR_OPENMP
   if (omp_get_num_threads()!=1)
-      error("BackProjectorByBin::reset_output cannot be called inside a thread");
+      error("BackProjectorByBin::start_accumulating_in_new_target cannot be called inside a thread");
 
   for (int i=0; i<static_cast<int>(_local_output_image_sptrs.size()); ++i)
                if(!is_null_ptr(_local_output_image_sptrs[i])) // only accumulate if a thread filled something in

--- a/src/recon_buildblock/BackProjectorByBin.cxx
+++ b/src/recon_buildblock/BackProjectorByBin.cxx
@@ -180,7 +180,7 @@ BackProjectorByBin::back_project(const ProjData& proj_data, int subset_num, int 
                                          subset_num, num_subsets);
 
 #ifdef STIR_OPENMP
-#pragma omp parallel shared(proj_data, symmetries_sptr, _local_output_image_sptrs)
+#pragma omp parallel shared(proj_data, symmetries_sptr)
 #endif
   {
 #ifdef STIR_OPENMP

--- a/src/recon_buildblock/BackProjectorByBin.cxx
+++ b/src/recon_buildblock/BackProjectorByBin.cxx
@@ -8,12 +8,13 @@
 
   \author Kris Thielemans
   \author PARAPET project
+  \author Richard Brown
   
 */
 /*
     Copyright (C) 2000 PARAPET partners
     Copyright (C) 2000- 2011, Hammersmith Imanet Ltd
-    Copyright (C) 2015, 2018, University College London
+    Copyright (C) 2015, 2018-2019, University College London
     This file is part of STIR.
 
     This file is free software; you can redistribute it and/or modify

--- a/src/recon_buildblock/BackProjectorByBin.cxx
+++ b/src/recon_buildblock/BackProjectorByBin.cxx
@@ -90,7 +90,7 @@ void
 BackProjectorByBin::back_project(DiscretisedDensity<3,float>& image,
 const ProjData& proj_data, int subset_num, int num_subsets)
 {
-  start_accumulating_in_new_image();
+  reset_output();
   back_project(proj_data, subset_num, num_subsets);
   get_output(image);
 }
@@ -161,7 +161,7 @@ back_project(DiscretisedDensity<3,float>& density,
 }
 #endif
 // -------------------------------------------------------------------------------------------------------------------- //
-// The following are repetition of above, where the DiscretisedDensity has already been set with start_accumulating_in_new_image()
+// The following are repetition of above, where the DiscretisedDensity has already been set with reset_output()
 // -------------------------------------------------------------------------------------------------------------------- //
 void
 BackProjectorByBin::back_project(const ProjData& proj_data, int subset_num, int num_subsets)
@@ -284,11 +284,11 @@ back_project(const RelatedViewgrams<float>& viewgrams,
 
 void
 BackProjectorByBin::
-start_accumulating_in_new_image()
+reset_output()
 {
 #ifdef STIR_OPENMP
   if (omp_get_num_threads()!=1)
-      error("BackProjectorByBin::start_accumulating_in_new_image cannot be called inside a thread");
+      error("BackProjectorByBin::reset_output cannot be called inside a thread");
 
   for (int i=0; i<static_cast<int>(_local_output_image_sptrs.size()); ++i)
                if(!is_null_ptr(_local_output_image_sptrs[i])) // only accumulate if a thread filled something in

--- a/src/recon_buildblock/BackProjectorByBin.cxx
+++ b/src/recon_buildblock/BackProjectorByBin.cxx
@@ -35,6 +35,7 @@
 #include "stir/RelatedViewgrams.h"
 #include "stir/ProjData.h"
 #include "stir/DiscretisedDensity.h"
+#include "stir/info.h"
 #include <vector>
 #ifdef STIR_OPENMP
 #include "stir/is_null_ptr.h"
@@ -61,7 +62,7 @@ set_up(const shared_ptr<ProjDataInfo>& proj_data_info_sptr,
 {
   _already_set_up = true;
   _proj_data_info_sptr = proj_data_info_sptr->create_shared_clone();
-  _density_info_sptr = density_info_sptr;
+  _density_sptr.reset(density_info_sptr->clone());
 }
 
 void
@@ -73,7 +74,7 @@ check(const ProjDataInfo& proj_data_info, const DiscretisedDensity<3,float>& den
   if (!(*this->_proj_data_info_sptr >= proj_data_info))
     error(boost::format("BackProjectorByBin set-up with different geometry for projection data.\nSet_up was with\n%1%\nCalled with\n%2%")
           % this->_proj_data_info_sptr->parameter_info() % proj_data_info.parameter_info());
-  if (! this->_density_info_sptr->has_same_characteristics(density_info))
+  if (! this->_density_sptr->has_same_characteristics(density_info))
     error("BackProjectorByBin set-up with different geometry for density or volume data.");
 }  
 
@@ -89,13 +90,14 @@ const ProjData& proj_data, int subset_num, int num_subsets)
       proj_data.get_exam_info().imaging_modality)
     error("back_project: Imaging modality should be the same for the image and the projection data");
 
-  if (subset_num < 0)
-    error(boost::format("forward_project: wrong subset number %1%") % subset_num);
-  if (subset_num > num_subsets - 1)
-    error(boost::format("forward_project: wrong subset number %1% (must be less than the number of subsets %2%)")
-          % subset_num % num_subsets);
-
-  check(*proj_data.get_proj_data_info_sptr(), image);
+	if (subset_num < 0)
+		error(boost::format("forward_project: wrong subset number %1%") % subset_num);
+	if (subset_num > num_subsets - 1)
+		error(boost::format("forward_project: wrong subset number %1% (must be less than the number of subsets %2%)")
+		% subset_num % num_subsets);
+	
+	check(*proj_data.get_proj_data_info_sptr(), image);
+  this->start_accumulating_in_new_image();
     
   shared_ptr<DataSymmetriesForViewSegmentNumbers> 
     symmetries_sptr(this->get_symmetries_used()->clone());  
@@ -136,7 +138,9 @@ const ProjData& proj_data, int subset_num, int num_subsets)
         
         back_project(*(local_output_image_sptrs[thread_num]), viewgrams);	  
 #else            
-        back_project(image, viewgrams);
+        info(boost::format("Processing view %1% of segment %2%") % vs.view_num() % vs.segment_num());
+        back_project(viewgrams);
+        this->get_output(image);
 #endif
       }
   }
@@ -214,6 +218,159 @@ back_project(DiscretisedDensity<3,float>& density,
 	     max_tangential_pos_num);
   stop_timers();
 }
+// -------------------------------------------------------------------------------------------------------------------- //
+// The following are repition of above, where the DiscretisedDensity has already been set with start_accumulating_in_new_image()
+// -------------------------------------------------------------------------------------------------------------------- //
+void
+BackProjectorByBin::back_project(const ProjData& proj_data)
+{
+#ifndef NDEBUG
+    assert(fabs(_density_sptr->sum()) < 1.e-7F);
+#endif
+  check(*proj_data.get_proj_data_info_sptr(), *_density_sptr);
 
+  shared_ptr<DataSymmetriesForViewSegmentNumbers>
+    symmetries_sptr(this->get_symmetries_used()->clone());
+
+  const std::vector<ViewSegmentNumbers> vs_nums_to_process =
+    detail::find_basic_vs_nums_in_subset(*proj_data.get_proj_data_info_ptr(), *symmetries_sptr,
+                                         proj_data.get_min_segment_num(), proj_data.get_max_segment_num(),
+                                         0, 1/*subset_num, num_subsets*/);
+
+#ifdef STIR_OPENMP
+  std::vector< shared_ptr<DiscretisedDensity<3,float> > > local_output_image_sptrs;
+#pragma omp parallel shared(proj_data, symmetries_sptr, local_output_image_sptrs)
+#endif
+  {
+#ifdef STIR_OPENMP
+#pragma omp single
+    {
+      local_output_image_sptrs.resize(omp_get_num_threads(), shared_ptr<DiscretisedDensity<3,float> >());
+    }
+#pragma omp for schedule(runtime)
+#endif
+    // note: older versions of openmp need an int as loop
+    for (int i=0; i<static_cast<int>(vs_nums_to_process.size()); ++i)
+      {
+        const ViewSegmentNumbers vs=vs_nums_to_process[i];
+#ifdef STIR_OPENMP
+        RelatedViewgrams<float> viewgrams;
+#pragma omp critical (BACKPROJECTORBYBIN_GETVIEWGRAMS)
+        viewgrams = proj_data.get_related_viewgrams(vs, symmetries_sptr);
+#else
+        const RelatedViewgrams<float> viewgrams =
+          proj_data.get_related_viewgrams(vs, symmetries_sptr);
+#endif
+#ifdef STIR_OPENMP
+        const int thread_num=omp_get_thread_num();
+        if(is_null_ptr(local_output_image_sptrs[thread_num]))
+          local_output_image_sptrs[thread_num].reset(image.get_empty_copy());
+
+        back_project(*(local_output_image_sptrs[thread_num]), viewgrams);
+#else
+        info(boost::format("Processing view %1% of segment %2%") % vs.view_num() % vs.segment_num());
+        back_project(viewgrams);
+#endif
+      }
+  }
+#ifdef STIR_OPENMP
+  // "reduce" data constructed by threads
+  {
+    for (int i=0; i<static_cast<int>(local_output_image_sptrs.size()); ++i)
+      if(!is_null_ptr(local_output_image_sptrs[i])) // only accumulate if a thread filled something in
+        image += *(local_output_image_sptrs[i]);
+  }
+#endif
+}
+
+void
+BackProjectorByBin::back_project(const RelatedViewgrams<float>& viewgrams)
+{
+  back_project(viewgrams,
+                  viewgrams.get_min_axial_pos_num(),
+          viewgrams.get_max_axial_pos_num(),
+          viewgrams.get_min_tangential_pos_num(),
+          viewgrams.get_max_tangential_pos_num());
+}
+
+void BackProjectorByBin::back_project
+  (const RelatedViewgrams<float>& viewgrams,
+   const int min_axial_pos_num,
+   const int max_axial_pos_num)
+{
+  back_project(viewgrams,
+             min_axial_pos_num,
+         max_axial_pos_num,
+         viewgrams.get_min_tangential_pos_num(),
+         viewgrams.get_max_tangential_pos_num());
+}
+
+void
+BackProjectorByBin::
+back_project(const RelatedViewgrams<float>& viewgrams,
+         const int min_axial_pos_num, const int max_axial_pos_num,
+         const int min_tangential_pos_num, const int max_tangential_pos_num)
+{
+  if (viewgrams.get_num_viewgrams()==0)
+    return;
+
+  check(*viewgrams.get_proj_data_info_sptr(), *_density_sptr);
+
+  start_timers();
+
+  // first check symmetries
+  {
+    const ViewSegmentNumbers basic_vs = viewgrams.get_basic_view_segment_num();
+
+    if (get_symmetries_used()->num_related_view_segment_numbers(basic_vs) !=
+      viewgrams.get_num_viewgrams())
+      error("BackProjectorByBin::back_project called with incorrect related_viewgrams. Problem with symmetries!\n");
+
+    for (RelatedViewgrams<float>::const_iterator iter = viewgrams.begin();
+     iter != viewgrams.end();
+     ++iter)
+      {
+    ViewSegmentNumbers vs(iter->get_view_num(), iter->get_segment_num());
+    get_symmetries_used()->find_basic_view_segment_numbers(vs);
+    if (vs != basic_vs)
+      error("BackProjectorByBin::back_project called with incorrect related_viewgrams. Problem with symmetries!\n");
+    }
+  }
+
+  actual_back_project(
+         viewgrams,
+         min_axial_pos_num,
+         max_axial_pos_num,
+         min_tangential_pos_num,
+         max_tangential_pos_num);
+  stop_timers();
+}
+
+void
+BackProjectorByBin::
+start_accumulating_in_new_image()
+{
+    _density_sptr->fill(0.);
+}
+
+void
+BackProjectorByBin::
+get_output(DiscretisedDensity<3,float> &density) const
+{
+    if (!density.has_same_characteristics(*_density_sptr))
+            error("Images should have similar characteristics.");
+    std::copy(_density_sptr->begin_all(), _density_sptr->end_all(), density.begin_all());
+}
+
+void
+BackProjectorByBin::
+actual_back_project(const RelatedViewgrams<float>& viewgrams,
+                         const int min_axial_pos_num, const int max_axial_pos_num,
+                         const int min_tangential_pos_num, const int max_tangential_pos_num)
+{
+    actual_back_project(*_density_sptr, viewgrams,
+                        min_axial_pos_num, max_axial_pos_num,
+                        min_tangential_pos_num, max_tangential_pos_num);
+}
 
 END_NAMESPACE_STIR

--- a/src/recon_buildblock/BinNormalisationFromAttenuationImage.cxx
+++ b/src/recon_buildblock/BinNormalisationFromAttenuationImage.cxx
@@ -132,6 +132,7 @@ set_up(const shared_ptr<ProjDataInfo>& proj_data_info_ptr)
 {
   BinNormalisation::set_up(proj_data_info_ptr);
   forward_projector_ptr->set_up(proj_data_info_ptr, attenuation_image_ptr);
+  forward_projector_ptr->set_input(*attenuation_image_ptr);
   return Succeeded::yes;
 }
 
@@ -141,7 +142,7 @@ BinNormalisationFromAttenuationImage::apply(RelatedViewgrams<float>& viewgrams,c
 {
   this->check(*viewgrams.get_proj_data_info_sptr());
   RelatedViewgrams<float> attenuation_viewgrams = viewgrams.get_empty_copy();
-  forward_projector_ptr->forward_project(attenuation_viewgrams, *attenuation_image_ptr);
+  forward_projector_ptr->forward_project(attenuation_viewgrams);
 	
   // TODO cannot use std::transform ?
   for (RelatedViewgrams<float>::iterator viewgrams_iter = 
@@ -160,7 +161,7 @@ undo(RelatedViewgrams<float>& viewgrams,const double start_time, const double en
 {
   this->check(*viewgrams.get_proj_data_info_sptr());
   RelatedViewgrams<float> attenuation_viewgrams = viewgrams.get_empty_copy();
-  forward_projector_ptr->forward_project(attenuation_viewgrams, *attenuation_image_ptr);
+  forward_projector_ptr->forward_project(attenuation_viewgrams);
 	
   // TODO cannot use std::transform ?
   for (RelatedViewgrams<float>::iterator viewgrams_iter = 

--- a/src/recon_buildblock/DistributedWorker.cxx
+++ b/src/recon_buildblock/DistributedWorker.cxx
@@ -212,6 +212,8 @@ namespace stir
     distributed::receive_and_initialize_projectors(this->proj_pair_sptr, 0);
                 
     proj_pair_sptr->set_up(this->proj_data_info_sptr, this->target_sptr);
+    proj_pair_sptr->get_forward_projector_sptr()->set_input(this->target_sptr);
+    proj_pair_sptr->get_back_projector_sptr()->set_output(this->output_target_sptr);
                 
     //some values to configure tests
     int configurations[4];
@@ -373,7 +375,10 @@ namespace stir
                 //make reduction over computed output_images
                 distributed::first_iteration=false;
 		if (!is_null_ptr(output_image_ptr))
-		  distributed::reduce_output_image(output_image_ptr, image_buffer_size, my_rank, 0);
+                  {
+                    proj_pair_sptr->get_back_projector_sptr()->get_output(output_image_ptr);
+                  distributed::reduce_output_image(output_image_ptr, image_buffer_size, my_rank, 0);
+                  }
 		// and log_likelihood
 		if (!is_null_ptr(log_likelihood_ptr))
 		  {

--- a/src/recon_buildblock/ForwardProjectorByBin.cxx
+++ b/src/recon_buildblock/ForwardProjectorByBin.cxx
@@ -201,8 +201,6 @@ void
 ForwardProjectorByBin::forward_project(ProjData& proj_data)
 {
 
-    std::cout <<"\nI'm here1. forward projecting but the input has already been set!\n";
-
  // this->set_up(proj_data_ptr->get_proj_data_info_ptr()->clone(),
 //			     image_sptr);
 

--- a/src/recon_buildblock/ForwardProjectorByBin.cxx
+++ b/src/recon_buildblock/ForwardProjectorByBin.cxx
@@ -63,7 +63,7 @@ set_up(const shared_ptr<ProjDataInfo>& proj_data_info_sptr,
 {
   _already_set_up = true;
   _proj_data_info_sptr = proj_data_info_sptr->create_shared_clone();
-  _density_info_sptr = density_info_sptr;
+  _density_sptr = density_info_sptr;
 }
 
 void
@@ -75,7 +75,7 @@ check(const ProjDataInfo& proj_data_info, const DiscretisedDensity<3,float>& den
   if (!(*this->_proj_data_info_sptr >= proj_data_info))
     error(boost::format("ForwardProjectorByBin set-up with different geometry for projection data.\nSet_up was with\n%1%\nCalled with\n%2%")
           % this->_proj_data_info_sptr->parameter_info() % proj_data_info.parameter_info());
-  if (! this->_density_info_sptr->has_same_characteristics(density_info))
+  if (! this->_density_sptr->has_same_characteristics(density_info))
     error("ForwardProjectorByBin set-up with different geometry for density or volume data.");
 }  
 
@@ -194,6 +194,135 @@ forward_project(RelatedViewgrams<float>& viewgrams,
 	     max_tangential_pos_num);
   stop_timers();
 }
+// -------------------------------------------------------------------------------------------------------------------- //
+// The following are repition of above, where the DiscretisedDensity has already been set with set_input()
+// -------------------------------------------------------------------------------------------------------------------- //
+void
+ForwardProjectorByBin::forward_project(ProjData& proj_data)
+{
 
+    std::cout <<"\nI'm here1. forward projecting but the input has already been set!\n";
+
+ // this->set_up(proj_data_ptr->get_proj_data_info_ptr()->clone(),
+//			     image_sptr);
+
+  check(*proj_data.get_proj_data_info_sptr(), *_density_sptr);
+  shared_ptr<DataSymmetriesForViewSegmentNumbers>
+    symmetries_sptr(this->get_symmetries_used()->clone());
+
+  const std::vector<ViewSegmentNumbers> vs_nums_to_process =
+    detail::find_basic_vs_nums_in_subset(*proj_data.get_proj_data_info_ptr(), *symmetries_sptr,
+                                         proj_data.get_min_segment_num(), proj_data.get_max_segment_num(),
+                                         0, 1/*subset_num, num_subsets*/);
+#ifdef STIR_OPENMP
+#pragma omp parallel for  shared(proj_data, _density_sptr, symmetries_sptr) schedule(runtime)
+#endif
+    // note: older versions of openmp need an int as loop
+  for (int i=0; i<static_cast<int>(vs_nums_to_process.size()); ++i)
+    {
+      const ViewSegmentNumbers vs=vs_nums_to_process[i];
+
+      info(boost::format("Processing view %1% of segment %2%") % vs.view_num() % vs.segment_num());
+
+      RelatedViewgrams<float> viewgrams =
+        proj_data.get_empty_related_viewgrams(vs, symmetries_sptr);
+      forward_project(viewgrams);
+#ifdef STIR_OPENMP
+#pragma omp critical (FORWARDPROJ_SETVIEWGRAMS)
+#endif
+      {
+        if (!(proj_data.set_related_viewgrams(viewgrams) == Succeeded::yes))
+          error("Error set_related_viewgrams in forward projecting");
+      }
+    }
+
+}
+
+void
+ForwardProjectorByBin::forward_project(RelatedViewgrams<float>& viewgrams)
+{
+  forward_project(viewgrams,
+                  viewgrams.get_min_axial_pos_num(),
+          viewgrams.get_max_axial_pos_num(),
+          viewgrams.get_min_tangential_pos_num(),
+          viewgrams.get_max_tangential_pos_num());
+}
+
+void ForwardProjectorByBin::forward_project
+  (RelatedViewgrams<float>& viewgrams,
+   const int min_axial_pos_num,
+   const int max_axial_pos_num)
+{
+  forward_project(viewgrams,
+             min_axial_pos_num,
+         max_axial_pos_num,
+         viewgrams.get_min_tangential_pos_num(),
+         viewgrams.get_max_tangential_pos_num());
+}
+
+void
+ForwardProjectorByBin::
+forward_project(RelatedViewgrams<float>& viewgrams,
+             const int min_axial_pos_num, const int max_axial_pos_num,
+             const int min_tangential_pos_num, const int max_tangential_pos_num)
+{
+  if (viewgrams.get_num_viewgrams()==0)
+    return;
+  check(*viewgrams.get_proj_data_info_sptr(), *_density_sptr);
+  start_timers();
+
+  // first check symmetries
+  {
+    const ViewSegmentNumbers basic_vs = viewgrams.get_basic_view_segment_num();
+
+    if (get_symmetries_used()->num_related_view_segment_numbers(basic_vs) !=
+      viewgrams.get_num_viewgrams())
+      error("ForwardProjectByBin: forward_project called with incorrect related_viewgrams. Problem with symmetries!\n");
+
+    for (RelatedViewgrams<float>::const_iterator iter = viewgrams.begin();
+     iter != viewgrams.end();
+     ++iter)
+      {
+    ViewSegmentNumbers vs(iter->get_view_num(), iter->get_segment_num());
+    get_symmetries_used()->find_basic_view_segment_numbers(vs);
+    if (vs != basic_vs)
+      error("ForwardProjectByBin: forward_project called with incorrect related_viewgrams. Problem with symmetries!\n");
+    }
+  }
+  actual_forward_project(viewgrams,
+             min_axial_pos_num,
+         max_axial_pos_num,
+         min_tangential_pos_num,
+         max_tangential_pos_num);
+  stop_timers();
+}
+
+void
+ForwardProjectorByBin::
+actual_forward_project(RelatedViewgrams<float>& viewgrams,
+        const int min_axial_pos_num, const int max_axial_pos_num,
+        const int min_tangential_pos_num, const int max_tangential_pos_num)
+{
+    actual_forward_project(viewgrams,*_density_sptr,
+                           min_axial_pos_num, max_axial_pos_num,
+                           min_tangential_pos_num, max_tangential_pos_num);
+}
+
+
+void
+ForwardProjectorByBin::
+set_input(const shared_ptr<DiscretisedDensity<3,float> >& density_sptr)
+{
+    _density_sptr.reset(density_sptr->clone());
+}
+
+void
+ForwardProjectorByBin::
+set_input(const DiscretisedDensity<3,float> *density_ptr)
+{
+    shared_ptr<DiscretisedDensity<3,float> > density_sptr;
+    density_sptr.reset(density_ptr->clone());
+    this->set_input(density_sptr);
+}
 
 END_NAMESPACE_STIR

--- a/src/recon_buildblock/ForwardProjectorByBin.cxx
+++ b/src/recon_buildblock/ForwardProjectorByBin.cxx
@@ -84,60 +84,16 @@ ForwardProjectorByBin::forward_project(ProjData& proj_data,
 				       const DiscretisedDensity<3,float>& image,
 							 int subset_num, int num_subsets, bool zero)
 {
-  if (image.get_exam_info().imaging_modality.is_unknown()
-      || proj_data.get_exam_info().imaging_modality.is_unknown())
-    warning("forward_project. Imaging modality unknown for either the image or the projection data or both.\n"
-            "Going ahead anyway.");
-  else if (image.get_exam_info().imaging_modality !=
-      proj_data.get_exam_info().imaging_modality)
-    error("forward_project: Imaging modality should be the same for the image and the projection data");
-  if (subset_num < 0)
-    error(boost::format("forward_project: wrong subset number %1%") % subset_num);
-  if (subset_num > num_subsets - 1)
-    error(boost::format("forward_project: wrong subset number %1% (must be less than the number of subsets %2%)") 
-          % subset_num % num_subsets);
-  if (zero && num_subsets > 1)
-    proj_data.fill(0.0);
-  // this->set_up(proj_data_ptr->get_proj_data_info_ptr()->clone(),
-//			     image_sptr);
-
-  check(*proj_data.get_proj_data_info_sptr(), image);
-  shared_ptr<DataSymmetriesForViewSegmentNumbers> 
-    symmetries_sptr(this->get_symmetries_used()->clone());
-  
-  const std::vector<ViewSegmentNumbers> vs_nums_to_process = 
-    detail::find_basic_vs_nums_in_subset(*proj_data.get_proj_data_info_ptr(), *symmetries_sptr,
-                                         proj_data.get_min_segment_num(), proj_data.get_max_segment_num(),
-                                         subset_num, num_subsets);
-#ifdef STIR_OPENMP
-#pragma omp parallel for  shared(proj_data, image, symmetries_sptr) schedule(runtime)  
-#endif
-    // note: older versions of openmp need an int as loop
-  for (int i=0; i<static_cast<int>(vs_nums_to_process.size()); ++i)
-    {
-      const ViewSegmentNumbers vs=vs_nums_to_process[i];
-
-      info(boost::format("Processing view %1% of segment %2%") % vs.view_num() % vs.segment_num());
-      
-      RelatedViewgrams<float> viewgrams = 
-        proj_data.get_empty_related_viewgrams(vs, symmetries_sptr);
-      forward_project(viewgrams, image);	  
-#ifdef STIR_OPENMP
-#pragma omp critical (FORWARDPROJ_SETVIEWGRAMS)
-#endif
-      {
-        if (!(proj_data.set_related_viewgrams(viewgrams) == Succeeded::yes))
-          error("Error set_related_viewgrams in forward projecting");
-      }
-    }   
-  
+  set_input(&image);
+  forward_project(proj_data,subset_num, num_subsets, zero);
 }
 
 void 
 ForwardProjectorByBin::forward_project(RelatedViewgrams<float>& viewgrams, 
 				 const DiscretisedDensity<3,float>& image)
 {
-  forward_project(viewgrams, image,
+  set_input(&image);
+  forward_project(viewgrams,
                   viewgrams.get_min_axial_pos_num(),
 		  viewgrams.get_max_axial_pos_num(),
 		  viewgrams.get_min_tangential_pos_num(),
@@ -150,7 +106,8 @@ void ForwardProjectorByBin::forward_project
    const int min_axial_pos_num, 
    const int max_axial_pos_num)
 {
-  forward_project(viewgrams, image,
+  set_input(&image);
+  forward_project(viewgrams,
              min_axial_pos_num,
 	     max_axial_pos_num,
 	     viewgrams.get_min_tangential_pos_num(),
@@ -164,43 +121,34 @@ forward_project(RelatedViewgrams<float>& viewgrams,
 		     const int min_axial_pos_num, const int max_axial_pos_num,
 		     const int min_tangential_pos_num, const int max_tangential_pos_num)
 {
-  if (viewgrams.get_num_viewgrams()==0)
-    return;
-  check(*viewgrams.get_proj_data_info_sptr(), density);
-  start_timers();
-
-  // first check symmetries    
-  {
-    const ViewSegmentNumbers basic_vs = viewgrams.get_basic_view_segment_num();
-        
-    if (get_symmetries_used()->num_related_view_segment_numbers(basic_vs) !=
-      viewgrams.get_num_viewgrams())
-      error("ForwardProjectByBin: forward_project called with incorrect related_viewgrams. Problem with symmetries!\n");
-    
-    for (RelatedViewgrams<float>::const_iterator iter = viewgrams.begin();
-	 iter != viewgrams.end();
-	 ++iter)
-      {
-	ViewSegmentNumbers vs(iter->get_view_num(), iter->get_segment_num());
-	get_symmetries_used()->find_basic_view_segment_numbers(vs);
-	if (vs != basic_vs)
-	  error("ForwardProjectByBin: forward_project called with incorrect related_viewgrams. Problem with symmetries!\n");
-    }
-  }
-  actual_forward_project(viewgrams, density,
+  set_input(&density);
+  forward_project(viewgrams,
              min_axial_pos_num,
-	     max_axial_pos_num,
-	     min_tangential_pos_num,
-	     max_tangential_pos_num);
-  stop_timers();
+         max_axial_pos_num,
+         min_tangential_pos_num,
+         max_tangential_pos_num);
 }
 // -------------------------------------------------------------------------------------------------------------------- //
-// The following are repition of above, where the DiscretisedDensity has already been set with set_input()
+// The following are repetition of above, where the DiscretisedDensity has already been set with set_input()
 // -------------------------------------------------------------------------------------------------------------------- //
 void
-ForwardProjectorByBin::forward_project(ProjData& proj_data)
+ForwardProjectorByBin::forward_project(ProjData& proj_data,
+                                       int subset_num, int num_subsets, bool zero)
 {
-
+    if (_density_sptr->get_exam_info().imaging_modality.is_unknown()
+        || proj_data.get_exam_info().imaging_modality.is_unknown())
+      warning("forward_project. Imaging modality unknown for either the image or the projection data or both.\n"
+              "Going ahead anyway.");
+    else if (_density_sptr->get_exam_info().imaging_modality !=
+        proj_data.get_exam_info().imaging_modality)
+      error("forward_project: Imaging modality should be the same for the image and the projection data");
+    if (subset_num < 0)
+      error(boost::format("forward_project: wrong subset number %1%") % subset_num);
+    if (subset_num > num_subsets - 1)
+      error(boost::format("forward_project: wrong subset number %1% (must be less than the number of subsets %2%)")
+            % subset_num % num_subsets);
+    if (zero && num_subsets > 1)
+      proj_data.fill(0.0);
  // this->set_up(proj_data_ptr->get_proj_data_info_ptr()->clone(),
 //			     image_sptr);
 
@@ -211,7 +159,7 @@ ForwardProjectorByBin::forward_project(ProjData& proj_data)
   const std::vector<ViewSegmentNumbers> vs_nums_to_process =
     detail::find_basic_vs_nums_in_subset(*proj_data.get_proj_data_info_ptr(), *symmetries_sptr,
                                          proj_data.get_min_segment_num(), proj_data.get_max_segment_num(),
-                                         0, 1/*subset_num, num_subsets*/);
+                                         subset_num, num_subsets);
 #ifdef STIR_OPENMP
 #pragma omp parallel for  shared(proj_data, _density_sptr, symmetries_sptr) schedule(runtime)
 #endif

--- a/src/recon_buildblock/ForwardProjectorByBin.cxx
+++ b/src/recon_buildblock/ForwardProjectorByBin.cxx
@@ -77,56 +77,122 @@ check(const ProjDataInfo& proj_data_info, const DiscretisedDensity<3,float>& den
           % this->_proj_data_info_sptr->parameter_info() % proj_data_info.parameter_info());
   if (! this->_density_sptr->has_same_characteristics(density_info))
     error("ForwardProjectorByBin set-up with different geometry for density or volume data.");
-}  
-
-void 
-ForwardProjectorByBin::forward_project(ProjData& proj_data, 
-				       const DiscretisedDensity<3,float>& image,
-							 int subset_num, int num_subsets, bool zero)
-{
-  set_input(&image);
-  forward_project(proj_data,subset_num, num_subsets, zero);
 }
 
-void 
-ForwardProjectorByBin::forward_project(RelatedViewgrams<float>& viewgrams, 
-				 const DiscretisedDensity<3,float>& image)
+void
+ForwardProjectorByBin::forward_project(ProjData& proj_data,
+                       const DiscretisedDensity<3,float>& image,
+                             int subset_num, int num_subsets, bool zero)
 {
-  set_input(&image);
-  forward_project(viewgrams,
+  if (image.get_exam_info().imaging_modality.is_unknown()
+      || proj_data.get_exam_info().imaging_modality.is_unknown())
+    warning("forward_project. Imaging modality unknown for either the image or the projection data or both.\n"
+            "Going ahead anyway.");
+  else if (image.get_exam_info().imaging_modality !=
+      proj_data.get_exam_info().imaging_modality)
+    error("forward_project: Imaging modality should be the same for the image and the projection data");
+  if (subset_num < 0)
+    error(boost::format("forward_project: wrong subset number %1%") % subset_num);
+  if (subset_num > num_subsets - 1)
+    error(boost::format("forward_project: wrong subset number %1% (must be less than the number of subsets %2%)")
+          % subset_num % num_subsets);
+  if (zero && num_subsets > 1)
+    proj_data.fill(0.0);
+  // this->set_up(proj_data_ptr->get_proj_data_info_ptr()->clone(),
+//			     image_sptr);
+
+  check(*proj_data.get_proj_data_info_sptr(), image);
+  shared_ptr<DataSymmetriesForViewSegmentNumbers>
+    symmetries_sptr(this->get_symmetries_used()->clone());
+
+  const std::vector<ViewSegmentNumbers> vs_nums_to_process =
+    detail::find_basic_vs_nums_in_subset(*proj_data.get_proj_data_info_ptr(), *symmetries_sptr,
+                                         proj_data.get_min_segment_num(), proj_data.get_max_segment_num(),
+                                         subset_num, num_subsets);
+#ifdef STIR_OPENMP
+#pragma omp parallel for  shared(proj_data, image, symmetries_sptr) schedule(runtime)
+#endif
+    // note: older versions of openmp need an int as loop
+  for (int i=0; i<static_cast<int>(vs_nums_to_process.size()); ++i)
+    {
+      const ViewSegmentNumbers vs=vs_nums_to_process[i];
+
+      info(boost::format("Processing view %1% of segment %2%") % vs.view_num() % vs.segment_num());
+
+      RelatedViewgrams<float> viewgrams =
+        proj_data.get_empty_related_viewgrams(vs, symmetries_sptr);
+      forward_project(viewgrams, image);
+#ifdef STIR_OPENMP
+#pragma omp critical (FORWARDPROJ_SETVIEWGRAMS)
+#endif
+      {
+        if (!(proj_data.set_related_viewgrams(viewgrams) == Succeeded::yes))
+          error("Error set_related_viewgrams in forward projecting");
+      }
+    }
+
+}
+
+void
+ForwardProjectorByBin::forward_project(RelatedViewgrams<float>& viewgrams,
+                 const DiscretisedDensity<3,float>& image)
+{
+  forward_project(viewgrams, image,
                   viewgrams.get_min_axial_pos_num(),
-		  viewgrams.get_max_axial_pos_num(),
-		  viewgrams.get_min_tangential_pos_num(),
-		  viewgrams.get_max_tangential_pos_num());
+          viewgrams.get_max_axial_pos_num(),
+          viewgrams.get_min_tangential_pos_num(),
+          viewgrams.get_max_tangential_pos_num());
 }
 
 void ForwardProjectorByBin::forward_project
-  (RelatedViewgrams<float>& viewgrams, 
+  (RelatedViewgrams<float>& viewgrams,
    const DiscretisedDensity<3,float>& image,
-   const int min_axial_pos_num, 
+   const int min_axial_pos_num,
    const int max_axial_pos_num)
 {
-  set_input(&image);
-  forward_project(viewgrams,
+  forward_project(viewgrams, image,
              min_axial_pos_num,
-	     max_axial_pos_num,
-	     viewgrams.get_min_tangential_pos_num(),
-	     viewgrams.get_max_tangential_pos_num());
+         max_axial_pos_num,
+         viewgrams.get_min_tangential_pos_num(),
+         viewgrams.get_max_tangential_pos_num());
 }
 
-void 
+void
 ForwardProjectorByBin::
-forward_project(RelatedViewgrams<float>& viewgrams, 
-		     const DiscretisedDensity<3,float>& density,
-		     const int min_axial_pos_num, const int max_axial_pos_num,
-		     const int min_tangential_pos_num, const int max_tangential_pos_num)
+forward_project(RelatedViewgrams<float>& viewgrams,
+             const DiscretisedDensity<3,float>& density,
+             const int min_axial_pos_num, const int max_axial_pos_num,
+             const int min_tangential_pos_num, const int max_tangential_pos_num)
 {
-  set_input(&density);
-  forward_project(viewgrams,
+  if (viewgrams.get_num_viewgrams()==0)
+    return;
+  check(*viewgrams.get_proj_data_info_sptr(), density);
+  start_timers();
+
+  // first check symmetries
+  {
+    const ViewSegmentNumbers basic_vs = viewgrams.get_basic_view_segment_num();
+
+    if (get_symmetries_used()->num_related_view_segment_numbers(basic_vs) !=
+      viewgrams.get_num_viewgrams())
+      error("ForwardProjectByBin: forward_project called with incorrect related_viewgrams. Problem with symmetries!\n");
+
+    for (RelatedViewgrams<float>::const_iterator iter = viewgrams.begin();
+     iter != viewgrams.end();
+     ++iter)
+      {
+    ViewSegmentNumbers vs(iter->get_view_num(), iter->get_segment_num());
+    get_symmetries_used()->find_basic_view_segment_numbers(vs);
+    if (vs != basic_vs)
+      error("ForwardProjectByBin: forward_project called with incorrect related_viewgrams. Problem with symmetries!\n");
+    }
+  }
+  actual_forward_project(viewgrams, density,
              min_axial_pos_num,
          max_axial_pos_num,
          min_tangential_pos_num,
          max_tangential_pos_num);
+  stop_timers();
 }
 // -------------------------------------------------------------------------------------------------------------------- //
 // The following are repetition of above, where the DiscretisedDensity has already been set with set_input()
@@ -161,7 +227,7 @@ ForwardProjectorByBin::forward_project(ProjData& proj_data,
                                          proj_data.get_min_segment_num(), proj_data.get_max_segment_num(),
                                          subset_num, num_subsets);
 #ifdef STIR_OPENMP
-#pragma omp parallel for  shared(proj_data, _density_sptr, symmetries_sptr) schedule(runtime)
+#pragma omp parallel for  shared(proj_data, symmetries_sptr) schedule(runtime)
 #endif
     // note: older versions of openmp need an int as loop
   for (int i=0; i<static_cast<int>(vs_nums_to_process.size()); ++i)
@@ -257,18 +323,9 @@ actual_forward_project(RelatedViewgrams<float>& viewgrams,
 
 void
 ForwardProjectorByBin::
-set_input(const shared_ptr<DiscretisedDensity<3,float> >& density_sptr)
+set_input(const DiscretisedDensity<3,float> & density)
 {
-    _density_sptr.reset(density_sptr->clone());
-}
-
-void
-ForwardProjectorByBin::
-set_input(const DiscretisedDensity<3,float> *density_ptr)
-{
-    shared_ptr<DiscretisedDensity<3,float> > density_sptr;
-    density_sptr.reset(density_ptr->clone());
-    this->set_input(density_sptr);
+    _density_sptr.reset(density.clone());
 }
 
 END_NAMESPACE_STIR

--- a/src/recon_buildblock/ForwardProjectorByBin.cxx
+++ b/src/recon_buildblock/ForwardProjectorByBin.cxx
@@ -9,6 +9,7 @@
 
   \author Kris Thielemans
   \author PARAPET project
+  \author Richard Brown
 
 
 */
@@ -16,7 +17,7 @@
     Copyright (C) 2000 PARAPET partners
     Copyright (C) 2000-2011 Hammersmith Imanet Ltd
     Copyright (C) 2013 Kris Thielemans
-    Copyright (C) 2015, 2018, University College London
+    Copyright (C) 2015, 2018-2019, University College London
     This file is part of STIR.
 
     This file is free software; you can redistribute it and/or modify

--- a/src/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMeanAndListModeDataWithProjMatrixByBin.cxx
+++ b/src/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMeanAndListModeDataWithProjMatrixByBin.cxx
@@ -345,7 +345,7 @@ add_subset_sensitivity(TargetT& sensitivity, const int subset_num) const
     const int max_segment_num = proj_data_info_sptr->get_max_segment_num();
 
     this->projector_pair_sptr->get_back_projector_sptr()->
-      reset_output();
+      start_accumulating_in_new_target();
 
     // warning: has to be same as subset scheme used as in distributable_computation
     for (int segment_num = min_segment_num; segment_num <= max_segment_num; ++segment_num)

--- a/src/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMeanAndListModeDataWithProjMatrixByBin.cxx
+++ b/src/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMeanAndListModeDataWithProjMatrixByBin.cxx
@@ -344,6 +344,9 @@ add_subset_sensitivity(TargetT& sensitivity, const int subset_num) const
     const int min_segment_num = proj_data_info_sptr->get_min_segment_num();
     const int max_segment_num = proj_data_info_sptr->get_max_segment_num();
 
+    this->projector_pair_sptr->get_back_projector_sptr()->
+      start_accumulating_in_new_image();
+
     // warning: has to be same as subset scheme used as in distributable_computation
     for (int segment_num = min_segment_num; segment_num <= max_segment_num; ++segment_num)
     {
@@ -355,15 +358,17 @@ add_subset_sensitivity(TargetT& sensitivity, const int subset_num) const
 
         if (! this->projector_pair_sptr->get_symmetries_used()->is_basic(view_segment_num))
           continue;
-        this->add_view_seg_to_sensitivity(sensitivity, view_segment_num);
+        this->add_view_seg_to_sensitivity(view_segment_num);
       }
     }
+    this->projector_pair_sptr->get_back_projector_sptr()->
+      get_output(sensitivity);
 }
 
 template<typename TargetT>
 void
 PoissonLogLikelihoodWithLinearModelForMeanAndListModeDataWithProjMatrixByBin<TargetT>::
-add_view_seg_to_sensitivity(TargetT& sensitivity, const ViewSegmentNumbers& view_seg_nums) const
+add_view_seg_to_sensitivity(const ViewSegmentNumbers& view_seg_nums) const
 {
     shared_ptr<DataSymmetriesForViewSegmentNumbers> symmetries_used
             (this->projector_pair_sptr->get_symmetries_used()->clone());
@@ -386,7 +391,7 @@ add_view_seg_to_sensitivity(TargetT& sensitivity, const ViewSegmentNumbers& view
        viewgrams.get_max_axial_pos_num();
 
     this->projector_pair_sptr->get_back_projector_sptr()->
-      back_project(sensitivity, viewgrams,
+      back_project(viewgrams,
                    min_ax_pos_num, max_ax_pos_num);
   }
 

--- a/src/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMeanAndListModeDataWithProjMatrixByBin.cxx
+++ b/src/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMeanAndListModeDataWithProjMatrixByBin.cxx
@@ -345,7 +345,7 @@ add_subset_sensitivity(TargetT& sensitivity, const int subset_num) const
     const int max_segment_num = proj_data_info_sptr->get_max_segment_num();
 
     this->projector_pair_sptr->get_back_projector_sptr()->
-      start_accumulating_in_new_image();
+      reset_output();
 
     // warning: has to be same as subset scheme used as in distributable_computation
     for (int segment_num = min_segment_num; segment_num <= max_segment_num; ++segment_num)

--- a/src/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMeanAndProjData.cxx
+++ b/src/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMeanAndProjData.cxx
@@ -832,7 +832,7 @@ actual_add_multiplication_with_approximate_sub_Hessian_without_penalty(TargetT& 
     this->get_time_frame_definitions().get_end_time(this->get_time_frame_num());
 
   this->get_projector_pair().get_forward_projector_sptr()->set_input(input);
-  this->get_projector_pair().get_back_projector_sptr()->reset_output();
+  this->get_projector_pair().get_back_projector_sptr()->start_accumulating_in_new_target();
 
   for (int segment_num = -this->get_max_segment_num_to_process();
        segment_num<= this->get_max_segment_num_to_process();

--- a/src/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMeanAndProjData.cxx
+++ b/src/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMeanAndProjData.cxx
@@ -1018,15 +1018,11 @@ void distributable_sensitivity_computation(
 void RPC_process_related_viewgrams_gradient(
                                             const shared_ptr<ForwardProjectorByBin>& forward_projector_sptr,
                                             const shared_ptr<BackProjectorByBin>& back_projector_sptr,
-                                            DiscretisedDensity<3,float>* output_image_ptr, 
-                                            const DiscretisedDensity<3,float>* input_image_ptr, 
                                             RelatedViewgrams<float>* measured_viewgrams_ptr,
                                             int& count, int& count2, double* log_likelihood_ptr /* = NULL */,
                                             const RelatedViewgrams<float>* additive_binwise_correction_ptr,
                                             const RelatedViewgrams<float>* mult_viewgrams_ptr)
 {       
-  assert(output_image_ptr != NULL);
-  assert(input_image_ptr != NULL);
   assert(measured_viewgrams_ptr != NULL);
   if (!is_null_ptr(mult_viewgrams_ptr))
     error("Internal error: mult_viewgrams_ptr should be zero when computing gradient");
@@ -1051,7 +1047,7 @@ void RPC_process_related_viewgrams_gradient(
                 }
     }
 */
-  forward_projector_sptr->forward_project(estimated_viewgrams, *input_image_ptr);
+  forward_projector_sptr->forward_project(estimated_viewgrams);
         
         
         
@@ -1069,29 +1065,24 @@ void RPC_process_related_viewgrams_gradient(
       
   divide_and_truncate(*measured_viewgrams_ptr, estimated_viewgrams, rim_truncation_sino, count, count2, log_likelihood_ptr);
       
-  back_projector_sptr->back_project(*output_image_ptr, *measured_viewgrams_ptr);
+  back_projector_sptr->back_project(*measured_viewgrams_ptr);
 };      
 
 
 void RPC_process_related_viewgrams_accumulate_loglikelihood(
                                                             const shared_ptr<ForwardProjectorByBin>& forward_projector_sptr,
                                                             const shared_ptr<BackProjectorByBin>& back_projector_sptr,
-                                                            DiscretisedDensity<3,float>* output_image_ptr,
-                                                            const DiscretisedDensity<3,float>* input_image_ptr, 
                                                             RelatedViewgrams<float>* measured_viewgrams_ptr,
                                                             int& count, int& count2, double* log_likelihood_ptr,
                                                             const RelatedViewgrams<float>* additive_binwise_correction_ptr,
                                                             const RelatedViewgrams<float>* mult_viewgrams_ptr)
 {
-
-  assert(output_image_ptr == NULL);
-  assert(input_image_ptr != NULL);
   assert(measured_viewgrams_ptr != NULL);
   assert(log_likelihood_ptr != NULL);
 
   RelatedViewgrams<float> estimated_viewgrams = measured_viewgrams_ptr->get_empty_copy();
 
-  forward_projector_sptr->forward_project(estimated_viewgrams, *input_image_ptr);
+  forward_projector_sptr->forward_project(estimated_viewgrams);
   
   if (additive_binwise_correction_ptr != NULL)
   {
@@ -1119,24 +1110,20 @@ void RPC_process_related_viewgrams_accumulate_loglikelihood(
 void RPC_process_related_viewgrams_sensitivity_computation(
                                                             const shared_ptr<ForwardProjectorByBin>& forward_projector_sptr,
                                                             const shared_ptr<BackProjectorByBin>& back_projector_sptr,
-                                                            DiscretisedDensity<3,float>* output_image_ptr,
-                                                            const DiscretisedDensity<3,float>* input_image_ptr,
                                                             RelatedViewgrams<float>* measured_viewgrams_ptr,
                                                             int& count, int& count2, double* log_likelihood_ptr,
                                                             const RelatedViewgrams<float>* additive_binwise_correction_ptr,
                                                             const RelatedViewgrams<float>* mult_viewgrams_ptr)
 {
-
-  assert(output_image_ptr != NULL);
   assert(measured_viewgrams_ptr != NULL);
 
   if( mult_viewgrams_ptr )
   {
-    back_projector_sptr->back_project(*output_image_ptr, *mult_viewgrams_ptr);
+    back_projector_sptr->back_project(*mult_viewgrams_ptr);
   }
   else
   {  
-    back_projector_sptr->back_project(*output_image_ptr, *measured_viewgrams_ptr);
+    back_projector_sptr->back_project(*measured_viewgrams_ptr);
   }
 
 }

--- a/src/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMeanAndProjData.cxx
+++ b/src/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMeanAndProjData.cxx
@@ -832,7 +832,7 @@ actual_add_multiplication_with_approximate_sub_Hessian_without_penalty(TargetT& 
     this->get_time_frame_definitions().get_end_time(this->get_time_frame_num());
 
   this->get_projector_pair().get_forward_projector_sptr()->set_input(input);
-  this->get_projector_pair().get_back_projector_sptr()->start_accumulating_in_new_image();
+  this->get_projector_pair().get_back_projector_sptr()->reset_output();
 
   for (int segment_num = -this->get_max_segment_num_to_process();
        segment_num<= this->get_max_segment_num_to_process();

--- a/src/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMeanAndProjData.cxx
+++ b/src/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMeanAndProjData.cxx
@@ -769,7 +769,7 @@ add_subset_sensitivity(TargetT& sensitivity, const int subset_num) const
 #endif
 }
 
-
+#if 0
 template<typename TargetT>
 void
 PoissonLogLikelihoodWithLinearModelForMeanAndProjData<TargetT>::
@@ -801,7 +801,7 @@ add_view_seg_to_sensitivity(TargetT& sensitivity, const ViewSegmentNumbers& view
   }
   
 }
-
+#endif
 
 template<typename TargetT>
 Succeeded
@@ -830,6 +830,9 @@ actual_add_multiplication_with_approximate_sub_Hessian_without_penalty(TargetT& 
     this->get_time_frame_definitions().get_start_time(this->get_time_frame_num());
   const double end_time =
     this->get_time_frame_definitions().get_end_time(this->get_time_frame_num());
+
+  this->get_projector_pair().get_forward_projector_sptr()->set_input(input);
+  this->get_projector_pair().get_back_projector_sptr()->start_accumulating_in_new_image();
 
   for (int segment_num = -this->get_max_segment_num_to_process();
        segment_num<= this->get_max_segment_num_to_process();
@@ -860,7 +863,7 @@ actual_add_multiplication_with_approximate_sub_Hessian_without_penalty(TargetT& 
           {
             tmp_viewgrams = this->get_proj_data().get_empty_related_viewgrams(view_segment_num, symmetries_sptr);
             this->get_projector_pair().get_forward_projector_sptr()->
-              forward_project(tmp_viewgrams, input);
+              forward_project(tmp_viewgrams);
           }
           
           // now divide by the data term
@@ -871,10 +874,12 @@ actual_add_multiplication_with_approximate_sub_Hessian_without_penalty(TargetT& 
 
           // back-project
           this->get_projector_pair().get_back_projector_sptr()->
-            back_project(output, tmp_viewgrams);
+            back_project(tmp_viewgrams);
       }
 
   } // end of loop over segments
+
+  this->get_projector_pair().get_back_projector_sptr()->get_output(output);
 
   return Succeeded::yes;
 }

--- a/src/recon_buildblock/PostsmoothingBackProjectorByBin.cxx
+++ b/src/recon_buildblock/PostsmoothingBackProjectorByBin.cxx
@@ -100,7 +100,7 @@ get_symmetries_used() const
 {
   return original_back_projector_ptr->get_symmetries_used();
 }
-
+#ifdef STIR_PROJECTORS_AS_V3
 void 
 PostsmoothingBackProjectorByBin::
 actual_back_project(DiscretisedDensity<3,float>& density,
@@ -126,14 +126,14 @@ actual_back_project(DiscretisedDensity<3,float>& density,
                                                 min_tangential_pos_num, max_tangential_pos_num);
     }
 }
- 
+#endif
 void
 PostsmoothingBackProjectorByBin::
 actual_back_project(const RelatedViewgrams<float>& viewgrams,
                     const int min_axial_pos_num, const int max_axial_pos_num,
                     const int min_tangential_pos_num, const int max_tangential_pos_num)
 {
-      original_back_projector_ptr->back_project(*_density_sptr, viewgrams,
+      original_back_projector_ptr->back_project(viewgrams,
                                                 min_axial_pos_num, max_axial_pos_num,
                                                 min_tangential_pos_num, max_tangential_pos_num);
 }

--- a/src/recon_buildblock/PostsmoothingBackProjectorByBin.cxx
+++ b/src/recon_buildblock/PostsmoothingBackProjectorByBin.cxx
@@ -90,9 +90,8 @@ set_up(const shared_ptr<ProjDataInfo>& proj_data_info_ptr,
 {
   BackProjectorByBin::set_up(proj_data_info_ptr, image_info_ptr);
   original_back_projector_ptr->set_up(proj_data_info_ptr, image_info_ptr);
-  // don't do set_up as image sizes might change
-  //if (!is_null_ptr(image_processor_ptr))
-  //   image_processor_ptr->set_up(*image_info_ptr);
+  if (!is_null_ptr(image_processor_ptr))
+     image_processor_ptr->set_up(*image_info_ptr);
 }
 
 const DataSymmetriesForViewSegmentNumbers * 
@@ -128,6 +127,25 @@ actual_back_project(DiscretisedDensity<3,float>& density,
     }
 }
  
+void
+PostsmoothingBackProjectorByBin::
+actual_back_project(const RelatedViewgrams<float>& viewgrams,
+                    const int min_axial_pos_num, const int max_axial_pos_num,
+                    const int min_tangential_pos_num, const int max_tangential_pos_num)
+{
+      original_back_projector_ptr->back_project(*_density_sptr, viewgrams,
+                                                min_axial_pos_num, max_axial_pos_num,
+                                                min_tangential_pos_num, max_tangential_pos_num);
+}
+
+void
+PostsmoothingBackProjectorByBin::
+get_output(DiscretisedDensity<3,float> &density) const
+{
+    BackProjectorByBin::get_output(density);
+    if (!is_null_ptr(image_processor_ptr))
+        image_processor_ptr->apply(density);
+}
 
 
 END_NAMESPACE_STIR

--- a/src/recon_buildblock/PostsmoothingBackProjectorByBin.cxx
+++ b/src/recon_buildblock/PostsmoothingBackProjectorByBin.cxx
@@ -4,10 +4,12 @@
   \brief Implementation of class stir::PostsmoothingBackProjectorByBin
 
   \author Kris Thielemans
+  \author Richard Brown
 
 */
 /*
     Copyright (C) 2000- 2012, Hammersmith Imanet
+    Copyright (C) 2019, University College London
 
     This file is part of STIR.
 

--- a/src/recon_buildblock/PresmoothingForwardProjectorByBin.cxx
+++ b/src/recon_buildblock/PresmoothingForwardProjectorByBin.cxx
@@ -5,10 +5,12 @@
   \brief Implementation of class stir::PresmoothingForwardProjectorByBin
 
   \author Kris Thielemans
+  \author Richard Brown
 
 */
 /*
     Copyright (C) 2000- 2012, Hammersmith Imanet
+    Copyright (C) 2019, University College London
 
     This file is part of STIR.
 

--- a/src/recon_buildblock/PresmoothingForwardProjectorByBin.cxx
+++ b/src/recon_buildblock/PresmoothingForwardProjectorByBin.cxx
@@ -126,6 +126,26 @@ actual_forward_project(RelatedViewgrams<float>& viewgrams,
     }
 }
  
+void
+PresmoothingForwardProjectorByBin::
+actual_forward_project(RelatedViewgrams<float>& viewgrams,
+                  const int min_axial_pos_num, const int max_axial_pos_num,
+                  const int min_tangential_pos_num, const int max_tangential_pos_num)
+{
+    // No need to do the data processing since it was already done on set_input()
+    original_forward_projector_ptr->forward_project(viewgrams,*_density_sptr,
+                                                      min_axial_pos_num, max_axial_pos_num,
+                                                      min_tangential_pos_num, max_tangential_pos_num);
+}
+
+void
+PresmoothingForwardProjectorByBin::
+set_input(const shared_ptr<DiscretisedDensity<3,float> >& density_sptr)
+{
+    _density_sptr.reset(density_sptr->clone());
+    if (!is_null_ptr(image_processor_ptr))
+        image_processor_ptr->apply(*_density_sptr,*density_sptr);
+}
 
 
 END_NAMESPACE_STIR

--- a/src/recon_buildblock/PresmoothingForwardProjectorByBin.cxx
+++ b/src/recon_buildblock/PresmoothingForwardProjectorByBin.cxx
@@ -101,7 +101,7 @@ get_symmetries_used() const
 {
   return original_forward_projector_ptr->get_symmetries_used();
 }
-
+#ifdef STIR_PROJECTORS_AS_V3
 void 
 PresmoothingForwardProjectorByBin::
 actual_forward_project(RelatedViewgrams<float>& viewgrams, 
@@ -125,7 +125,7 @@ actual_forward_project(RelatedViewgrams<float>& viewgrams,
                                                       min_tangential_pos_num, max_tangential_pos_num);
     }
 }
- 
+#endif
 void
 PresmoothingForwardProjectorByBin::
 actual_forward_project(RelatedViewgrams<float>& viewgrams,
@@ -133,7 +133,7 @@ actual_forward_project(RelatedViewgrams<float>& viewgrams,
                   const int min_tangential_pos_num, const int max_tangential_pos_num)
 {
     // No need to do the data processing since it was already done on set_input()
-    original_forward_projector_ptr->forward_project(viewgrams,*_density_sptr,
+    original_forward_projector_ptr->forward_project(viewgrams,
                                                       min_axial_pos_num, max_axial_pos_num,
                                                       min_tangential_pos_num, max_tangential_pos_num);
 }

--- a/src/recon_buildblock/distributable.cxx
+++ b/src/recon_buildblock/distributable.cxx
@@ -472,7 +472,6 @@ void distributable_computation(
             }
 #else // STIR_MPI
 
-#ifndef NDEBUG
 #ifdef STIR_OPENMP
           const int thread_num=omp_get_thread_num();
           info(boost::format("Thread %d/%d calculating segment_num: %d, view_num: %d")
@@ -481,7 +480,6 @@ void distributable_computation(
 #else
           info(boost::format("calculating segment_num: %d, view_num: %d")
                % view_segment_num.segment_num() % view_segment_num.view_num());
-#endif
 #endif
 
 #ifdef STIR_OPENMP
@@ -493,7 +491,7 @@ void distributable_computation(
             
           RPC_process_related_viewgrams(forward_projector_ptr,
                                         back_projector_ptr,
-                                        local_output_image_sptrs[thread_num].get(), input_image_ptr, y.get(), 
+                                        y.get(),
                                         local_counts[thread_num], local_count2s[thread_num], 
                                         is_null_ptr(log_likelihood_ptr)? NULL : &local_log_likelihoods[thread_num], 
                                         additive_binwise_correction_viewgrams.get(),

--- a/src/recon_buildblock/distributable.cxx
+++ b/src/recon_buildblock/distributable.cxx
@@ -410,7 +410,7 @@ void distributable_computation(
   //double total_seq_rpc_time=0.0; //sums up times used for RPC_process_related_viewgrams
 
   forward_projector_ptr->set_input(*input_image_ptr);
-  back_projector_ptr->reset_output();
+  back_projector_ptr->start_accumulating_in_new_target();
 
 #ifdef STIR_OPENMP
   std::vector<double> local_log_likelihoods;

--- a/src/recon_buildblock/distributable.cxx
+++ b/src/recon_buildblock/distributable.cxx
@@ -410,7 +410,7 @@ void distributable_computation(
   //double total_seq_rpc_time=0.0; //sums up times used for RPC_process_related_viewgrams
 
   forward_projector_ptr->set_input(*input_image_ptr);
-  back_projector_ptr->start_accumulating_in_new_image();
+  back_projector_ptr->reset_output();
 
 #ifdef STIR_OPENMP
   std::vector<double> local_log_likelihoods;

--- a/src/recon_test/bcktest.cxx
+++ b/src/recon_test/bcktest.cxx
@@ -102,6 +102,8 @@ do_segments(DiscretisedDensity<3,float>& image,
   
   list<ViewSegmentNumbers> already_processed;
   
+  back_projector_ptr->start_accumulating_in_new_image();
+
   for (int segment_num = start_segment_num; segment_num <= end_segment_num; ++segment_num)
     for (int view= start_view; view<=end_view; view++)
   { 
@@ -137,7 +139,7 @@ do_segments(DiscretisedDensity<3,float>& image,
 	r_viewgrams_iter++;	  
       } 
       
-      back_projector_ptr->back_project(image,viewgrams_empty,
+      back_projector_ptr->back_project(viewgrams_empty,
 				       std::max(start_axial_pos_num, viewgrams_empty.get_min_axial_pos_num()), 
 				       std::min(end_axial_pos_num, viewgrams_empty.get_max_axial_pos_num()),
 				       start_tang_pos_num, end_tang_pos_num);
@@ -170,12 +172,14 @@ do_segments(DiscretisedDensity<3,float>& image,
 	++r_viewgrams_iter;
       }
 	
-      back_projector_ptr->back_project(image,viewgrams,
+      back_projector_ptr->back_project(viewgrams,
 				       std::max(start_axial_pos_num, viewgrams.get_min_axial_pos_num()), 
 				       std::min(end_axial_pos_num, viewgrams.get_max_axial_pos_num()),
 				       start_tang_pos_num, end_tang_pos_num);      
     } // fill
   } // for view_num, segment_num    
+    
+  back_projector_ptr->get_output(image);
     
 }
 

--- a/src/recon_test/bcktest.cxx
+++ b/src/recon_test/bcktest.cxx
@@ -102,7 +102,7 @@ do_segments(DiscretisedDensity<3,float>& image,
   
   list<ViewSegmentNumbers> already_processed;
   
-  back_projector_ptr->reset_output();
+  back_projector_ptr->start_accumulating_in_new_target();
 
   for (int segment_num = start_segment_num; segment_num <= end_segment_num; ++segment_num)
     for (int view= start_view; view<=end_view; view++)

--- a/src/recon_test/bcktest.cxx
+++ b/src/recon_test/bcktest.cxx
@@ -102,7 +102,7 @@ do_segments(DiscretisedDensity<3,float>& image,
   
   list<ViewSegmentNumbers> already_processed;
   
-  back_projector_ptr->start_accumulating_in_new_image();
+  back_projector_ptr->reset_output();
 
   for (int segment_num = start_segment_num; segment_num <= end_segment_num; ++segment_num)
     for (int view= start_view; view<=end_view; view++)

--- a/src/recon_test/fwdtest.cxx
+++ b/src/recon_test/fwdtest.cxx
@@ -337,6 +337,8 @@ do_segments(const VoxelsOnCartesianGrid<float>& image,
   
   std::list<ViewSegmentNumbers> already_processed;
   
+  forw_projector.set_input(image);
+
   for (int segment_num = start_segment_num; segment_num <= end_segment_num; ++segment_num)
     for (int view= start_view; view<=end_view; view++)      
     {       
@@ -354,7 +356,7 @@ do_segments(const VoxelsOnCartesianGrid<float>& image,
       
       RelatedViewgrams<float> viewgrams = 
         proj_data.get_empty_related_viewgrams(vs, symmetries_sptr,false);
-      forw_projector.forward_project(viewgrams, image,
+      forw_projector.forward_project(viewgrams,
         viewgrams.get_min_axial_pos_num(),
         viewgrams.get_max_axial_pos_num(),
         start_tangential_pos_num, end_tangential_pos_num);	  

--- a/src/utilities/back_project.cxx
+++ b/src/utilities/back_project.cxx
@@ -104,13 +104,17 @@ main (int argc, char * argv[])
       back_projector_sptr.reset(new BackProjectorByBinUsingProjMatrixByBin(PM)); 
     }
 
+  image_density_sptr->fill(0.F);
   back_projector_sptr->set_up(proj_data_sptr->get_proj_data_info_ptr()->create_shared_clone(),
 			      image_density_sptr );
 
-  image_density_sptr->fill(0.F);
-  
+#if 0
   back_projector_sptr->back_project(*image_density_sptr, *proj_data_sptr);
-  
+#else
+  back_projector_sptr->start_accumulating_in_new_image();
+  back_projector_sptr->back_project(*proj_data_sptr);
+  back_projector_sptr->get_output(*image_density_sptr);
+#endif
   OutputFileFormat<DiscretisedDensity<3,float> >::default_sptr()->
     write_to_file(output_filename, *image_density_sptr);
 

--- a/src/utilities/back_project.cxx
+++ b/src/utilities/back_project.cxx
@@ -111,7 +111,7 @@ main (int argc, char * argv[])
 #if 0
   back_projector_sptr->back_project(*image_density_sptr, *proj_data_sptr);
 #else
-  back_projector_sptr->start_accumulating_in_new_image();
+  back_projector_sptr->reset_output();
   back_projector_sptr->back_project(*proj_data_sptr);
   back_projector_sptr->get_output(*image_density_sptr);
 #endif

--- a/src/utilities/back_project.cxx
+++ b/src/utilities/back_project.cxx
@@ -111,7 +111,7 @@ main (int argc, char * argv[])
 #if 0
   back_projector_sptr->back_project(*image_density_sptr, *proj_data_sptr);
 #else
-  back_projector_sptr->reset_output();
+  back_projector_sptr->start_accumulating_in_new_target();
   back_projector_sptr->back_project(*proj_data_sptr);
   back_projector_sptr->get_output(*image_density_sptr);
 #endif


### PR DESCRIPTION
This breaks the current multithreading in STIR (due to changes to distributable.cxx and DistributedWorker.cxx).