### PR TITLE
Set verbosity from parameter file

### DIFF
--- a/documentation/release_4.0.htm
+++ b/documentation/release_4.0.htm
@@ -195,6 +195,9 @@ These are only minimally documented at the present stage unfortunately.
   </li>
 <li>Indirect parametric reconstruction (Patlak) no longer requires you to pass a pre-existing template file. If one is supplied, it will be used; else the parametric image will be created based on the dynamic image.
   </li>
+  <li>Verbosity can be set in reconstructions with the "verbosity := " keyword
+    in the parameter file.
+  </li>
   </ul>
 
 

--- a/examples/samples/OSMAPOSL_QuadraticPrior.par
+++ b/examples/samples/OSMAPOSL_QuadraticPrior.par
@@ -51,6 +51,7 @@ number of subiterations:= 24
 save estimates at subiteration intervals:= 12
 
 ; This is the default verbosity, just putting it here as an example
+; lower value means less output, 0 being the minimum
 verbosity := 2
 
 ; enable this for multiplicative form of OSMAPOSL (see User's Guide)

--- a/examples/samples/OSMAPOSL_QuadraticPrior.par
+++ b/examples/samples/OSMAPOSL_QuadraticPrior.par
@@ -50,6 +50,9 @@ number of subsets:= 12
 number of subiterations:= 24
 save estimates at subiteration intervals:= 12
 
+; This is the default verbosity, just putting it here as an example
+verbosity := 2
+
 ; enable this for multiplicative form of OSMAPOSL (see User's Guide)
 ;MAP model := multiplicative
 

--- a/src/buildblock/Verbosity.cxx
+++ b/src/buildblock/Verbosity.cxx
@@ -34,7 +34,7 @@ START_NAMESPACE_STIR
 Verbosity* Verbosity::_instance = NULL; 
 
 Verbosity::Verbosity(){
-  _verbosity_level = 1;
+  _verbosity_level = 2;
 };
 
 int Verbosity::get() 

--- a/src/include/stir/recon_buildblock/Reconstruction.h
+++ b/src/include/stir/recon_buildblock/Reconstruction.h
@@ -236,6 +236,10 @@ protected:
   bool _disable_output;
 
 
+  /// Verbosity level
+  int _verbosity;
+
+
 };
 
 END_NAMESPACE_STIR

--- a/src/recon_buildblock/Reconstruction.cxx
+++ b/src/recon_buildblock/Reconstruction.cxx
@@ -64,6 +64,7 @@ Reconstruction<TargetT>::set_defaults()
   this->post_filter_sptr.reset();
 
   this->_disable_output = false;
+  this->_verbosity = -1;
 
 }
 
@@ -76,6 +77,7 @@ Reconstruction<TargetT>::initialise_keymap()
   this->parser.add_parsing_key("output file format type", &this->output_file_format_ptr);
   this->parser.add_parsing_key("post-filter type", &this->post_filter_sptr); 
   this->parser.add_key("disable output", &_disable_output);
+  this->parser.add_key("verbosity", &_verbosity);
 //  parser.add_key("END", &KeyParser::stop_parsing);
  
 }
@@ -123,6 +125,9 @@ post_processing()
 
   if (is_null_ptr(this->output_file_format_ptr))
     { warning("output file format has to be set to valid value"); return true; }
+
+  if (_verbosity >= 0)
+      Verbosity::set(_verbosity);
 
   return false;
 }

--- a/src/recon_buildblock/distributable.cxx
+++ b/src/recon_buildblock/distributable.cxx
@@ -476,7 +476,7 @@ void distributable_computation(
                % view_segment_num.segment_num() % view_segment_num.view_num());
 #else
           info(boost::format("calculating segment_num: %d, view_num: %d")
-               % view_segment_num.segment_num() % view_segment_num.view_num());
+               % view_segment_num.segment_num() % view_segment_num.view_num(), 2);
 #endif
 
 #ifdef STIR_OPENMP


### PR DESCRIPTION
Had to change printing of segment number to info level 2, otherwise the only way to disable was to have no output at all. Therefore changed the default verbosity to two.