### PR TITLE
fixed executable

### DIFF
--- a/src/utilities/zoom_image.cxx
+++ b/src/utilities/zoom_image.cxx
@@ -45,10 +45,10 @@ USING_NAMESPACE_STIR
 static void print_usage_and_exit(const std::string& prog_name)
 {
   cerr<<"Usage: \n" 
-      << '\t' << prog_name << " [--scaling option] <output filename> <input filename> sizexy [zoomxy [offset_in_mm_x [offset_in_mm_y [sizez [zoomz [offset_in_mm_z]]]]]]]\n"
+      << '\t' << prog_name << " [--scaling <option>] <output filename> <input filename> sizexy [zoomxy [offset_in_mm_x [offset_in_mm_y [sizez [zoomz [offset_in_mm_z]]]]]]]\n"
       << "or alternatively\n"
-      << '\t' << prog_name << " [--scaling option] --template template_filename <output filename> <input filename>\n"
-      << "Supported scaling option: preserve_sum, preserve_values, preserve_projections.\n";
+      << '\t' << prog_name << " [--scaling <option>] --template template_filename <output filename> <input filename>\n"
+      << "Supported <option>: preserve_sum, preserve_values, preserve_projections.\n";
   exit(EXIT_FAILURE);
 }
 


### PR DESCRIPTION
I found "--scaling option" a bit confusing. as the code says:
"Supported scaling option: preserve_sum, preserve_values, preserve_projections.\n";
So it seems that it needs to be replaced by one argument only at first glance. I think if we put --scaling <option> is clearer.