### PR TITLE
Only functional hkem

### DIFF
--- a/examples/samples/KOSMAPOSL_hkem_spect.par
+++ b/examples/samples/KOSMAPOSL_hkem_spect.par
@@ -6,7 +6,6 @@ KOSMAPOSLParameters :=
 ;the following disables the alpha coefficient output:
 disable output :=1
 
-
 ; here we have the possibility to choose the parameters which define the kernel
 ; matrix and the name of the anatomical image. the following are the defaults values:
 
@@ -14,7 +13,6 @@ disable output :=1
 ; OR
 ; 0 kernel is MR-only
 hybrid:=1
-
 
 ; The following should only be set to 1 if hybrid is set to 1. You still need to load your anatomical
 ; image or an empty image with the right dimensions and voxel size 
@@ -49,10 +47,10 @@ number of neighbours:= 3
 number of non-zero feature elements:=1
 
 ; this are the file names of the anatomical images (at the moment we can accept only one image)
-anatomical image filenames:= {MRbrain.hv}
+anatomical image filenames:= {PET_CL02_003_4hr_head.hv}
 
 ; the following should be 1 if you want to reconstruct 2D data
-only_2D:=1
+only_2D:=0
 
 ; the following is the output prefix of the PET reconstructed image
 kernelised output filename prefix :=KOSMAPOSL
@@ -60,31 +58,26 @@ kernelised output filename prefix :=KOSMAPOSL
 objective function type:= PoissonLogLikelihoodWithLinearModelForMeanAndProjData
 PoissonLogLikelihoodWithLinearModelForMeanAndProjData Parameters:=
 
-input file := my_noisy_prompts_1ax_pos.hs
+input file := input_CL02_003_4hr_head_hkem.hs
 
-; Daniel: here we have the possibility to choose the parameters which define the kernel matrix and the name of the MR image.
-
+;SPECT:
 projector pair type := Matrix
 Projector Pair Using Matrix Parameters :=
-Matrix type := Ray Tracing
-Ray tracing matrix parameters :=
-number of rays in tangential direction to trace for each bin := 10
-do symmetry 90degrees min phi := 1
-do_symmetry_180degrees_min_phi:= 1
-do_symmetry_swap_s:= 1
-do_symmetry_swap_segment:= 1
-do_symmetry_shift_z:= 1
-End Ray tracing matrix parameters :=
+Matrix type := SPECT UB
+Projection Matrix By Bin SPECT UB Parameters:=
+maximum number of sigmas:= 2.0
+psf type:= Geometrical
+psf type:= Geometrical
+attenuation type := Simple
+attenuation map := ${umap}
+mask type := No
+;mask file := mask.hv
+End Projection Matrix By Bin SPECT UB Parameters:=
 End Projector Pair Using Matrix Parameters :=
+;SPECT END
 
 ; additive projection data to handle randoms etc
 additive sinogram := my_additive_sinogram_1ax_pos.hs 
-
-; norm and acf
-Bin Normalisation type := From ProjData
-Bin Normalisation From ProjData :=
-normalisation projdata filename:= my_multfactors_1ax_pos.hs
-End Bin Normalisation From ProjData:=
 
 ; if the next parameters are enabled, 
 ; the sensitivity will be computed and saved
@@ -92,20 +85,24 @@ End Bin Normalisation From ProjData:=
 ; we do this here for illustration, but also for re-use later on (to save some time)
 ; CAREFUL: use correct number of subsets in name to avoid confusion
 
-subset sensitivity filenames:= sens_%d.hv
-recompute sensitivity := 1
+zoom := 1
+z zoom:=0.5
 
-xy output image size (in pixels) := -1
+XY output image size (in pixels):=128
+Z output image size (in pixels):=128 
+subset sensitivity filenames := sens_%d.hv
+recompute sensitivity := 1
+use subset sensitivities := 1
 end PoissonLogLikelihoodWithLinearModelForMeanAndProjData Parameters:=
 
 
 ; if you want to continue from a particular image
 ; initial estimate:= reconML.hv
 
-; Number of subsets should usually be a divisor of num_views/8
-; the following is an example for the Siemens mMR
-number of subsets:= 21
-number of subiterations:= 210
-save estimates at subiteration intervals:= 21
+output filename prefix := kosmaposl
+
+number of subsets:= 12
+number of subiterations:= 12
+save estimates at subiteration intervals:= 12
 
 END KOSMAPOSLParameters:=

--- a/src/include/stir/KOSMAPOSL/KOSMAPOSLReconstruction.h
+++ b/src/include/stir/KOSMAPOSL/KOSMAPOSLReconstruction.h
@@ -202,7 +202,7 @@ public:
   int num_neighbours,num_non_zero_feat,num_elem_neighbourhood,num_voxels,dimz,dimy,dimx;
   double sigma_m;
   bool only_2D;
-  bool hybrid;
+  bool hybrid, only_iterative_info;
   double sigma_p;
   double sigma_dp, sigma_dm;
 

--- a/src/include/stir/KOSMAPOSL/KOSMAPOSLReconstruction.h
+++ b/src/include/stir/KOSMAPOSL/KOSMAPOSLReconstruction.h
@@ -179,6 +179,7 @@ public:
   void set_sigma_dm(const double);
   void set_only_2D(const bool);
   void set_hybrid(const bool);
+  void set_only_iterative(const bool);
 
   //! boolean value to determine if the update images have to be written to disk
   void set_write_update_image(const int);

--- a/src/iterative/KOSMAPOSL/KOSMAPOSLReconstruction.cxx
+++ b/src/iterative/KOSMAPOSL/KOSMAPOSLReconstruction.cxx
@@ -219,7 +219,7 @@ post_processing()
      this->num_elem_neighbourhood=this->num_neighbours*this->num_neighbours ;
       }
 
-  if (this->only_iterative_info & !this->hybrid)
+  if ((this->only_iterative_info) && (!this->hybrid))
       error("If you choose to have only the iterative side information hybrid needs to be set as 1");
   if (!this->anatomical_image_filenames.empty()){
       this->anatomical_prior_sptr= (read_from_file<TargetT>(anatomical_image_filenames[0]));

--- a/src/iterative/KOSMAPOSL/KOSMAPOSLReconstruction.cxx
+++ b/src/iterative/KOSMAPOSL/KOSMAPOSLReconstruction.cxx
@@ -463,6 +463,13 @@ set_hybrid(const bool arg)
     this->hybrid = arg;
 }
 
+template <typename TargetT>
+void
+KOSMAPOSLReconstruction<TargetT>::
+set_only_iterative(const bool arg)
+{
+    this->only_iterative_info = arg;
+}
 /***************************************************************/
 // Here start the definition of few functions that calculate the SD of the anatomical image, a norm matrix and
 // finally the Kernelised image

--- a/src/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMeanAndListModeDataWithProjMatrixByBin.cxx
+++ b/src/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMeanAndListModeDataWithProjMatrixByBin.cxx
@@ -99,8 +99,8 @@ initialise_keymap()
   this->parser.add_key("max ring difference num to process", &this->max_ring_difference_num_to_process);
   this->parser.add_parsing_key("Matrix type", &this->PM_sptr); 
   this->parser.add_key("additive sinogram",&this->additive_projection_data_filename); 
- 
   this->parser.add_key("num_events_to_use",&this->num_events_to_use);
+
 } 
 template <typename TargetT> 
 int 
@@ -183,6 +183,10 @@ actual_subsets_are_approximately_balanced(std::string& warning_message) const
         }
         return true;
 }
+
+template <typename TargetT> void
+PoissonLogLikelihoodWithLinearModelForMeanAndListModeDataWithProjMatrixByBin<TargetT>::start_new_time_frame(const unsigned int)
+{}
 
 template <typename TargetT>  
 Succeeded 


### PR DESCRIPTION
solved issue #415 and #416: allowing HKEM to only use the iterative information. an example par file was added for PET and SPECT.
to only use the iterative information the user needs to:

    give the anatomical image (it will be filled with all zeros), or an empty image with the right dimensions and voxel sizes.
    set hybrid:=1
    set only_iterative_info:=1
    @ashgillman @HarryMarquis
