### PR TITLE
FIX: HKEM didn't respect `start at subiteration number`

### DIFF
--- a/recon_test_pack/KOSMAPOSL_test_consistency.par
+++ b/recon_test_pack/KOSMAPOSL_test_consistency.par
@@ -1,0 +1,86 @@
+KOSMAPOSLParameters :=
+
+disable output := 1
+hybrid := 0
+sigma_m := 1
+;sigma_p := 1  ; don't care, hybrid is false
+sigma_dm := 1
+;sigma_dp := 1  ; don't care, hybrid is false	
+number of neighbours := 1
+number of non-zero feature elements := 1
+; since nu
+anatomical image filenames := {RPTsens_seg4.hv}
+
+objective function type:= PoissonLogLikelihoodWithLinearModelForMeanAndProjData
+PoissonLogLikelihoodWithLinearModelForMeanAndProjData Parameters:=
+
+input file := Utahscat600k_ca_seg4.hs
+; if disabled, defaults to maximum segment number in the file
+maximum absolute segment number to process := 4
+zero end planes of segment 0:= 1
+
+projector pair type := Separate Projectors
+ projector pair using separate projectors parameters :=
+ forward projector type := Ray Tracing
+ forward projector using ray tracing parameters :=
+ end forward projector using ray tracing parameters := 
+ back projector type := Interpolation
+ back projector using interpolation parameters :=
+ end back projector using interpolation parameters := 
+end projector pair using separate projectors parameters := 
+
+;Bin Normalisation type:=None
+; change to STIR 2.x default for compatibility 
+use subset sensitivities:=0
+; if the next parameter is disabled, 
+; it default to an image full of 1s.
+; this will be wrong however
+sensitivity filename:= RPTsens_seg4.hv
+
+end PoissonLogLikelihoodWithLinearModelForMeanAndProjData Parameters:=
+
+kernelised output filename prefix := my_test_image_k0
+; if the next parameter is disabled, 
+; it default to an image full of 1s.
+; this funny value is just for testing if you can read an initial image
+initial estimate:= RPTsens_seg4.hv
+enforce initial positivity condition:=0
+
+number of subsets:= 12
+start at subset:= 1
+number of subiterations:= 5
+start at subiteration number:=2
+save estimates at subiteration intervals:= 3
+
+
+inter-update filter subiteration interval:= 4
+inter-update filter type := Separable Cartesian Metz
+Separable Cartesian Metz Filter Parameters :=
+x-dir filter FWHM (in mm):= 5
+y-dir filter FWHM (in mm):= 5
+z-dir filter FWHM (in mm):= 8
+x-dir filter Metz power:= 1.0
+y-dir filter Metz power:= 1.0
+z-dir filter Metz power:=1.0
+x-dir maximum kernel size := 129
+y-dir maximum kernel size := 129
+z-dir maximum kernel size := 31
+END Separable Cartesian Metz Filter Parameters :=
+
+inter-iteration filter subiteration interval:= 4
+inter-iteration filter type := Separable Cartesian Metz
+Separable Cartesian Metz Filter Parameters :=
+x-dir filter FWHM (in mm):= 6.0
+y-dir filter FWHM (in mm):= 6.0
+z-dir filter FWHM (in mm):= 6.0
+x-dir filter Metz power:= 2.0
+y-dir filter Metz power:= 2.0
+z-dir filter Metz power:= 2.0
+x-dir maximum kernel size := 129
+y-dir maximum kernel size := 129
+z-dir maximum kernel size := 31
+END Separable Cartesian Metz Filter Parameters :=
+
+
+
+END :=

--- a/recon_test_pack/run_tests.sh
+++ b/recon_test_pack/run_tests.sh
@@ -293,6 +293,23 @@ echo ------------- tests on stir_math and correct_projdata ---------
      ThereWereErrors=1;
    fi
 
+  echo
+  echo ------------- Running KOSMAPOSL consistency test ------------- 
+  echo "(a Kernel with no neighbourhood should be equivalent to OSMAPOSL)"
+  echo Running ${INSTALL_DIR}KOSMAPOSL
+  ${MPIRUN} ${INSTALL_DIR}KOSMAPOSL KOSMAPOSL_test_consistency.par 1> KOSMAPOSL_test.log 2> KOSMAPOSL_test_stderr.log
+
+  echo '---- Comparing output of KOSMAPOSL subiter 5 (should be identical up to tolerance)'
+  echo Running ${INSTALL_DIR}compare_image
+  if ${INSTALL_DIR}compare_image my_test_image_k0_5.hv test_image_5.hv;
+  then
+  echo ---- This test seems to be ok !;
+  else
+  echo There were problems here!;
+  ThereWereErrors=1;
+  fi
+
+
 echo
 echo '--------------- End of tests -------------'
 echo

--- a/src/iterative/KOSMAPOSL/KOSMAPOSLReconstruction.cxx
+++ b/src/iterative/KOSMAPOSL/KOSMAPOSLReconstruction.cxx
@@ -1026,17 +1026,18 @@ update_estimate(TargetT &current_alpha_coefficent_image)
     compute_kernelised_image (*kcurrent_ptr, current_alpha_coefficent_image,current_alpha_coefficent_image);
 
     //Write the emission image estimate:
-    subiteration_counter++;
     if((subiteration_counter)%this->save_interval==0){
 
         char itC[10];
-        sprintf (itC, "%d", subiteration_counter);
+        sprintf (itC, "%d", subiteration_counter + this->start_subiteration_num);
         std::string it=itC;
         std::string us="_";
         std::string k=".hv";
         this->current_kimage_filename =this->kernelised_output_filename_prefix+us+it+k;
 
-        write_to_file(this->current_kimage_filename,*kcurrent_ptr); }
+        write_to_file(this->current_kimage_filename,*kcurrent_ptr);
+    }
+    subiteration_counter++;
   }
   
 #ifndef PARALLEL


### PR DESCRIPTION
Added test for HKEM that using a neighbourhood of 1 is equivalent to OSEM.

This failed, because the recon_test_pack default test uses `start at subiteration number := 2` (not sure why, but a good test since it picked up an unknown bug).

Turns out KOSMAPOSLReconstructor doesn't use `start_subeteration_num` in it's caluclation - this fixes that.