### PR TITLE
Fix to distributable to suppress OpenMP cerr output

### DIFF
--- a/src/recon_buildblock/distributable.cxx
+++ b/src/recon_buildblock/distributable.cxx
@@ -423,7 +423,7 @@ void distributable_computation(
 #ifdef STIR_OPENMP
 #pragma omp single
     {
-      info("Starting loop with " + std::to_string(omp_get_num_threads()) + " threads");
+      info(boost::format("Starting loop with %1% threads") % omp_get_num_threads());
       local_log_likelihoods.resize(omp_get_max_threads(), 0.);
       local_counts.resize(omp_get_max_threads(), 0);
       local_count2s.resize(omp_get_max_threads(), 0);

--- a/src/recon_buildblock/distributable.cxx
+++ b/src/recon_buildblock/distributable.cxx
@@ -423,7 +423,7 @@ void distributable_computation(
 #ifdef STIR_OPENMP
 #pragma omp single
     {
-      std::cerr << "Starting loop with " << omp_get_num_threads() << " threads\n"; 
+      info("Starting loop with " + std::to_string(omp_get_num_threads()) + " threads");
       local_log_likelihoods.resize(omp_get_max_threads(), 0.);
       local_counts.resize(omp_get_max_threads(), 0);
       local_count2s.resize(omp_get_max_threads(), 0);


### PR DESCRIPTION
Output was created by a std::cerr which was causing spam output when OpenMP functions are called multiple times. This change will allow verbosity levels to suppress this output.