### PR TITLE
Pursuing enhancement #458:

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -23,6 +23,10 @@ option(STIR_MPI
        "Compile with MPI" OFF)
 option(STIR_OPENMP 
        "Compile with OpenMP" OFF)
+option(STIR_OPENMP_MATRIX 
+       "Compile with OpenMP_MATRIX" OFF)
+option(STIR_OPENMP_PROJECTIONS 
+       "Compile with OpenMP_PROJECTIONS" ${STIR_OPENMP})
 
 option(BUILD_TESTING 
        "Build test programs" ON)

--- a/src/cmake/STIRConfig.h.in
+++ b/src/cmake/STIRConfig.h.in
@@ -69,6 +69,10 @@ namespace stir {
 
 #cmakedefine STIR_OPENMP
 
+#cmakedefine STIR_OPENMP_PROJECTIONS
+
+#cmakedefine STIR_OPENMP_MATRIX
+
 #cmakedefine STIR_MPI
 
 #cmakedefine STIR_USE_BOOST_SHARED_PTR

--- a/src/include/stir/recon_buildblock/BackProjectorByBin.h
+++ b/src/include/stir/recon_buildblock/BackProjectorByBin.h
@@ -197,7 +197,7 @@ protected:
 	    const int start_tang_pos_num,const int end_tang_pos_num,
 	    const int start_view, const int end_view);
 
-#ifdef STIR_OPENMP
+#ifdef STIR_OPENMP_PROJECTIONS
   //! A vector of back projected images that will be used with openMP. There will be as many images as openMP threads
   std::vector< shared_ptr<DiscretisedDensity<3,float> > > _local_output_image_sptrs;
 #endif

--- a/src/recon_buildblock/BackProjectorByBin.cxx
+++ b/src/recon_buildblock/BackProjectorByBin.cxx
@@ -40,7 +40,7 @@
 #include "stir/is_null_ptr.h"
 #include "stir/DataProcessor.h"
 #include <vector>
-#ifdef STIR_OPENMP
+#ifdef STIR_OPENMP_PROJECTIONS
 #include "stir/is_null_ptr.h"
 #include "stir/DiscretisedDensity.h"
 #include <omp.h>
@@ -84,7 +84,7 @@ set_up(const shared_ptr<ProjDataInfo>& proj_data_info_sptr,
   _proj_data_info_sptr = proj_data_info_sptr->create_shared_clone();
   _density_sptr.reset(density_info_sptr->clone());
 
-#ifdef STIR_OPENMP
+#ifdef STIR_OPENMP_PROJECTIONS
 #pragma omp parallel
     {
 #pragma omp single
@@ -199,18 +199,18 @@ BackProjectorByBin::back_project(const ProjData& proj_data, int subset_num, int 
                                          proj_data.get_min_segment_num(), proj_data.get_max_segment_num(),
                                          subset_num, num_subsets);
 
-#ifdef STIR_OPENMP
+#ifdef STIR_OPENMP_PROJECTIONS
 #pragma omp parallel shared(proj_data, symmetries_sptr)
 #endif
   {
-#ifdef STIR_OPENMP
+#ifdef STIR_OPENMP_PROJECTIONS
 #pragma omp for schedule(runtime)
 #endif
     // note: older versions of openmp need an int as loop
     for (int i=0; i<static_cast<int>(vs_nums_to_process.size()); ++i)
       {
         const ViewSegmentNumbers vs=vs_nums_to_process[i];
-#ifdef STIR_OPENMP
+#ifdef STIR_OPENMP_PROJECTIONS
         RelatedViewgrams<float> viewgrams;
 #pragma omp critical (BACKPROJECTORBYBIN_GETVIEWGRAMS)
         viewgrams = proj_data.get_related_viewgrams(vs, symmetries_sptr);
@@ -223,7 +223,7 @@ BackProjectorByBin::back_project(const ProjData& proj_data, int subset_num, int 
         back_project(viewgrams);
       }
   }
-#ifdef STIR_OPENMP
+#ifdef STIR_OPENMP_PROJECTIONS
   // "reduce" data constructed by threads
   {
     for (int i=0; i<static_cast<int>(_local_output_image_sptrs.size()); ++i)
@@ -268,7 +268,7 @@ back_project(const RelatedViewgrams<float>& viewgrams,
 
   start_timers();
 
-#ifdef STIR_OPENMP
+#ifdef STIR_OPENMP_PROJECTIONS
   const int thread_num=omp_get_thread_num();
   if(is_null_ptr(_local_output_image_sptrs[thread_num]))
     _local_output_image_sptrs[thread_num].reset(_density_sptr->get_empty_copy());
@@ -306,7 +306,7 @@ void
 BackProjectorByBin::
 start_accumulating_in_new_target()
 {
-#ifdef STIR_OPENMP
+#ifdef STIR_OPENMP_PROJECTIONS
   if (omp_get_num_threads()!=1)
       error("BackProjectorByBin::start_accumulating_in_new_target cannot be called inside a thread");
 
@@ -325,7 +325,7 @@ get_output(DiscretisedDensity<3,float> &density) const
     if (!density.has_same_characteristics(*_density_sptr))
             error("Images should have similar characteristics.");
 
-#ifdef STIR_OPENMP
+#ifdef STIR_OPENMP_PROJECTIONS
   if (omp_get_num_threads()!=1)
         error("BackProjectorByBin::get_output() cannot be called inside a thread");
 
@@ -373,7 +373,7 @@ actual_back_project(const RelatedViewgrams<float>& viewgrams,
                          const int min_tangential_pos_num, const int max_tangential_pos_num)
 {
     shared_ptr<DiscretisedDensity<3,float> > density_sptr = _density_sptr;
-#ifdef STIR_OPENMP
+#ifdef STIR_OPENMP_PROJECTIONS
     const int thread_num=omp_get_thread_num();
     density_sptr = _local_output_image_sptrs[thread_num];
 #endif

--- a/src/recon_buildblock/ForwardProjectorByBin.cxx
+++ b/src/recon_buildblock/ForwardProjectorByBin.cxx
@@ -202,7 +202,7 @@ ForwardProjectorByBin::forward_project(ProjData& proj_data,
     detail::find_basic_vs_nums_in_subset(*proj_data.get_proj_data_info_ptr(), *symmetries_sptr,
                                          proj_data.get_min_segment_num(), proj_data.get_max_segment_num(),
                                          subset_num, num_subsets);
-#ifdef STIR_OPENMP
+#ifdef STIR_OPENMP_PROJECTIONS
 #pragma omp parallel for  shared(proj_data, symmetries_sptr) schedule(runtime)
 #endif
     // note: older versions of openmp need an int as loop
@@ -215,7 +215,7 @@ ForwardProjectorByBin::forward_project(ProjData& proj_data,
       RelatedViewgrams<float> viewgrams =
         proj_data.get_empty_related_viewgrams(vs, symmetries_sptr);
       forward_project(viewgrams);
-#ifdef STIR_OPENMP
+#ifdef STIR_OPENMP_PROJECTIONS
 #pragma omp critical (FORWARDPROJ_SETVIEWGRAMS)
 #endif
       {

--- a/src/recon_buildblock/ProjMatrixByBinSPECTUB.cxx
+++ b/src/recon_buildblock/ProjMatrixByBinSPECTUB.cxx
@@ -41,7 +41,7 @@
 #include "stir/Coordinate3D.h"
 #include "stir/info.h"
 #include "stir/CPUTimer.h"
-#ifdef STIR_OPENMP
+#ifdef STIR_OPENMP_MATRIX
 #include "stir/num_threads.h"
 #endif
 
@@ -249,7 +249,7 @@ set_up(
 
   ProjMatrixByBin::set_up(proj_data_info_ptr_v, density_info_ptr);
 
-#ifdef STIR_OPENMP
+#ifdef STIR_OPENMP_MATRIX
   if (!this->keep_all_views_in_cache)
     {
       warning("SPECTUB matrix can currently only use single-threaded code unless all views are kept. Setting num_threads to 1");
@@ -856,7 +856,7 @@ calculate_proj_matrix_elems_for_one_bin(ProjMatrixElemsForOneBin& lor
       if (prj.order[kOS] == view_num)
 	break;
     }
-#ifdef STIR_OPENMP
+#ifdef STIR_OPENMP_MATRIX
 #pragma omp critical(PROJMATRIXBYBINUBONEVIEW)
 #endif
   if (!subset_already_processed[kOS])

--- a/src/recon_buildblock/distributable.cxx
+++ b/src/recon_buildblock/distributable.cxx
@@ -65,7 +65,7 @@
 #include "stir/recon_buildblock/distributed_test_functions.h"
 #include "stir/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMeanAndProjData.h" // needed for RPC functions
 #endif
-#ifdef STIR_OPENMP
+#ifdef STIR_OPENMP_PROJECTIONS
 #  ifdef STIR_MPI
 #    error Cannot use both OPENMP and MP
 #  endif
@@ -86,7 +86,7 @@ void setup_distributable_computation(
                                      const bool distributed_cache_enabled)
 {
   set_num_threads();
-#ifdef STIR_OPENMP
+#ifdef STIR_OPENMP_PROJECTIONS
   info(boost::format("Using distributable_computation with %d threads on %d processors.")
        % omp_get_max_threads() % omp_get_num_procs());
 #endif
@@ -178,7 +178,7 @@ void get_viewgrams(shared_ptr<RelatedViewgrams<float> >& y,
 {
   if (!is_null_ptr(binwise_correction))
     {
-#ifdef STIR_OPENMP
+#ifdef STIR_OPENMP_PROJECTIONS
 #pragma omp critical(ADDSINO)
 #endif
 #if !defined(_MSC_VER) || _MSC_VER>1300
@@ -194,7 +194,7 @@ void get_viewgrams(shared_ptr<RelatedViewgrams<float> >& y,
                         
   if (read_from_proj_dat)
     {
-#ifdef STIR_OPENMP
+#ifdef STIR_OPENMP_PROJECTIONS
 #pragma omp critical(VIEW)
 #endif
 #if !defined(_MSC_VER) || _MSC_VER>1300
@@ -219,7 +219,7 @@ void get_viewgrams(shared_ptr<RelatedViewgrams<float> >& y,
       mult_viewgrams_sptr.reset(
 				new RelatedViewgrams<float>(proj_dat_ptr->get_empty_related_viewgrams(view_segment_num, symmetries_ptr)));
       mult_viewgrams_sptr->fill(1.F);
-#ifdef STIR_OPENMP
+#ifdef STIR_OPENMP_PROJECTIONS
 #pragma omp critical(MULT)
 #endif
       normalisation_sptr->undo(*mult_viewgrams_sptr,start_time_of_frame,end_time_of_frame);
@@ -411,7 +411,7 @@ void distributable_computation(
   if (output_image_ptr != NULL)
     back_projector_ptr->start_accumulating_in_new_target();
 
-#ifdef STIR_OPENMP
+#ifdef STIR_OPENMP_PROJECTIONS
   std::vector<double> local_log_likelihoods;
   std::vector<int> local_counts, local_count2s;
 #pragma omp parallel shared(local_log_likelihoods, local_counts, local_count2s)
@@ -419,7 +419,7 @@ void distributable_computation(
 
   // start of threaded section if openmp
   { 
-#ifdef STIR_OPENMP
+#ifdef STIR_OPENMP_PROJECTIONS
 #pragma omp single
     {
       info(boost::format("Starting loop with %1% threads") % omp_get_num_threads());
@@ -469,7 +469,7 @@ void distributable_computation(
             }
 #else // STIR_MPI
 
-#ifdef STIR_OPENMP
+#ifdef STIR_OPENMP_PROJECTIONS
           const int thread_num=omp_get_thread_num();
           info(boost::format("Thread %d/%d calculating segment_num: %d, view_num: %d")
                % thread_num % omp_get_num_threads()
@@ -479,7 +479,7 @@ void distributable_computation(
                % view_segment_num.segment_num() % view_segment_num.view_num(), 2);
 #endif
 
-#ifdef STIR_OPENMP
+#ifdef STIR_OPENMP_PROJECTIONS
           RPC_process_related_viewgrams(forward_projector_ptr,
                                         back_projector_ptr,
                                         y.get(),
@@ -499,7 +499,7 @@ void distributable_computation(
       } // end of for-loop 
   } // end of parallel section of openmp
   
-#ifdef STIR_OPENMP
+#ifdef STIR_OPENMP_PROJECTIONS
   // "reduce" data constructed by threads
   {
     if (log_likelihood_ptr != NULL)


### PR DESCRIPTION
create an extra CMake variable, STIR_OPENMP_PROJECTIONS (set by default to STIR_OPENMP),
change the code in distributable.cxx, ForwardProjectorByBin.cxx etc to use that variable.

create another variable STIR_OPENMP_MATRIX (set by default to false) that enables then any projector parallelisations.
Parallelise SPECTUB matrix calculation (not working yet)