### PR TITLE
Object/ParsingObject/RegisteredObject hierarchy

### DIFF
--- a/documentation/release_3.1.htm
+++ b/documentation/release_3.1.htm
@@ -385,6 +385,18 @@ from the above):</H2>
   </li>
 <li> <code>ProjMatrixByBin</code> now uses <code>get_symmetries_sptr()</code> (replaces <code>get_symmetries_ptr()</code>).
   </li>
+<li> The inheritance between <code>Object</code>, <code>ParsingObject</code> and <code>RegisteredObject</code> have changed. Specifically:
+  <ul>
+    <li><code>Object</code> inherits from <code>ParsingObject</code>.</li>
+    <li><code>Object</code> no longer needs the <code>method parameter_info()</code>.</li>
+    <li>Classes that inherit from <code>RegisteredObject</code> no longer need to also 
+    	inherit from <code>ParsingObject</code>.</li>
+    <li>The class <code>AddParser</code> has been removed. The default third argument of 
+    	<code>RegisteredParsingObject</code> has been changed accordingly.</li>
+    <li><code>Object</code> has been renamed as <code>RegisteredObjectBase</code>. 
+        This is because the class only exists for the parser to get information about the class.</li>
+  </ul>
+</li>
 </ul>
 
 <h3>New functionality</h3>

--- a/src/buildblock/KeyParser.cxx
+++ b/src/buildblock/KeyParser.cxx
@@ -29,7 +29,7 @@
 
 #include "stir/KeyParser.h"
 #include "stir/Succeeded.h"
-#include "stir/Object.h"
+#include "stir/RegisteredObjectBase.h"
 #include "stir/interfile_keyword_functions.h"
 #include "stir/stream.h"
 #include "stir/is_null_ptr.h"
@@ -213,7 +213,7 @@ map_element::map_element(KeyArgument::type t,
 }
 
 map_element::map_element(void (KeyParser::*pom)(),
-	      Object** pov, 
+	      RegisteredObjectBase** pov, 
               Parser* parser)
   :
   type(KeyArgument::PARSINGOBJECT),
@@ -223,7 +223,7 @@ map_element::map_element(void (KeyParser::*pom)(),
   {}
 
 map_element::map_element(void (KeyParser::*pom)(),
-	      shared_ptr<Object>* pov, 
+	      shared_ptr<RegisteredObjectBase>* pov, 
               Parser* parser)
   :
   type(KeyArgument::SHARED_PARSINGOBJECT),
@@ -883,7 +883,7 @@ void KeyParser::set_parsing_object()
   if(current_index!=0)
     error("KeyParser::PARSINGOBJECT can't handle vectored keys yet\n");
   const std::string& par_ascii = *boost::any_cast<std::string>(&this->parameter);
-  *reinterpret_cast<Object **>(current->p_object_variable) =
+  *reinterpret_cast<RegisteredObjectBase **>(current->p_object_variable) =
     (*current->parser)(input, par_ascii);	    
 }
 
@@ -901,7 +901,7 @@ void KeyParser::set_shared_parsing_object()
   if(current_index!=0)
     error("KeyParser::SHARED_PARSINGOBJECT can't handle vectored keys yet");
   const std::string& par_ascii = *boost::any_cast<std::string>(&this->parameter);
-  reinterpret_cast<shared_ptr<Object> *>(current->p_object_variable)->
+  reinterpret_cast<shared_ptr<RegisteredObjectBase> *>(current->p_object_variable)->
     reset((*current->parser)(input, par_ascii));
 }
 
@@ -1179,8 +1179,8 @@ string KeyParser::parameter_info() const
 	}
       case KeyArgument::PARSINGOBJECT:
         {
-          Object* parsing_object_ptr =
-            *reinterpret_cast<Object**>(i->second.p_object_variable);
+          RegisteredObjectBase* parsing_object_ptr =
+            *reinterpret_cast<RegisteredObjectBase**>(i->second.p_object_variable);
 	  if (parsing_object_ptr!=0)
 	  {
 	    s << parsing_object_ptr->get_registered_name() << endl;
@@ -1196,8 +1196,8 @@ string KeyParser::parameter_info() const
 
           s << "COMPILED WITH GNU C++ (prior to version 3.0), CANNOT INSERT VALUE";
 #else
-          shared_ptr<Object> parsing_object_ptr =
-            (*reinterpret_cast<shared_ptr<Object>*>(i->second.p_object_variable));
+          shared_ptr<RegisteredObjectBase> parsing_object_ptr =
+            (*reinterpret_cast<shared_ptr<RegisteredObjectBase>*>(i->second.p_object_variable));
           
           if (!is_null_ptr(parsing_object_ptr))
 	  {

--- a/src/buildblock/ParsingObject.cxx
+++ b/src/buildblock/ParsingObject.cxx
@@ -143,7 +143,7 @@ ParsingObject::ask_parameters()
 }
 
 std::string
-ParsingObject::parameter_info() 
+ParsingObject::parameter_info()
 { 
   if (!keymap_is_initialised)
   {

--- a/src/include/stir/DataProcessor.h
+++ b/src/include/stir/DataProcessor.h
@@ -30,7 +30,6 @@
 
 
 #include "stir/RegisteredObject.h"
-#include "stir/ParsingObject.h"
 #include "stir/TimedObject.h"
 #include "stir/Succeeded.h"
 
@@ -50,12 +49,11 @@ START_NAMESPACE_STIR
   RegisteredParsingObject are supposed to handle. So, all this 
   functionality is achieved by deriving DataProcessor from the
   appropriate RegisteredObject class, and deriving the 'leaves'
-  from Registered ParsingObject.
+  from RegisteredParsingObject.
  */
 template <typename DataT>
 class DataProcessor : 
 public RegisteredObject<DataProcessor<DataT> >,
-public ParsingObject,
 public TimedObject
 {
 public:

--- a/src/include/stir/IO/InputStreamFromROOTFile.h
+++ b/src/include/stir/IO/InputStreamFromROOTFile.h
@@ -32,7 +32,6 @@
 #include "stir/Succeeded.h"
 #include "stir/listmode/CListRecordROOT.h"
 #include "stir/RegisteredObject.h"
-#include "stir/ParsingObject.h"
 
 #include <TROOT.h>
 #include <TSystem.h>
@@ -71,8 +70,7 @@ START_NAMESPACE_STIR
         \warning The initial validation of the ROOT input was done with version 5.34.
 */
 
-class InputStreamFromROOTFile : public RegisteredObject< InputStreamFromROOTFile > ,
-        public ParsingObject
+class InputStreamFromROOTFile : public RegisteredObject< InputStreamFromROOTFile >
 {
 public:
     typedef std::vector<long long int>::size_type SavedPosition;

--- a/src/include/stir/IO/OutputFileFormat.h
+++ b/src/include/stir/IO/OutputFileFormat.h
@@ -30,7 +30,6 @@
 #define __stir_IO_OutputFileFormat_H__
 
 #include "stir/RegisteredObject.h"
-#include "stir/ParsingObject.h"
 #include "stir/NumericType.h"
 #include "stir/ByteOrder.h"
 #include <string>
@@ -63,8 +62,7 @@ class Succeeded;
  */
 template <typename DataT>
 class OutputFileFormat : 
-  public RegisteredObject<OutputFileFormat<DataT> >,
-  public ParsingObject
+  public RegisteredObject<OutputFileFormat<DataT> >
 {
 public:
   //! A function to return a default output file format

--- a/src/include/stir/IO/OutputFileFormat.txx
+++ b/src/include/stir/IO/OutputFileFormat.txx
@@ -85,15 +85,15 @@ initialise_keymap()
     byte_order_values.push_back("LITTLEENDIAN");
     byte_order_values.push_back("BIGENDIAN");
   }
-  parser.add_key("byte order",
+  this->parser.add_key("byte order",
 		 &byte_order_index,
 		 &byte_order_values);
-  parser.add_key("number format",
+  this->parser.add_key("number format",
 		 &number_format_index,
 		 &number_format_values);
-  parser.add_key("number of bytes per pixel",
+  this->parser.add_key("number of bytes per pixel",
 		 &bytes_per_pixel);
-  parser.add_key("scale_to_write_data",
+  this->parser.add_key("scale_to_write_data",
 		 &scale_to_write_data);
 }
 
@@ -112,7 +112,7 @@ set_key_values()
                                      bytes_per_pixel_in_size_t);
   bytes_per_pixel = static_cast<int>(bytes_per_pixel_in_size_t);
   number_format_index =
-     parser.find_in_ASCIIlist(number_format, number_format_values); 
+     this->parser.find_in_ASCIIlist(number_format, number_format_values);
 
 }
 

--- a/src/include/stir/KeyParser.h
+++ b/src/include/stir/KeyParser.h
@@ -46,7 +46,7 @@ START_NAMESPACE_STIR
 
 typedef std::vector<std::string> ASCIIlist_type;
 
-class Object;
+class RegisteredObjectBase;
 class Succeeded;
 
 class KeyParser;
@@ -90,7 +90,7 @@ public :
   void *p_object_variable;		// pointer to a variable 
   const ASCIIlist_type *p_object_list_of_values;// only used by ASCIIlist
   // TODO should really not be here, but it works for now
-  typedef Object * (Parser)(std::istream*, const std::string&);
+  typedef RegisteredObjectBase * (Parser)(std::istream*, const std::string&);
   Parser* parser;
 
   map_element();
@@ -98,10 +98,10 @@ public :
   map_element(KeyArgument::type t, void (KeyParser::*pom)(),
 	      void* pov= 0, const ASCIIlist_type *list_of_valid_keywords = 0);
   map_element(void (KeyParser::*pom)(),
-	      Object** pov, 
+	      RegisteredObjectBase** pov, 
               Parser *);
   map_element(void (KeyParser::*pom)(),
-	      shared_ptr<Object>* pov, 
+	      shared_ptr<RegisteredObjectBase>* pov, 
               Parser *);
   ~map_element();
 	
@@ -275,7 +275,7 @@ public:
   {
     add_in_keymap(keyword,     
                   map_element(&KeyParser::set_parsing_object, 
-                    reinterpret_cast<Object**>(parsed_object_ptr_ptr), 
+                    reinterpret_cast<RegisteredObjectBase**>(parsed_object_ptr_ptr), 
                     (map_element::Parser *)(&ParsingClass::read_registered_object))
 		    );
   }
@@ -287,7 +287,7 @@ public:
   {
     add_in_keymap(keyword,     
                   map_element(&KeyParser::set_shared_parsing_object, 
-                    reinterpret_cast<shared_ptr<Object>*>(parsed_object_ptr_ptr), 
+                    reinterpret_cast<shared_ptr<RegisteredObjectBase>*>(parsed_object_ptr_ptr), 
                     (map_element::Parser *)(&ParsingClass::read_registered_object))
 		    );
   }

--- a/src/include/stir/ParsingObject.h
+++ b/src/include/stir/ParsingObject.h
@@ -69,7 +69,7 @@ public:
 
    void ask_parameters();
 
-   std::string parameter_info();  
+   virtual std::string parameter_info();
 
 protected:
   //! Set defaults before parsing

--- a/src/include/stir/RegisteredObject.h
+++ b/src/include/stir/RegisteredObject.h
@@ -28,7 +28,7 @@
 #ifndef __stir_RegisteredObject_H__
 #define __stir_RegisteredObject_H__
 
-#include "stir/Object.h"
+#include "stir/RegisteredObjectBase.h"
 #include "stir/FactoryRegistry.h"
 #include "stir/interfile_keyword_functions.h"
 #include <iostream>
@@ -107,7 +107,7 @@ START_NAMESPACE_STIR
   you forgot to do this.
 */
 template <typename Root>
-class RegisteredObject : public Object
+class RegisteredObject : public RegisteredObjectBase
 {
 public:
   inline RegisteredObject();

--- a/src/include/stir/RegisteredObject.h
+++ b/src/include/stir/RegisteredObject.h
@@ -63,24 +63,23 @@ START_NAMESPACE_STIR
   and its parameters. This makes only sense if the object construction
   can be interactive as well (see ask_type_and_parameters()).
 
-  In case the construction of the object is done by using ParsingObject,
-  nearly all of the necessary functionality can be provided to the
-  hierarchy by using RegisteredParsingObject in the hierarchy. In such 
-  a case, the hierarchy looks normally as follows:
+  We currently assume that the construction of the object is done by using ParsingObject.
+  Nearly all of the necessary functionality can be provided to the
+  hierarchy by using RegisteredParsingObject in the hierarchy.
+  The hierarchy looks normally as follows:
   \code
   RegisteredObject<Base>
   Base
   ...
-  Parent   <- ParsingObject
+  Parent
   RegisteredParsingObject<Derived,Base,Parent>
   Derived
   \endcode
 
-  A <strong>recommended</strong> variation on this is the following:
+  When there is no intermediate class in hierarchy, this is simplified to:
   \code
   RegisteredObject<Base>
-  Base <- ParsingObject
-  ...
+  Base
   RegisteredParsingObject<Derived,Base,Base>
   Derived
   \endcode

--- a/src/include/stir/RegisteredObjectBase.h
+++ b/src/include/stir/RegisteredObjectBase.h
@@ -28,6 +28,7 @@
 */
 
 #include "stir/common.h"
+#include "stir/ParsingObject.h"
 
 #include <string>
 
@@ -45,20 +46,11 @@ START_NAMESPACE_STIR
   for parsing..
 */
 
-class Object
+class Object : public ParsingObject
 {
 public:
   virtual ~Object() {}
-  /*! \brief return a string describing all parameters of the object
 
-  There is currently no requirement on the format of the returned string.
-  Ideally it would be such that the object can be constructed by parsing
-  the string again.
-
-  \todo Ideally this function would be a const member, but we cannot
-  do this because ParsingObject::parameter_info is not const.
-  */
-  virtual std::string parameter_info()  = 0;
   /*! \brief Returns the name of the type of the object.
 
   Each type that can be parsed has a unique (within its hierarchy) name

--- a/src/include/stir/RegisteredObjectBase.h
+++ b/src/include/stir/RegisteredObjectBase.h
@@ -4,7 +4,7 @@
 
   \file
 
-  \brief Declaration of class stir::Object
+  \brief Declaration of class stir::RegisteredObjectBase
 
   \author Kris Thielemans
   
@@ -27,29 +27,28 @@
     See STIR/LICENSE.txt for details
 */
 
-#include "stir/common.h"
 #include "stir/ParsingObject.h"
 
 #include <string>
 
-#ifndef __stir_Object_H__
-#define __stir_Object_H__
+#ifndef __stir_RegisteredObjectBase_H__
+#define __stir_RegisteredObjectBase_H__
 
 START_NAMESPACE_STIR
 
 /*! \brief Base class for all classes that can parse .par files (and more?) 
   \ingroup buildblock
-  The main reason that this class exists is such that KeyParser can store
+  The only reason that this class exists is such that KeyParser can store
   different types of objects, and get some basic info from it.
 
   \see RegisteredObject for more info on the registries etc that are used
   for parsing..
 */
 
-class Object : public ParsingObject
+class RegisteredObjectBase : public ParsingObject
 {
 public:
-  virtual ~Object() {}
+  virtual ~RegisteredObjectBase() {}
 
   /*! \brief Returns the name of the type of the object.
 

--- a/src/include/stir/RegisteredParsingObject.h
+++ b/src/include/stir/RegisteredParsingObject.h
@@ -97,7 +97,7 @@ class AddParser : public Base, public ParsingObject
   the variables in that file are never referenced, so would not include
   it in the final executable (to try to remove redundant object files).
 */
-template <typename Derived, typename Base, typename Parent = AddParser<Base> >
+template <typename Derived, typename Base, typename Parent = Base>
 class RegisteredParsingObject : public Parent
 {
 public:

--- a/src/include/stir/RegisteredParsingObject.h
+++ b/src/include/stir/RegisteredParsingObject.h
@@ -34,21 +34,6 @@
 #include <string>
 
 START_NAMESPACE_STIR
-
-
-//! Auxiliary class for RegisteredParsingObject
-/*!
-  \ingroup buildblock
-   This class simply makes a class derived from Base and ParsingObject. Its use
-    should be restricted to the default value of the RegisteredParsingObject
-    template.
-*/
-template <typename Base>
-class AddParser : public Base, public ParsingObject
-{};
-
-
-
 /*!
   \brief Parent class for all leaves in a RegisteredObject hierarchy that
   do parsing of parameter files.

--- a/src/include/stir/Shape/Shape3D.h
+++ b/src/include/stir/Shape/Shape3D.h
@@ -71,8 +71,7 @@ template <typename elemT> class VoxelsOnCartesianGrid;
   \endverbatim
 */
 class Shape3D :
-   public RegisteredObject<Shape3D>,
-   public ParsingObject
+   public RegisteredObject<Shape3D>
 {
 public:
 

--- a/src/include/stir/data/SinglesRatesFromECAT7.h
+++ b/src/include/stir/data/SinglesRatesFromECAT7.h
@@ -40,7 +40,7 @@ START_NAMESPACE_ECAT7
 */
 class SinglesRatesFromECAT7 : 
 public RegisteredParsingObject<SinglesRatesFromECAT7, SinglesRates,
-                               AddParser<SinglesRatesForTimeFrames> >
+                               SinglesRatesForTimeFrames>
 { 
 public:
 

--- a/src/include/stir/recon_buildblock/GeneralisedObjectiveFunction.h
+++ b/src/include/stir/recon_buildblock/GeneralisedObjectiveFunction.h
@@ -88,8 +88,7 @@ class Succeeded;
 */
 template <typename TargetT>
 class GeneralisedObjectiveFunction: 
-   public RegisteredObject<GeneralisedObjectiveFunction<TargetT> >,
-   public ParsingObject
+   public RegisteredObject<GeneralisedObjectiveFunction<TargetT> >
 {
 public:
   

--- a/src/include/stir/recon_buildblock/GeneralisedPrior.h
+++ b/src/include/stir/recon_buildblock/GeneralisedPrior.h
@@ -48,8 +48,7 @@ class Succeeded;
 */
 template <typename DataT>
 class GeneralisedPrior: 
-   public RegisteredObject<GeneralisedPrior<DataT> >,
-   public ParsingObject
+   public RegisteredObject<GeneralisedPrior<DataT> >
 			 
 {
 public:

--- a/src/include/stir/recon_buildblock/ProjDataRebinning.h
+++ b/src/include/stir/recon_buildblock/ProjDataRebinning.h
@@ -79,7 +79,7 @@ class Succeeded;
 
 
 class ProjDataRebinning : 
-  public TimedObject, public ParsingObject ,
+  public TimedObject,
   public RegisteredObject<ProjDataRebinning >
 {
 public:

--- a/src/include/stir/recon_buildblock/ProjMatrixByBin.h
+++ b/src/include/stir/recon_buildblock/ProjMatrixByBin.h
@@ -86,8 +86,7 @@ class Bin;
   only the 'basic' bins, and computes symmetry related bins from the 'basic' ones.
 */
 class ProjMatrixByBin :  
-  public RegisteredObject<ProjMatrixByBin>,  
-  public ParsingObject,
+  public RegisteredObject<ProjMatrixByBin>,
   public TimedObject
 {
 public:

--- a/src/include/stir/recon_buildblock/ProjectorByBinPair.h
+++ b/src/include/stir/recon_buildblock/ProjectorByBinPair.h
@@ -50,8 +50,7 @@ class ProjDataInfo;
   file.
 */
 class ProjectorByBinPair : 
-public RegisteredObject<ProjectorByBinPair> ,
-public ParsingObject
+public RegisteredObject<ProjectorByBinPair>
 { 
 public:
 

--- a/src/include/stir/recon_buildblock/Reconstruction.h
+++ b/src/include/stir/recon_buildblock/Reconstruction.h
@@ -77,8 +77,7 @@ class Succeeded;
 template <typename TargetT>
 class Reconstruction :
         public RegisteredObject<Reconstruction < TargetT > >,
-        public TimedObject,
-        public ParsingObject
+        public TimedObject
 {
 public:
   //! virtual destructor

--- a/src/include/stir_experimental/AbsTimeInterval.h
+++ b/src/include/stir_experimental/AbsTimeInterval.h
@@ -27,8 +27,7 @@ START_NAMESPACE_STIR
   Absolute time means at present 'secs since midnight 1/1/1970 UTC'
 
 */
-class AbsTimeInterval: public RegisteredObject<AbsTimeInterval>,
-                           public ParsingObject
+class AbsTimeInterval: public RegisteredObject<AbsTimeInterval>
 {
 
 public:

--- a/src/include/stir_experimental/motion/ObjectTransformation.h
+++ b/src/include/stir_experimental/motion/ObjectTransformation.h
@@ -28,8 +28,7 @@ START_NAMESPACE_STIR
 */
 template <int num_dimensions, class elemT>
 class ObjectTransformation :
-  public RegisteredObject<ObjectTransformation<num_dimensions, elemT> >,
-  public ParsingObject
+  public RegisteredObject<ObjectTransformation<num_dimensions, elemT> >
 {
 public:
 

--- a/src/include/stir_experimental/motion/RigidObject3DMotion.h
+++ b/src/include/stir_experimental/motion/RigidObject3DMotion.h
@@ -43,8 +43,7 @@ class AbsTimeInterval;
     is completely dependent on what the derived class does.
     
 */
-class RigidObject3DMotion: public RegisteredObject<RigidObject3DMotion>,
-                           public ParsingObject
+class RigidObject3DMotion: public RegisteredObject<RigidObject3DMotion>
 {
 
 public:

--- a/src/swig/stir.i
+++ b/src/swig/stir.i
@@ -1657,17 +1657,11 @@ namespace stir {
 
 %include "stir/recon_buildblock/ProjMatrixByBinUsingRayTracing.h"
 
-%shared_ptr(  stir::ForwardProjectorByBin);
-%template (internalAddParserForwardProjectorByBin)
-  stir::ForwardProjectorByBin;
 %template (internalRPForwardProjectorByBinUsingProjMatrixByBin)  
   stir::RegisteredParsingObject<stir::ForwardProjectorByBinUsingProjMatrixByBin,
      stir::ForwardProjectorByBin>;
 %include "stir/recon_buildblock/ForwardProjectorByBinUsingProjMatrixByBin.h"
 
-%shared_ptr(  stir::BackProjectorByBin);
-%template (internalAddParserBackProjectorByBin)
-  stir::BackProjectorByBin;
 %template (internalRPBackProjectorByBinUsingProjMatrixByBin)  
   stir::RegisteredParsingObject<stir::BackProjectorByBinUsingProjMatrixByBin,
      stir::BackProjectorByBin>;

--- a/src/swig/stir.i
+++ b/src/swig/stir.i
@@ -1657,17 +1657,17 @@ namespace stir {
 
 %include "stir/recon_buildblock/ProjMatrixByBinUsingRayTracing.h"
 
-%shared_ptr(  stir::AddParser<stir::ForwardProjectorByBin>);
+%shared_ptr(  stir::ForwardProjectorByBin);
 %template (internalAddParserForwardProjectorByBin)
-  stir::AddParser<stir::ForwardProjectorByBin>;
+  stir::ForwardProjectorByBin;
 %template (internalRPForwardProjectorByBinUsingProjMatrixByBin)  
   stir::RegisteredParsingObject<stir::ForwardProjectorByBinUsingProjMatrixByBin,
      stir::ForwardProjectorByBin>;
 %include "stir/recon_buildblock/ForwardProjectorByBinUsingProjMatrixByBin.h"
 
-%shared_ptr(  stir::AddParser<stir::BackProjectorByBin>);
+%shared_ptr(  stir::BackProjectorByBin);
 %template (internalAddParserBackProjectorByBin)
-  stir::AddParser<stir::BackProjectorByBin>;
+  stir::BackProjectorByBin;
 %template (internalRPBackProjectorByBinUsingProjMatrixByBin)  
   stir::RegisteredParsingObject<stir::BackProjectorByBinUsingProjMatrixByBin,
      stir::BackProjectorByBin>;


### PR DESCRIPTION
1. `Object` inherits from `ParsingObject`
2. `Object` no longer needs the method `parameter_info()`
3. Classes that inherit from `RegisteredObject` no longer need to inherit from `ParsingObject`, too
4. Modify the default 3rd argument in `RegisteredParsingObject`

The old naming scheme was then misleading. The class, `Object` only exists so that the parser can get the registered name of the class. This is therefore a non-templated version of the `RegisteredObject`, so is now called `RegisteredObjectBase`.