### PR TITLE
return success value of bash scripts

### DIFF
--- a/recon_test_pack/SPECT/run_SPECT_tests.sh
+++ b/recon_test_pack/SPECT/run_SPECT_tests.sh
@@ -150,7 +150,9 @@ echo "============================================="
 if [ -z "${error_log_files}" ]; then
  echo "All tests OK!"
  echo "You can remove all output using \"rm -rf out\""
+ exit 0
 else
  echo "There were errors. Check ${error_log_files}"
+ exit 1
 fi
 

--- a/recon_test_pack/run_ecat_tests.sh
+++ b/recon_test_pack/run_ecat_tests.sh
@@ -131,5 +131,6 @@ echo "Everything seems to be fine !"
 echo 'You could remove all generated files using "rm -f my_* *.log"'
 fi
 
+exit ${ThereWereErrors}
 
 

--- a/recon_test_pack/run_root_GATE.sh
+++ b/recon_test_pack/run_root_GATE.sh
@@ -192,8 +192,9 @@ then
       cat ${log}
     done
   fi
-  exit 1
 else
   echo "Everything seems to be fine !"
   echo 'You could remove all generated files using "rm -f my_* *.log"'
 fi
+
+exit ${ThereWereErrors}

--- a/recon_test_pack/run_scatter_tests.sh
+++ b/recon_test_pack/run_scatter_tests.sh
@@ -72,7 +72,9 @@ fi
 if [ -z "${error_log_files}" ]; then
  echo "All tests OK!"
  echo "You can remove all output using \"rm -f my_*\""
+ exit 0
 else
  echo "There were errors. Check ${error_log_files}"
+ exit 1
 fi
 

--- a/recon_test_pack/run_test_listmode_recon.sh
+++ b/recon_test_pack/run_test_listmode_recon.sh
@@ -121,3 +121,4 @@ echo "Everything seems to be fine !"
 echo 'You could remove all generated files using "rm -f my_* *.log"'
 fi
 
+exit ${ThereWereErrors}

--- a/recon_test_pack/run_test_simulate_and_recon.sh
+++ b/recon_test_pack/run_test_simulate_and_recon.sh
@@ -180,7 +180,9 @@ done
 if [ -z "${error_log_files}" ]; then
  echo "All tests OK!"
  echo "You can remove all output using \"rm -f my_*\""
+ exit 0
 else
  echo "There were errors. Check ${error_log_files}"
+ exit 1
 fi
 

--- a/recon_test_pack/run_test_simulate_and_recon_with_motion.sh
+++ b/recon_test_pack/run_test_simulate_and_recon_with_motion.sh
@@ -188,6 +188,8 @@ fi
 if [ -z "${error_log_files}" ]; then
  echo "All tests OK!"
  echo "You can remove all output using \"rm -f my_*\""
+ exit 0
 else
  echo "There were errors. Check ${error_log_files}"
+ exit 1
 fi

--- a/recon_test_pack/run_test_zoom_image.sh
+++ b/recon_test_pack/run_test_zoom_image.sh
@@ -194,7 +194,9 @@ fi
 if [ -z "${error_log_files}" ]; then
  echo "All tests OK!"
  echo "You can remove all output using \"rm -f my_*\""
+ exit 0
 else
  echo "There were errors. Check ${error_log_files}"
+ exit 1
 fi
 

--- a/recon_test_pack/run_tests.sh
+++ b/recon_test_pack/run_tests.sh
@@ -304,5 +304,6 @@ echo "Everything seems to be fine !"
 echo 'You could remove all generated files using "rm -f my_* *.log"'
 fi
 
+exit ${ThereWereErrors}
 
 


### PR DESCRIPTION
fixes some of #393 (tests failing but travis happy).

The relevant bit of the `.travis.yml` currently looks like this:

```
  - ./run_test_simulate_and_recon.sh
  - ./run_test_listmode_recon.sh
  - ./run_test_simulate_and_recon_with_motion.sh
  - ./run_scatter_tests.sh
  - ./run_tests.sh --nointbp
  - ./run_test_zoom_image.sh
```
@KrisThielemans - would you rather:
```
rtn_run_test_simulate_and_recon=$(./run_test_simulate_and_recon.sh)
rtn_run_test_listmode_recon=$(./run_test_listmode_recon.sh)
...
```
In this way we can run all tests and then check the result, with e.g.:
```
rtn_all_tests=$(( rtn_run_test_simulate_and_recon * rtn_run_test_listmode_recon * ... ))
if [ "$rtn_all_tests" = false ] ; then
    exit 1 or print message, not sure what you're supposed to do with Travis
fi
```