### PR TITLE
temporarily disable ROOT for OSX Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,14 +37,15 @@ matrix:
  - os: osx
    python: 3
    env: EXTRA_BUILD_FLAGS="-DDISABLE_CERN_ROOT=1 -DSTIR_OPENMP:BOOL=OFF" CC=gcc CXX=g++
- - os: osx
-   osx_image: xcode9 # need that for ROOT
-   python: 3
-   env: EXTRA_BUILD_FLAGS="-DDISABLE_CERN_ROOT=0 -DSTIR_OPENMP:BOOL=OFF" CC=gcc CXX=g++
+   # Disable as ROOT is currently failing via brew
+ # - os: osx
+ #   osx_image: xcode9 # need that for ROOT
+ #   python: 3
+ #   env: EXTRA_BUILD_FLAGS="-DDISABLE_CERN_ROOT=0 -DSTIR_OPENMP:BOOL=OFF" CC=gcc CXX=g++
  - os: osx
    osx_image: xcode9  # need that for ROOT
    python: 3
-   env: EXTRA_BUILD_FLAGS="-DDISABLE_CERN_ROOT=0 -DSTIR_OPENMP:BOOL=OFF -DSTIR_ENABLE_EXPERIMENTAL:BOOL=ON" CC=clang CXX=clang++
+   env: EXTRA_BUILD_FLAGS="-DDISABLE_CERN_ROOT=1 -DSTIR_OPENMP:BOOL=OFF -DSTIR_ENABLE_EXPERIMENTAL:BOOL=ON" CC=clang CXX=clang++
 
 env:
   global:


### PR DESCRIPTION
can't currently `brew install root` on OSX Travis (#386). Tried upgrading to osxbuild 11 & 11.2 (#387) and 9 & 9.4 (https://github.com/UCL/STIR/tree/OSX_xcode_version).

No luck, so temporarily disabling.