### PR TITLE
Convert most shared_ptr<DiscretisedDensity> arguments to shared_ptr<const...>

### DIFF
--- a/documentation/release_4.0.htm
+++ b/documentation/release_4.0.htm
@@ -439,8 +439,15 @@ from the above):</H2>
     <li><code>Object</code> has been renamed as <code>RegisteredObjectBase</code>. 
         This is because the class only exists for the parser to get information about the class.</li>
     <li>Classes that used<code>InterfilePDFSHeader</code> now contains a <code>shared_ptr&lt;ProjDataInfo&gt;</code> instead of a raw pointer.</li>
-    <li>Where possible, classes that internally contained a <code>shared_ptr&lt;ProjDataInfo&gt;</code> now contain a <code>shared_ptr&lt;const ProjDataInfo&gt;</code></li>
-    <li><code>get_proj_data_info_sptr</code> used to return <code>shared_ptr&lt;ProjDataInfo&gt;</code>, but now returns <code>shared_ptr&lt;const ProjDataInfo&gt;</code>.</li>
+    <li>Changes improving safety of use of <code>shared_ptr</code>:<br />
+      In the previous version of STIR, the use of <code>shared_ptr</code> allowed unsafe access to
+      the objects (although this never happened in distributed STIR code). We now prevent this with changes to the class interface (although there is still work to do):
+      <ul>
+        <li>Where possible, classes that internally contained a <code>shared_ptr&lt;ProjDataInfo&gt;</code> now contain a <code>shared_ptr&lt;const ProjDataInfo&gt;</code>, and similar for <code>DiscretisedDensity</code></li>
+        <li><code>get_proj_data_info_sptr</code> used to return <code>shared_ptr&lt;ProjDataInfo&gt;</code>, but now returns <code>shared_ptr&lt;const ProjDataInfo&gt;</code>.</li>
+	<li>Corresponding constructors and some functions, including <code>set_up</code>, that accept <code>shared_ptr</code> now take a <code>shared_ptr</code> to a <code>const</code> object.</li>
+      </ul>
+      </li>
   </ul>
 </li>
 </ul>

--- a/src/Shape_buildblock/DiscretisedShape3D.cxx
+++ b/src/Shape_buildblock/DiscretisedShape3D.cxx
@@ -35,9 +35,9 @@ void
 DiscretisedShape3D::
 set_origin(const CartesianCoordinate3D<float>& new_origin)
 { 
-  assert(this->get_origin() == density_ptr->get_origin());
+  assert(this->get_origin() == density_sptr->get_origin());
   Shape3D::set_origin(new_origin);
-  density_ptr->set_origin(new_origin);
+  density_sptr->set_origin(new_origin);
 }
 
 // TODO check code
@@ -48,11 +48,11 @@ get_voxel_weight(
                  const CartesianCoordinate3D<float>& voxel_size, 
                  const CartesianCoordinate3D<int>& num_samples) const
 {
-  assert(this->get_origin() == density_ptr->get_origin());
+  assert(this->get_origin() == density_sptr->get_origin());
 
   assert(voxel_size == image().get_voxel_size());
   const CartesianCoordinate3D<float> r = 
-    this->density_ptr->get_index_coordinates_for_physical_coordinates(voxel_centre);
+    this->density_sptr->get_index_coordinates_for_physical_coordinates(voxel_centre);
 
   const int x = round(r.x());
   const int y = round(r.y());
@@ -73,7 +73,7 @@ bool
 DiscretisedShape3D::
 is_inside_shape(const CartesianCoordinate3D<float>& coord) const
 {
-  assert(this->get_origin() == density_ptr->get_origin());
+  assert(this->get_origin() == density_sptr->get_origin());
   return 
     get_voxel_weight(coord, 
                      image().get_voxel_size(), 
@@ -91,7 +91,7 @@ Shape3D*
 DiscretisedShape3D::
 clone() const
 {
-  assert(this->get_origin() == density_ptr->get_origin());
+  assert(this->get_origin() == density_sptr->get_origin());
 
   return new DiscretisedShape3D(*this);
 }
@@ -100,14 +100,14 @@ DiscretisedDensity<3,float>&
 DiscretisedShape3D::
 get_discretised_density()
 {
-  return *density_ptr;
+  return *density_sptr;
 }
 
 const DiscretisedDensity<3,float>& 
 DiscretisedShape3D::
 get_discretised_density() const
 {
-  return *density_ptr;
+  return *density_sptr;
 }
 
 DiscretisedShape3D::
@@ -118,7 +118,7 @@ DiscretisedShape3D()
 
 DiscretisedShape3D::
 DiscretisedShape3D(const VoxelsOnCartesianGrid<float>& image_v)
-   : density_ptr(image_v.clone())
+   : density_sptr(image_v.clone())
 {
   this->set_origin(image_v.get_origin());
   this->filename = "FROM MEMORY";
@@ -127,14 +127,14 @@ DiscretisedShape3D(const VoxelsOnCartesianGrid<float>& image_v)
 
 
 DiscretisedShape3D::
-DiscretisedShape3D(const shared_ptr<const DiscretisedDensity<3,float> >& density_ptr_v)
-  : density_ptr(density_ptr_v->clone())
+DiscretisedShape3D(const shared_ptr<const DiscretisedDensity<3,float> >& density_sptr_v)
+  : density_sptr(density_sptr_v->clone())
 {
-  if(dynamic_cast<const VoxelsOnCartesianGrid<float> *>(density_ptr.get()) == NULL)
+  if(dynamic_cast<const VoxelsOnCartesianGrid<float> *>(density_sptr.get()) == NULL)
   {
     error("DiscretisedShape3D can currently only handle images of type VoxelsOnCartesianGrid.\n"); 
   }
-  this->set_origin(density_ptr_v->get_origin());
+  this->set_origin(density_sptr_v->get_origin());
   this->filename = "FROM MEMORY";
 }
 
@@ -163,16 +163,16 @@ post_processing()
   if (Shape3D::post_processing()==true)
     return true;
 
-  density_ptr = read_from_file<DiscretisedDensity<3,float> >(filename);
-  if (!is_null_ptr(density_ptr))
+  density_sptr = read_from_file<DiscretisedDensity<3,float> >(filename);
+  if (!is_null_ptr(density_sptr))
     {
-      if (this->get_origin() != density_ptr->get_origin())
+      if (this->get_origin() != density_sptr->get_origin())
 	{
 	  warning("DiscretisedShape3D: Shape3D::origin and image origin are inconsistent. Using origin from image\n");
-	  this->set_origin(density_ptr->get_origin());
+	  this->set_origin(density_sptr->get_origin());
 	}
     }
-  return is_null_ptr(density_ptr);
+  return is_null_ptr(density_sptr);
 }
 
 const char * const 

--- a/src/Shape_buildblock/DiscretisedShape3D.cxx
+++ b/src/Shape_buildblock/DiscretisedShape3D.cxx
@@ -127,10 +127,10 @@ DiscretisedShape3D(const VoxelsOnCartesianGrid<float>& image_v)
 
 
 DiscretisedShape3D::
-DiscretisedShape3D(const shared_ptr<DiscretisedDensity<3,float> >& density_ptr_v)
-   : density_ptr(density_ptr_v)
+DiscretisedShape3D(const shared_ptr<const DiscretisedDensity<3,float> >& density_ptr_v)
+  : density_ptr(density_ptr_v->clone())
 {
-  if(dynamic_cast<VoxelsOnCartesianGrid<float> *>(density_ptr.get()) == NULL)
+  if(dynamic_cast<const VoxelsOnCartesianGrid<float> *>(density_ptr.get()) == NULL)
   {
     error("DiscretisedShape3D can currently only handle images of type VoxelsOnCartesianGrid.\n"); 
   }

--- a/src/experimental/recon_buildblock/PostsmoothingForwardProjectorByBin.cxx
+++ b/src/experimental/recon_buildblock/PostsmoothingForwardProjectorByBin.cxx
@@ -115,7 +115,7 @@ PostsmoothingForwardProjectorByBin(
 void
 PostsmoothingForwardProjectorByBin::
 set_up(const shared_ptr<const ProjDataInfo>& proj_data_info_ptr,
-       const shared_ptr<DiscretisedDensity<3,float> >& image_info_ptr)
+       const shared_ptr<const DiscretisedDensity<3,float> >& image_info_ptr)
 {
   original_forward_projector_ptr->set_up(proj_data_info_ptr, image_info_ptr);
 }

--- a/src/include/stir/Shape/DiscretisedShape3D.h
+++ b/src/include/stir/Shape/DiscretisedShape3D.h
@@ -73,12 +73,8 @@ public:
       returns somewhat useful info. This has a consequence that the object cannot
       be constructed from its own parameter_info(). This is in contrast with most
       other shapes.
-
-      \warning any modifications to the object that this shared_ptr points to
-      (and hence any modifications to this shape) will have
-      confusing consequences.
   */
-  DiscretisedShape3D(const shared_ptr<DiscretisedDensity<3,float> >& density_ptr);
+  DiscretisedShape3D(const shared_ptr<const DiscretisedDensity<3,float> >& density_ptr);
 
   //! Compare shapes
   /*! \todo currently not implemented (will call error() */
@@ -155,7 +151,7 @@ private:
   shared_ptr<DiscretisedDensity<3,float> > density_ptr;
   
   inline const VoxelsOnCartesianGrid<float>& image() const;
-  inline VoxelsOnCartesianGrid<float>& image();
+  // inline VoxelsOnCartesianGrid<float>& image();
 
   //! \name Parsing functions
   //@{

--- a/src/include/stir/Shape/DiscretisedShape3D.h
+++ b/src/include/stir/Shape/DiscretisedShape3D.h
@@ -74,7 +74,7 @@ public:
       be constructed from its own parameter_info(). This is in contrast with most
       other shapes.
   */
-  DiscretisedShape3D(const shared_ptr<const DiscretisedDensity<3,float> >& density_ptr);
+  DiscretisedShape3D(const shared_ptr<const DiscretisedDensity<3,float> >& density_sptr);
 
   //! Compare shapes
   /*! \todo currently not implemented (will call error() */
@@ -83,21 +83,7 @@ public:
   { error("DiscretisedShape3D::operator== not implemented. Sorry"); return false;}
 
   //! set origin of the shape
-  /*! \warning this will shift the origin of the object pointed to by \a density_ptr.
-     This is dangerous if you used the constructor taking a shared_ptr argument.*/
   virtual void set_origin(const CartesianCoordinate3D<float>&);
-
-#ifdef DOXYGEN_SKIP
-  // following lines here are only read by doxygen. 
-  // They include a comment to warn the user. 
-  // In actual fact, the function does not need to be reimplemented as it uses set_origin()
-  //! translate the object by shifting its origin
-  /*! \warning this will shift the origin of the object pointed to by \a density_ptr as it uses set_origin().
-      \warning This function is in fact not reimplemented from the
-      base_type.
-  */
-  void translate(const CartesianCoordinate3D<float>& direction);
-#endif
 
   //! Scale shape
   /*! \todo Not implemented (will call error()) */
@@ -148,7 +134,7 @@ public:
  const DiscretisedDensity<3,float>& get_discretised_density() const;
   
 private:
-  shared_ptr<DiscretisedDensity<3,float> > density_ptr;
+  shared_ptr<DiscretisedDensity<3,float> > density_sptr;
   
   inline const VoxelsOnCartesianGrid<float>& image() const;
   // inline VoxelsOnCartesianGrid<float>& image();

--- a/src/include/stir/Shape/DiscretisedShape3D.inl
+++ b/src/include/stir/Shape/DiscretisedShape3D.inl
@@ -36,11 +36,12 @@ image() const
   return static_cast<const VoxelsOnCartesianGrid<float>&>(*density_ptr);
 }
  
+#if 0
 VoxelsOnCartesianGrid<float>& 
 DiscretisedShape3D::
 image()
 {
-  return static_cast<VoxelsOnCartesianGrid<float>&>(*density_ptr);
+  return static_cast<const VoxelsOnCartesianGrid<float>&>(*density_ptr);
 }
-
+#endif
 END_NAMESPACE_STIR

--- a/src/include/stir/Shape/DiscretisedShape3D.inl
+++ b/src/include/stir/Shape/DiscretisedShape3D.inl
@@ -33,7 +33,7 @@ const VoxelsOnCartesianGrid<float>&
 DiscretisedShape3D::
 image() const
 {
-  return static_cast<const VoxelsOnCartesianGrid<float>&>(*density_ptr);
+  return static_cast<const VoxelsOnCartesianGrid<float>&>(*density_sptr);
 }
  
 #if 0
@@ -41,7 +41,7 @@ VoxelsOnCartesianGrid<float>&
 DiscretisedShape3D::
 image()
 {
-  return static_cast<const VoxelsOnCartesianGrid<float>&>(*density_ptr);
+  return static_cast<const VoxelsOnCartesianGrid<float>&>(*density_sptr);
 }
 #endif
 END_NAMESPACE_STIR

--- a/src/include/stir/recon_buildblock/BackProjectorByBin.h
+++ b/src/include/stir/recon_buildblock/BackProjectorByBin.h
@@ -74,7 +74,7 @@ public:
   */
  virtual void set_up(		 
     const shared_ptr<const ProjDataInfo>& proj_data_info_ptr,
-    const shared_ptr<DiscretisedDensity<3,float> >& density_info_sptr // TODO should be Info only
+    const shared_ptr<const DiscretisedDensity<3,float> >& density_info_sptr // TODO should be Info only
     ) =0;
 
   /*! \brief Informs on which symmetries the projector handles

--- a/src/include/stir/recon_buildblock/BackProjectorByBinUsingInterpolation.h
+++ b/src/include/stir/recon_buildblock/BackProjectorByBinUsingInterpolation.h
@@ -148,7 +148,7 @@ public:
   /*! \deprecated Use set_up() instead */
   BackProjectorByBinUsingInterpolation(
     shared_ptr<const ProjDataInfo>const&,
-    shared_ptr<DiscretisedDensity<3,float> > const& image_info_ptr,
+    shared_ptr<const DiscretisedDensity<3,float> > const& image_info_ptr,
     const bool use_piecewise_linear_interpolation = true, const bool use_exact_Jacobian = true);
 
   //! Stores all necessary geometric info
@@ -156,7 +156,7 @@ public:
   */
   virtual void set_up(		 
     const shared_ptr<const ProjDataInfo>& proj_data_info_ptr,
-    const shared_ptr<DiscretisedDensity<3,float> >& density_info_ptr // TODO should be Info only
+    const shared_ptr<const DiscretisedDensity<3,float> >& density_info_ptr // TODO should be Info only
     );
 
   /*! \brief Gets the symmetries used by this backprojector

--- a/src/include/stir/recon_buildblock/BackProjectorByBinUsingProjMatrixByBin.h
+++ b/src/include/stir/recon_buildblock/BackProjectorByBinUsingProjMatrixByBin.h
@@ -72,7 +72,7 @@ public:
   */
   virtual void set_up(		 
     const shared_ptr<const ProjDataInfo>& proj_data_info_ptr,
-    const shared_ptr<DiscretisedDensity<3,float> >& density_info_ptr // TODO should be Info only
+    const shared_ptr<const DiscretisedDensity<3,float> >& density_info_ptr // TODO should be Info only
     );
 	 
   const DataSymmetriesForViewSegmentNumbers * get_symmetries_used() const;

--- a/src/include/stir/recon_buildblock/BackProjectorByBinUsingSquareProjMatrixByBin.h
+++ b/src/include/stir/recon_buildblock/BackProjectorByBinUsingSquareProjMatrixByBin.h
@@ -62,7 +62,7 @@ public:
 
    virtual void set_up(		 
     const shared_ptr<const ProjDataInfo>& proj_data_info_ptr,
-    const shared_ptr<DiscretisedDensity<3,float> >& density_info_ptr // TODO should be Info only
+    const shared_ptr<const DiscretisedDensity<3,float> >& density_info_ptr // TODO should be Info only
     );
 
 

--- a/src/include/stir/recon_buildblock/BinNormalisationFromAttenuationImage.h
+++ b/src/include/stir/recon_buildblock/BinNormalisationFromAttenuationImage.h
@@ -84,7 +84,7 @@ public:
   /*! Default forward projector is ForwardProjectorByBinUsingRayTracing.
       The image pointed to by attenuation_image_ptr is NOT modified.
   */
-  BinNormalisationFromAttenuationImage(shared_ptr<DiscretisedDensity<3,float> > const& attenuation_image_ptr,
+  BinNormalisationFromAttenuationImage(const shared_ptr<const DiscretisedDensity<3,float> >& attenuation_image_ptr,
                                        shared_ptr<ForwardProjectorByBin> const& = shared_ptr<ForwardProjectorByBin>());
 
   //! Checks if we can handle certain projection data.
@@ -110,7 +110,7 @@ public:
   virtual float get_bin_efficiency(const Bin& bin,const double start_time, const double end_time) const; 
 
 private:
-  shared_ptr<DiscretisedDensity<3,float> > attenuation_image_ptr;
+  shared_ptr<const DiscretisedDensity<3,float> > attenuation_image_ptr;
   shared_ptr<ForwardProjectorByBin> forward_projector_ptr;
 
   // parsing stuff

--- a/src/include/stir/recon_buildblock/DataSymmetriesForBins_PET_CartesianGrid.h
+++ b/src/include/stir/recon_buildblock/DataSymmetriesForBins_PET_CartesianGrid.h
@@ -89,7 +89,7 @@ public:
       views is not a multiple of 4.
   */    
   DataSymmetriesForBins_PET_CartesianGrid(const shared_ptr<const ProjDataInfo>& proj_data_info_ptr,
-                                          const shared_ptr<DiscretisedDensity<3,float> >& image_info_ptr,
+                                          const shared_ptr<const DiscretisedDensity<3,float> >& image_info_ptr,
                                           const bool do_symmetry_90degrees_min_phi = true,
                                           const bool do_symmetry_180degrees_min_phi = true,
 					  const bool do_symmetry_swap_segment = true,
@@ -184,7 +184,7 @@ private:
   // at the moment, we don't need the following 2 members
 
   // TODO somehow store only the info
-  shared_ptr<DiscretisedDensity<3,float> > image_info_ptr;
+  shared_ptr<constDiscretisedDensity<3,float> > image_info_ptr;
 
   // a convenience function that does the dynamic_cast from the above
   inline const DiscretisedDensityOnCartesianGrid<3,float> *

--- a/src/include/stir/recon_buildblock/FilterRootPrior.h
+++ b/src/include/stir/recon_buildblock/FilterRootPrior.h
@@ -107,7 +107,7 @@ public:
 			const DataT &current_estimate);
 
   //! Has to be called before using this object
-  virtual Succeeded set_up(shared_ptr<DataT> const& target_sptr);
+  virtual Succeeded set_up(shared_ptr<const DataT> const& target_sptr);
   
 protected:
 

--- a/src/include/stir/recon_buildblock/ForwardProjectorByBin.h
+++ b/src/include/stir/recon_buildblock/ForwardProjectorByBin.h
@@ -75,7 +75,7 @@ public:
   */
 virtual void set_up(		 
     const shared_ptr<const ProjDataInfo>& proj_data_info_ptr,
-    const shared_ptr<DiscretisedDensity<3,float> >& density_info_sptr // TODO should be Info only
+    const shared_ptr<const DiscretisedDensity<3,float> >& density_info_sptr // TODO should be Info only
     ) =0;
 
   //! Informs on which symmetries the projector handles

--- a/src/include/stir/recon_buildblock/ForwardProjectorByBinUsingProjMatrixByBin.h
+++ b/src/include/stir/recon_buildblock/ForwardProjectorByBinUsingProjMatrixByBin.h
@@ -73,7 +73,7 @@ public:
   */
   virtual void set_up(		 
     const shared_ptr<const ProjDataInfo>& proj_data_info_ptr,
-    const shared_ptr<DiscretisedDensity<3,float> >& density_info_ptr // TODO should be Info only
+    const shared_ptr<const DiscretisedDensity<3,float> >& density_info_ptr // TODO should be Info only
     );
 
   

--- a/src/include/stir/recon_buildblock/ForwardProjectorByBinUsingRayTracing.h
+++ b/src/include/stir/recon_buildblock/ForwardProjectorByBinUsingRayTracing.h
@@ -91,13 +91,13 @@ public:
   /*! \warning Obsolete */
   ForwardProjectorByBinUsingRayTracing(
                        const shared_ptr<const ProjDataInfo>&,
-                       const shared_ptr<DiscretisedDensity<3,float> >&);
+                       const shared_ptr<const DiscretisedDensity<3,float> >&);
   //! Stores all necessary geometric info
   /*! Note that the density_info_ptr is not stored in this object. It's only used to get some info on sizes etc.
   */
   virtual void set_up(		 
     const shared_ptr<const ProjDataInfo>& proj_data_info_ptr,
-    const shared_ptr<DiscretisedDensity<3,float> >& density_info_ptr // TODO should be Info only
+    const shared_ptr<const DiscretisedDensity<3,float> >& density_info_ptr // TODO should be Info only
     );
 
   virtual const DataSymmetriesForViewSegmentNumbers * get_symmetries_used() const;

--- a/src/include/stir/recon_buildblock/GeneralisedPrior.h
+++ b/src/include/stir/recon_buildblock/GeneralisedPrior.h
@@ -81,7 +81,7 @@ public:
 
   //! Has to be called before using this object
   virtual Succeeded 
-    set_up(shared_ptr<DataT> const& target_sptr);
+    set_up(shared_ptr<const DataT> const& target_sptr);
 
 protected:
   float penalisation_factor;

--- a/src/include/stir/recon_buildblock/PLSPrior.h
+++ b/src/include/stir/recon_buildblock/PLSPrior.h
@@ -127,7 +127,7 @@ class PLSPrior:  public
 
   //! Has to be called before using this object
   /*! \todo set the anatomical image to zero if not defined */
-  virtual Succeeded set_up(shared_ptr<DiscretisedDensity<3,elemT> > const& target_sptr);
+  virtual Succeeded set_up(shared_ptr<const DiscretisedDensity<3,elemT> > const& target_sptr);
 
   //! compute the value of the function
   double
@@ -142,9 +142,9 @@ class PLSPrior:  public
       modify the image by manipulating the image refered to by this pointer.
       Unpredictable results will occur.
   */
-  shared_ptr<DiscretisedDensity<3,elemT> > get_kappa_sptr() const;
-  shared_ptr<DiscretisedDensity<3,elemT> > get_anatomical_grad_sptr(int direction) const;
-  shared_ptr<DiscretisedDensity<3,elemT> > get_norm_sptr() const;
+  shared_ptr<const DiscretisedDensity<3,elemT> > get_kappa_sptr() const;
+  shared_ptr<const DiscretisedDensity<3,elemT> > get_anatomical_grad_sptr(int direction) const;
+  shared_ptr<const DiscretisedDensity<3,elemT> > get_norm_sptr() const;
 
   //!get eta and alpha parameters
   double get_eta() const;
@@ -156,14 +156,14 @@ class PLSPrior:  public
   void set_alpha(const double);
 
   //! set anatomical pointer
-  void set_anatomical_image_sptr(const shared_ptr<DiscretisedDensity<3,elemT> >&);
+  void set_anatomical_image_sptr(const shared_ptr<const DiscretisedDensity<3,elemT> >&);
   //! get anatomical pointer
-  shared_ptr<DiscretisedDensity<3,elemT> > get_anatomical_image_sptr() const;
+  shared_ptr<const DiscretisedDensity<3,elemT> > get_anatomical_image_sptr() const;
   /// Set anatomical filename
   void set_anatomical_filename(const std::string& filename);
 
   //! set kappa image
-  void set_kappa_sptr(const shared_ptr<DiscretisedDensity<3,elemT> >&);
+  void set_kappa_sptr(const shared_ptr<const DiscretisedDensity<3,elemT> >&);
   /// Set kappa filename
   void set_kappa_filename(const std::string& filename);
 
@@ -218,14 +218,14 @@ protected:
                                          DiscretisedDensity<3,elemT> &pet_im_grad_x,
                         const DiscretisedDensity<3,elemT> &pet_image);
 
-  shared_ptr<DiscretisedDensity<3,elemT> > anatomical_grad_x_sptr;
-  shared_ptr<DiscretisedDensity<3,elemT> > anatomical_grad_y_sptr;
-  shared_ptr<DiscretisedDensity<3,elemT> > anatomical_grad_z_sptr;
-  shared_ptr<DiscretisedDensity<3,elemT> > anatomical_sptr;
-  shared_ptr<DiscretisedDensity<3,elemT> > norm_sptr;
-  shared_ptr<DiscretisedDensity<3,elemT> > kappa_ptr;
-  void set_anatomical_grad_sptr(const shared_ptr<DiscretisedDensity<3,elemT> >&, int);
-  void set_anatomical_grad_norm_sptr(const shared_ptr<DiscretisedDensity<3,elemT> >&);
+  shared_ptr<const DiscretisedDensity<3,elemT> > anatomical_grad_x_sptr;
+  shared_ptr<const DiscretisedDensity<3,elemT> > anatomical_grad_y_sptr;
+  shared_ptr<const DiscretisedDensity<3,elemT> > anatomical_grad_z_sptr;
+  shared_ptr<const DiscretisedDensity<3,elemT> > anatomical_sptr;
+  shared_ptr<const DiscretisedDensity<3,elemT> > norm_sptr;
+  shared_ptr<const DiscretisedDensity<3,elemT> > kappa_ptr;
+  void set_anatomical_grad_sptr(const shared_ptr<const DiscretisedDensity<3,elemT> >&, int);
+  void set_anatomical_grad_norm_sptr(const shared_ptr<const DiscretisedDensity<3,elemT> >&);
   };
 
 

--- a/src/include/stir/recon_buildblock/PoissonLogLikelihoodWithLinearKineticModelAndDynamicProjectionData.h
+++ b/src/include/stir/recon_buildblock/PoissonLogLikelihoodWithLinearKineticModelAndDynamicProjectionData.h
@@ -88,7 +88,7 @@ public  RegisteredParsingObject<PoissonLogLikelihoodWithLinearKineticModelAndDyn
     actual_compute_objective_function_without_penalty(const TargetT& current_estimate,
                                                       const int subset_num);
 
-  virtual Succeeded set_up_before_sensitivity(shared_ptr <TargetT> const& target_sptr);
+  virtual Succeeded set_up_before_sensitivity(shared_ptr <const TargetT> const& target_sptr);
 
   //! Add subset sensitivity to existing data
   /*! \todo Current implementation does NOT add to the subset sensitivity, but overwrites

--- a/src/include/stir/recon_buildblock/PoissonLogLikelihoodWithLinearKineticModelAndDynamicProjectionData.txx
+++ b/src/include/stir/recon_buildblock/PoissonLogLikelihoodWithLinearKineticModelAndDynamicProjectionData.txx
@@ -291,7 +291,7 @@ set_num_subsets(const int num_subsets)
 template<typename TargetT>
 Succeeded 
 PoissonLogLikelihoodWithLinearKineticModelAndDynamicProjectionData<TargetT>::
-set_up_before_sensitivity(shared_ptr<TargetT > const& target_sptr)
+set_up_before_sensitivity(shared_ptr<const TargetT > const& target_sptr)
 {
   if (this->_max_segment_num_to_process==-1)
     this->_max_segment_num_to_process =

--- a/src/include/stir/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMean.h
+++ b/src/include/stir/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMean.h
@@ -263,7 +263,7 @@ public  GeneralisedObjectiveFunction<TargetT>
 protected:
   //! set-up specifics for the derived class 
   virtual Succeeded 
-    set_up_before_sensitivity(shared_ptr<TargetT > const& target_sptr) = 0;
+    set_up_before_sensitivity(shared_ptr<const TargetT > const& target_sptr) = 0;
 
   //! compute subset and total sensitivity
   /*! This function fills in the sensitivity data by calling add_subset_sensitivity()

--- a/src/include/stir/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMeanAndGatedProjDataWithMotion.h
+++ b/src/include/stir/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMeanAndGatedProjDataWithMotion.h
@@ -96,7 +96,7 @@ public  RegisteredParsingObject<PoissonLogLikelihoodWithLinearModelForMeanAndGat
     actual_compute_objective_function_without_penalty(const TargetT& current_estimate,
 						      const int subset_num);
 
-  virtual Succeeded set_up_before_sensitivity(shared_ptr <TargetT> const& target_sptr);
+  virtual Succeeded set_up_before_sensitivity(shared_ptr <const TargetT> const& target_sptr);
 
   //! Add subset sensitivity to existing data
   virtual void

--- a/src/include/stir/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMeanAndGatedProjDataWithMotion.txx
+++ b/src/include/stir/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMeanAndGatedProjDataWithMotion.txx
@@ -343,7 +343,7 @@ set_normalisation_sptr(const shared_ptr<BinNormalisation>& arg)
 template<typename TargetT>
 Succeeded 
 PoissonLogLikelihoodWithLinearModelForMeanAndGatedProjDataWithMotion<TargetT>::
-set_up_before_sensitivity(shared_ptr<TargetT > const& target_sptr)
+set_up_before_sensitivity(shared_ptr<const TargetT > const& target_sptr)
 {
   /*!todo define in the PoissonLogLikelihoodWithLinearModelForMean class to return Succeeded::yes 
     if (base_type::set_up_before_sensitivity(target_sptr) != Succeeded::yes)

--- a/src/include/stir/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMeanAndListModeDataWithProjMatrixByBin.h
+++ b/src/include/stir/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMeanAndListModeDataWithProjMatrixByBin.h
@@ -93,7 +93,7 @@ protected:
   }
 
   virtual Succeeded 
-    set_up_before_sensitivity(shared_ptr <TargetT > const& target_sptr); 
+    set_up_before_sensitivity(shared_ptr <const TargetT > const& target_sptr); 
  
   virtual void
     add_subset_sensitivity(TargetT& sensitivity, const int subset_num) const;

--- a/src/include/stir/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMeanAndProjData.h
+++ b/src/include/stir/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMeanAndProjData.h
@@ -234,7 +234,7 @@ public:
 
  protected:
   virtual Succeeded 
-    set_up_before_sensitivity(shared_ptr <TargetT > const& target_sptr);
+    set_up_before_sensitivity(shared_ptr <const TargetT > const& target_sptr);
 
   virtual double
     actual_compute_objective_function_without_penalty(const TargetT& current_estimate,

--- a/src/include/stir/recon_buildblock/PostsmoothingBackProjectorByBin.h
+++ b/src/include/stir/recon_buildblock/PostsmoothingBackProjectorByBin.h
@@ -73,7 +73,7 @@ public:
   */
   virtual void set_up(           
                       const shared_ptr<const ProjDataInfo>& proj_data_info_ptr,
-                      const shared_ptr<DiscretisedDensity<3,float> >& density_info_ptr // TODO should be Info only
+                      const shared_ptr<const DiscretisedDensity<3,float> >& density_info_ptr // TODO should be Info only
     );
 
 

--- a/src/include/stir/recon_buildblock/PresmoothingForwardProjectorByBin.h
+++ b/src/include/stir/recon_buildblock/PresmoothingForwardProjectorByBin.h
@@ -71,7 +71,7 @@ public:
   */
   virtual void set_up(           
                       const shared_ptr<const ProjDataInfo>& proj_data_info_ptr,
-                      const shared_ptr<DiscretisedDensity<3,float> >& density_info_ptr // TODO should be Info only
+                      const shared_ptr<const DiscretisedDensity<3,float> >& density_info_ptr // TODO should be Info only
     );
 
 

--- a/src/include/stir/recon_buildblock/ProjMatrixByBin.h
+++ b/src/include/stir/recon_buildblock/ProjMatrixByBin.h
@@ -102,7 +102,7 @@ public:
   */
   virtual void set_up(
     const shared_ptr<const ProjDataInfo>& proj_data_info_ptr,
-    const shared_ptr<DiscretisedDensity<3,float> >& density_info_ptr // TODO should be Info only
+    const shared_ptr<const DiscretisedDensity<3,float> >& density_info_ptr // TODO should be Info only
   ) = 0;
 
   //! get a pointer to an object encoding all symmetries that are used by this ProjMatrixByBin

--- a/src/include/stir/recon_buildblock/ProjMatrixByBinFromFile.h
+++ b/src/include/stir/recon_buildblock/ProjMatrixByBinFromFile.h
@@ -105,7 +105,7 @@ static Succeeded
   //! Checks all necessary geometric info
   virtual void set_up(		 
 		      const shared_ptr<const ProjDataInfo>& proj_data_info_ptr,
-    const shared_ptr<DiscretisedDensity<3,float> >& density_info_ptr // TODO should be Info only
+		      const shared_ptr<const DiscretisedDensity<3,float> >& density_info_ptr // TODO should be Info only
     );
 
 private:

--- a/src/include/stir/recon_buildblock/ProjMatrixByBinSPECTUB.h
+++ b/src/include/stir/recon_buildblock/ProjMatrixByBinSPECTUB.h
@@ -104,7 +104,7 @@ class ProjMatrixByBinSPECTUB :
   //! Checks all necessary geometric info
   virtual void set_up(		 
 		      const shared_ptr<const ProjDataInfo>& proj_data_info_ptr,
-                      const shared_ptr<DiscretisedDensity<3,float> >& density_info_ptr // TODO should be Info only
+                      const shared_ptr<const DiscretisedDensity<3,float> >& density_info_ptr // TODO should be Info only
                       );
 
   bool get_keep_all_views_in_cache() const;

--- a/src/include/stir/recon_buildblock/ProjMatrixByBinUsingInterpolation.h
+++ b/src/include/stir/recon_buildblock/ProjMatrixByBinUsingInterpolation.h
@@ -75,7 +75,7 @@ public :
   */
   virtual void set_up(		 
 		      const shared_ptr<const ProjDataInfo>& proj_data_info_ptr,
-    const shared_ptr<DiscretisedDensity<3,float> >& density_info_ptr // TODO should be Info only
+		      const shared_ptr<const DiscretisedDensity<3,float> >& density_info_ptr // TODO should be Info only
     );
 
 private:

--- a/src/include/stir/recon_buildblock/ProjMatrixByBinUsingRayTracing.h
+++ b/src/include/stir/recon_buildblock/ProjMatrixByBinUsingRayTracing.h
@@ -137,7 +137,7 @@ public :
   */
   virtual void set_up(		 
     const shared_ptr<const ProjDataInfo>& proj_data_info_ptr,
-    const shared_ptr<DiscretisedDensity<3,float> >& density_info_ptr // TODO should be Info only
+    const shared_ptr<const DiscretisedDensity<3,float> >& density_info_ptr // TODO should be Info only
     );
 
   //! \name If a cylindrical FOV or the whole image will be handled

--- a/src/include/stir/recon_buildblock/ProjectorByBinPair.h
+++ b/src/include/stir/recon_buildblock/ProjectorByBinPair.h
@@ -70,7 +70,7 @@ public:
   virtual Succeeded
     set_up(		 
 	   const shared_ptr<const ProjDataInfo>&,
-	   const shared_ptr<DiscretisedDensity<3,float> >& // TODO should be Info only
+	   const shared_ptr<const DiscretisedDensity<3,float> >& // TODO should be Info only
     );
 
 
@@ -113,7 +113,7 @@ protected:
   shared_ptr<const ProjDataInfo> _proj_data_info_sptr;
   //! The density ptr set with set_up()
   /*! \todo it is wasteful to have to store the whole image as this uses memory that we don't need. */
-  shared_ptr<DiscretisedDensity<3,float> > _density_info_sptr;
+  shared_ptr<const DiscretisedDensity<3,float> > _density_info_sptr;
 };
 
 END_NAMESPACE_STIR

--- a/src/include/stir/recon_buildblock/ProjectorByBinPairUsingProjMatrixByBin.h
+++ b/src/include/stir/recon_buildblock/ProjectorByBinPairUsingProjMatrixByBin.h
@@ -64,7 +64,7 @@ public:
   /*! First constructs forward and back projectors and then calls base_type::setup */
   virtual Succeeded set_up(		 
     const shared_ptr<const ProjDataInfo>& proj_data_info_sptr,
-    const shared_ptr<DiscretisedDensity<3,float> >& density_info_sptr // TODO should be Info only
+    const shared_ptr<const DiscretisedDensity<3,float> >& density_info_sptr // TODO should be Info only
     );
 
   ProjMatrixByBin const * 

--- a/src/include/stir/recon_buildblock/QuadraticPrior.h
+++ b/src/include/stir/recon_buildblock/QuadraticPrior.h
@@ -144,13 +144,13 @@ class QuadraticPrior:  public
       modify the image by manipulating the image refered to by this pointer.
       Unpredictable results will occur.
   */
-  shared_ptr<DiscretisedDensity<3,elemT> > get_kappa_sptr() const;
+  shared_ptr<const DiscretisedDensity<3,elemT> > get_kappa_sptr() const;
 
   //! set kappa image
-  void set_kappa_sptr(const shared_ptr<DiscretisedDensity<3,elemT> >&);
+  void set_kappa_sptr(const shared_ptr<const DiscretisedDensity<3,elemT> >&);
 
   //! Has to be called before using this object
-  virtual Succeeded set_up(shared_ptr<DiscretisedDensity<3,elemT> > const& target_sptr);
+  virtual Succeeded set_up(shared_ptr<const DiscretisedDensity<3,elemT> > const& target_sptr);
   
 protected:
   //! can be set during parsing to restrict the weights to the 2D case
@@ -178,7 +178,7 @@ protected:
   virtual void initialise_keymap();
   virtual bool post_processing();
  private:
-  shared_ptr<DiscretisedDensity<3,elemT> > kappa_ptr;
+  shared_ptr<const DiscretisedDensity<3,elemT> > kappa_ptr;
 };
 
 

--- a/src/include/stir/recon_buildblock/distributable.h
+++ b/src/include/stir/recon_buildblock/distributable.h
@@ -72,7 +72,7 @@ void setup_distributable_computation(
                                      const shared_ptr<ProjectorByBinPair>& proj_pair_sptr,
                                      const shared_ptr<ExamInfo>& exam_info_sptr,
                                      const shared_ptr<const ProjDataInfo> proj_data_info_sptr,
-                                     const shared_ptr<DiscretisedDensity<3,float> >& target_sptr,
+                                     const shared_ptr<const DiscretisedDensity<3,float> >& target_sptr,
                                      const bool zero_seg0_end_planes,
                                      const bool distributed_cache_enabled);
 

--- a/src/include/stir_experimental/recon_buildblock/DataSymmetriesForDensels_PET_CartesianGrid.h
+++ b/src/include/stir_experimental/recon_buildblock/DataSymmetriesForDensels_PET_CartesianGrid.h
@@ -59,7 +59,7 @@ private:
 public:
 
   DataSymmetriesForDensels_PET_CartesianGrid(const shared_ptr<const ProjDataInfo>& proj_data_info_ptr,
-                                            const shared_ptr<DiscretisedDensity<3,float> >& image_info_ptr);
+					     const shared_ptr<const DiscretisedDensity<3,float> >& image_info_ptr);
 
 
   virtual 
@@ -122,7 +122,7 @@ private:
   // at the moment, we don't need the following 2 members
 
   // TODO somehow store only the info
-  shared_ptr<DiscretisedDensity<3,float> > image_info_ptr;
+  shared_ptr<const DiscretisedDensity<3,float> > image_info_ptr;
 
   // a convenience function that does the dynamic_cast from the above
   inline const DiscretisedDensityOnCartesianGrid<3,float> *

--- a/src/include/stir_experimental/recon_buildblock/ParametricQuadraticPrior.h
+++ b/src/include/stir_experimental/recon_buildblock/ParametricQuadraticPrior.h
@@ -157,7 +157,7 @@ class ParametricQuadraticPrior:  public
   void set_kappa_sptr(const shared_ptr<TargetT >&);
 
   //! Has to be called before using this object
-  virtual Succeeded set_up(shared_ptr<DiscretisedDensity<3,elemT> > const& target_sptr);
+  virtual Succeeded set_up(shared_ptr<const DiscretisedDensity<3,elemT> > const& target_sptr);
   
 protected:
   //! can be set during parsing to restrict the weights to the 2D case

--- a/src/include/stir_experimental/recon_buildblock/PostsmoothingForwardProjectorByBin.h
+++ b/src/include/stir_experimental/recon_buildblock/PostsmoothingForwardProjectorByBin.h
@@ -48,7 +48,7 @@ public:
   */
   virtual void set_up(		 
 		      const shared_ptr<const ProjDataInfo>& proj_data_info_ptr,
-                      const shared_ptr<DiscretisedDensity<3,float> >& density_info_ptr // TODO should be Info only
+                      const shared_ptr<const DiscretisedDensity<3,float> >& density_info_ptr // TODO should be Info only
     );
 
 

--- a/src/include/stir_experimental/recon_buildblock/ProjMatrixByBinSinglePhoton.h
+++ b/src/include/stir_experimental/recon_buildblock/ProjMatrixByBinSinglePhoton.h
@@ -57,7 +57,7 @@ public :
   */
   virtual void set_up(		 
 		      const shared_ptr<const ProjDataInfo>& proj_data_info_ptr,
-    const shared_ptr<DiscretisedDensity<3,float> >& density_info_ptr // TODO should be Info only
+		      const shared_ptr<const DiscretisedDensity<3,float> >& density_info_ptr // TODO should be Info only
     );
 
 private:

--- a/src/include/stir_experimental/recon_buildblock/ProjMatrixByBinUsingSolidAngle.h
+++ b/src/include/stir_experimental/recon_buildblock/ProjMatrixByBinUsingSolidAngle.h
@@ -54,7 +54,7 @@ public :
   */
   virtual void set_up(		 
 		      const shared_ptr<const ProjDataInfo>& proj_data_info_ptr,
-    const shared_ptr<DiscretisedDensity<3,float> >& density_info_ptr // TODO should be Info only
+		      const shared_ptr<const DiscretisedDensity<3,float> >& density_info_ptr // TODO should be Info only
     );
 
 private:

--- a/src/include/stir_experimental/recon_buildblock/ProjMatrixByBinWithPositronRange.h
+++ b/src/include/stir_experimental/recon_buildblock/ProjMatrixByBinWithPositronRange.h
@@ -54,7 +54,7 @@ public :
   */
   virtual void set_up(		 
 		      const shared_ptr<const ProjDataInfo>& proj_data_info_ptr,
-    const shared_ptr<DiscretisedDensity<3,float> >& density_info_ptr // TODO should be Info only
+		      const shared_ptr<const DiscretisedDensity<3,float> >& density_info_ptr // TODO should be Info only
     );
 
 private:

--- a/src/include/stir_experimental/recon_buildblock/ProjMatrixByDensel.h
+++ b/src/include/stir_experimental/recon_buildblock/ProjMatrixByDensel.h
@@ -65,7 +65,7 @@ public:
   */
   virtual void set_up(
     const shared_ptr<const ProjDataInfo>& proj_data_info_ptr,
-    const shared_ptr<DiscretisedDensity<3,float> >& density_info_ptr // TODO should be Info only
+    const shared_ptr<const DiscretisedDensity<3,float> >& density_info_ptr // TODO should be Info only
   ) = 0;
 
   //! get a pointer to an object encoding all symmetries that are used by this ProjMatrixByDensel

--- a/src/include/stir_experimental/recon_buildblock/ProjMatrixByDenselOnCartesianGridUsingElement.h
+++ b/src/include/stir_experimental/recon_buildblock/ProjMatrixByDenselOnCartesianGridUsingElement.h
@@ -67,7 +67,7 @@ public :
   */
   virtual void set_up(		 
     const shared_ptr<const ProjDataInfo>& proj_data_info_ptr,
-    const shared_ptr<DiscretisedDensity<3,float> >& density_info_ptr // TODO should be Info only
+    const shared_ptr<const DiscretisedDensity<3,float> >& density_info_ptr // TODO should be Info only
     );
 
   //! this member computes a single element of the projection matrix

--- a/src/include/stir_experimental/recon_buildblock/ProjMatrixByDenselUsingRayTracing.h
+++ b/src/include/stir_experimental/recon_buildblock/ProjMatrixByDenselUsingRayTracing.h
@@ -71,7 +71,7 @@ public :
   */
   virtual void set_up(		 
     const shared_ptr<const ProjDataInfo>& proj_data_info_ptr,
-    const shared_ptr<DiscretisedDensity<3,float> >& density_info_ptr // TODO should be Info only
+    const shared_ptr<const DiscretisedDensity<3,float> >& density_info_ptr // TODO should be Info only
     );
 
   virtual const  DataSymmetriesForDensels* get_symmetries_ptr() const;

--- a/src/recon_buildblock/BackProjectorByBin.cxx
+++ b/src/recon_buildblock/BackProjectorByBin.cxx
@@ -78,7 +78,7 @@ initialise_keymap()
 void
 BackProjectorByBin::
 set_up(const shared_ptr<const ProjDataInfo>& proj_data_info_sptr, 
-       const shared_ptr<DiscretisedDensity<3,float> >& density_info_sptr)
+       const shared_ptr<const DiscretisedDensity<3,float> >& density_info_sptr)
 {
   _already_set_up = true;
   _proj_data_info_sptr = proj_data_info_sptr->create_shared_clone();

--- a/src/recon_buildblock/BackProjectorByBinUsingInterpolation.cxx
+++ b/src/recon_buildblock/BackProjectorByBinUsingInterpolation.cxx
@@ -120,7 +120,7 @@ BackProjectorByBinUsingInterpolation(const bool use_piecewise_linear_interpolati
 
 BackProjectorByBinUsingInterpolation::
 BackProjectorByBinUsingInterpolation(shared_ptr<const ProjDataInfo> const& proj_data_info_ptr,
-				     shared_ptr<DiscretisedDensity<3,float> > const& image_info_ptr,
+				     shared_ptr<const DiscretisedDensity<3,float> > const& image_info_ptr,
 				     const bool use_piecewise_linear_interpolation,
                                      const bool use_exact_Jacobian)
 {
@@ -132,7 +132,7 @@ BackProjectorByBinUsingInterpolation(shared_ptr<const ProjDataInfo> const& proj_
 
 void
 BackProjectorByBinUsingInterpolation::set_up(shared_ptr<const ProjDataInfo> const& proj_data_info_ptr,
-				     shared_ptr<DiscretisedDensity<3,float> > const& image_info_ptr)
+				     shared_ptr<const DiscretisedDensity<3,float> > const& image_info_ptr)
 {
   BackProjectorByBin::set_up(proj_data_info_ptr, image_info_ptr);
   this->symmetries_ptr.

--- a/src/recon_buildblock/BackProjectorByBinUsingProjMatrixByBin.cxx
+++ b/src/recon_buildblock/BackProjectorByBinUsingProjMatrixByBin.cxx
@@ -105,7 +105,7 @@ BackProjectorByBinUsingProjMatrixByBin(
 void
 BackProjectorByBinUsingProjMatrixByBin::
 set_up(const shared_ptr<const ProjDataInfo>& proj_data_info_ptr,
-       const shared_ptr<DiscretisedDensity<3,float> >& image_info_ptr)
+       const shared_ptr<const DiscretisedDensity<3,float> >& image_info_ptr)
 
 {
   BackProjectorByBin::set_up(proj_data_info_ptr, image_info_ptr);

--- a/src/recon_buildblock/BackProjectorByBinUsingSquareProjMatrixByBin.cxx
+++ b/src/recon_buildblock/BackProjectorByBinUsingSquareProjMatrixByBin.cxx
@@ -133,7 +133,7 @@ BackProjectorByBinUsingSquareProjMatrixByBin()
 void
 BackProjectorByBinUsingSquareProjMatrixByBin::
 set_up(const shared_ptr<const ProjDataInfo>& proj_data_info_ptr,
-       const shared_ptr<DiscretisedDensity<3,float> >& image_info_ptr)
+       const shared_ptr<const DiscretisedDensity<3,float> >& image_info_ptr)
 
 {
   BackProjectorByBin::set_up(proj_data_info_ptr, image_info_ptr);

--- a/src/recon_buildblock/BinNormalisationFromAttenuationImage.cxx
+++ b/src/recon_buildblock/BinNormalisationFromAttenuationImage.cxx
@@ -89,13 +89,15 @@ post_processing()
   // projectors work in pixel units, so convert attenuation data 
   // from cm^-1 to pixel_units^-1
   const float rescale = 
-    dynamic_cast<DiscretisedDensityOnCartesianGrid<3,float> *>(attenuation_image_ptr.get())->
+    dynamic_cast<DiscretisedDensityOnCartesianGrid<3,float> const &>(*attenuation_image_ptr).
     get_grid_spacing()[3]/10;
 #else
   const float rescale = 
     0.1F;
 #endif
-  *attenuation_image_ptr *= rescale;
+  shared_ptr<DiscretisedDensity<3,float> > new_sptr(attenuation_image_ptr->clone());
+  *new_sptr *= rescale;
+  attenuation_image_ptr = new_sptr;
 
   return false;
 }
@@ -118,7 +120,7 @@ BinNormalisationFromAttenuationImage(const std::string& filename,
 }
 
 BinNormalisationFromAttenuationImage::
-BinNormalisationFromAttenuationImage(shared_ptr<DiscretisedDensity<3,float> > const& attenuation_image_ptr_v,
+BinNormalisationFromAttenuationImage(shared_ptr<const DiscretisedDensity<3,float> > const& attenuation_image_ptr_v,
                                      shared_ptr<ForwardProjectorByBin> const& forward_projector_ptr)
   : attenuation_image_ptr(attenuation_image_ptr_v->clone()), // need a clone as it guarantees we won't be affected by the caller, and vice versa
     forward_projector_ptr(forward_projector_ptr)

--- a/src/recon_buildblock/DataSymmetriesForBins_PET_CartesianGrid.cxx
+++ b/src/recon_buildblock/DataSymmetriesForBins_PET_CartesianGrid.cxx
@@ -124,7 +124,7 @@ DataSymmetriesForBins_PET_CartesianGrid::
 DataSymmetriesForBins_PET_CartesianGrid
 (
  const shared_ptr<const ProjDataInfo>& proj_data_info_ptr,
- const shared_ptr<DiscretisedDensity<3,float> >& image_info_ptr,
+ const shared_ptr<const DiscretisedDensity<3,float> >& image_info_ptr,
  const bool do_symmetry_90degrees_min_phi_v,
  const bool do_symmetry_180degrees_min_phi_v,
  const bool do_symmetry_swap_segment_v,

--- a/src/recon_buildblock/FilterRootPrior.cxx
+++ b/src/recon_buildblock/FilterRootPrior.cxx
@@ -163,7 +163,7 @@ FilterRootPrior<DataT>::set_defaults()
 
 template <typename DataT>
 Succeeded
-FilterRootPrior<DataT>::set_up (shared_ptr<DataT> const& target_sptr)
+FilterRootPrior<DataT>::set_up (shared_ptr<const DataT> const& target_sptr)
 {
   base_type::set_up(target_sptr);
 

--- a/src/recon_buildblock/ForwardProjectorByBin.cxx
+++ b/src/recon_buildblock/ForwardProjectorByBin.cxx
@@ -79,11 +79,11 @@ initialise_keymap()
 void
 ForwardProjectorByBin::
 set_up(const shared_ptr<const ProjDataInfo>& proj_data_info_sptr, 
-       const shared_ptr<DiscretisedDensity<3,float> >& density_info_sptr)
+       const shared_ptr<const DiscretisedDensity<3,float> >& density_info_sptr)
 {
   _already_set_up = true;
   _proj_data_info_sptr = proj_data_info_sptr->create_shared_clone();
-  _density_sptr = density_info_sptr;
+  _density_sptr.reset(density_info_sptr->clone());
 }
 
 void

--- a/src/recon_buildblock/ForwardProjectorByBinUsingProjMatrixByBin.cxx
+++ b/src/recon_buildblock/ForwardProjectorByBinUsingProjMatrixByBin.cxx
@@ -103,7 +103,7 @@ ForwardProjectorByBinUsingProjMatrixByBin(
 void
 ForwardProjectorByBinUsingProjMatrixByBin::
 set_up(const shared_ptr<const ProjDataInfo>& proj_data_info_ptr,
-       const shared_ptr<DiscretisedDensity<3,float> >& image_info_ptr)
+       const shared_ptr<const DiscretisedDensity<3,float> >& image_info_ptr)
 {    	   
   ForwardProjectorByBin::set_up(proj_data_info_ptr, image_info_ptr);
   proj_matrix_ptr->set_up(proj_data_info_ptr, image_info_ptr);

--- a/src/recon_buildblock/ForwardProjectorByBinUsingRayTracing.cxx
+++ b/src/recon_buildblock/ForwardProjectorByBinUsingRayTracing.cxx
@@ -106,7 +106,7 @@ ForwardProjectorByBinUsingRayTracing::
 ForwardProjectorByBinUsingRayTracing::
   ForwardProjectorByBinUsingRayTracing(
 				   const shared_ptr<const ProjDataInfo>& proj_data_info_sptr,
-                                   const shared_ptr<DiscretisedDensity<3,float> >& image_info_ptr)
+                                   const shared_ptr<const DiscretisedDensity<3,float> >& image_info_ptr)
 {
   set_defaults();
   set_up(proj_data_info_sptr, image_info_ptr);
@@ -115,7 +115,7 @@ ForwardProjectorByBinUsingRayTracing::
 void
 ForwardProjectorByBinUsingRayTracing::
 set_up(const shared_ptr<const ProjDataInfo>& proj_data_info_sptr,
-       const shared_ptr<DiscretisedDensity<3,float> >& image_info_ptr)
+       const shared_ptr<const DiscretisedDensity<3,float> >& image_info_ptr)
 {
   ForwardProjectorByBin::set_up(proj_data_info_sptr, image_info_ptr);
   

--- a/src/recon_buildblock/GeneralisedPrior.cxx
+++ b/src/recon_buildblock/GeneralisedPrior.cxx
@@ -53,7 +53,7 @@ GeneralisedPrior<TargetT>::set_defaults()
 template <typename TargetT>
 Succeeded 
 GeneralisedPrior<TargetT>::
-set_up(shared_ptr<TargetT> const&)
+set_up(shared_ptr<const TargetT> const&)
 {
   _already_set_up = true;
   return Succeeded::yes;

--- a/src/recon_buildblock/PLSPrior.cxx
+++ b/src/recon_buildblock/PLSPrior.cxx
@@ -62,7 +62,7 @@ PLSPrior<elemT>::initialise_keymap()
 
 template <typename elemT>
 Succeeded
-PLSPrior<elemT>::set_up (shared_ptr<DiscretisedDensity<3,elemT> > const& target_sptr)
+PLSPrior<elemT>::set_up (shared_ptr<const DiscretisedDensity<3,elemT> > const& target_sptr)
 {
     base_type::set_up(target_sptr);
 
@@ -97,7 +97,7 @@ PLSPrior<elemT>::set_up (shared_ptr<DiscretisedDensity<3,elemT> > const& target_
 
     compute_normalisation_anatomical_gradient (*norm_sptr,*anatomical_im_grad_z_sptr,*anatomical_im_grad_y_sptr,*anatomical_im_grad_x_sptr );
 
-    this->set_anatomical_grad_norm_sptr (shared_ptr<DiscretisedDensity<3,elemT> >(norm_sptr));
+    this->set_anatomical_grad_norm_sptr (shared_ptr<const DiscretisedDensity<3,elemT> >(norm_sptr));
 
 return Succeeded::yes;
 }
@@ -162,7 +162,7 @@ PLSPrior<elemT>::PLSPrior(const bool only_2D_v, float penalisation_factor_v)
 }
 
 template <typename elemT>
-shared_ptr<DiscretisedDensity<3,elemT> >
+shared_ptr<const DiscretisedDensity<3,elemT> >
 PLSPrior<elemT>::
 get_anatomical_grad_sptr(int direction) const{
 
@@ -181,14 +181,14 @@ get_anatomical_grad_sptr(int direction) const{
 }
 
 template <typename elemT>
-shared_ptr<DiscretisedDensity<3,elemT> >
+shared_ptr<const DiscretisedDensity<3,elemT> >
 PLSPrior<elemT>::
 get_norm_sptr () const{
 return this->norm_sptr;
 }
 
 template <typename elemT>
-shared_ptr<DiscretisedDensity<3,elemT> >
+shared_ptr<const DiscretisedDensity<3,elemT> >
 PLSPrior<elemT>::
 get_anatomical_image_sptr() const{
 return this->anatomical_sptr;
@@ -211,7 +211,7 @@ return this->alpha;
 template <typename elemT>
 void
 PLSPrior<elemT>::
-set_anatomical_image_sptr (const shared_ptr<DiscretisedDensity<3,elemT> >& arg)
+set_anatomical_image_sptr (const shared_ptr<const DiscretisedDensity<3,elemT> >& arg)
 {
     this->anatomical_sptr = arg;
     this->anatomical_filename = ""; // Clear filename in case it was set.
@@ -231,7 +231,7 @@ set_alpha (const double arg)
 
 template <typename elemT>
 void
-PLSPrior<elemT>::set_anatomical_grad_sptr(const shared_ptr<DiscretisedDensity<3,elemT> >& arg, int direction){
+PLSPrior<elemT>::set_anatomical_grad_sptr(const shared_ptr<const DiscretisedDensity<3,elemT> >& arg, int direction){
 
     if(direction==2){
         this->anatomical_grad_x_sptr=arg;}
@@ -245,7 +245,7 @@ PLSPrior<elemT>::set_anatomical_grad_sptr(const shared_ptr<DiscretisedDensity<3,
 
 template <typename elemT>
 void
-PLSPrior<elemT>::set_anatomical_grad_norm_sptr (const shared_ptr<DiscretisedDensity<3,elemT> >& arg){
+PLSPrior<elemT>::set_anatomical_grad_norm_sptr (const shared_ptr<const DiscretisedDensity<3,elemT> >& arg){
 
 
         this->norm_sptr=arg;
@@ -257,7 +257,7 @@ PLSPrior<elemT>::set_anatomical_grad_norm_sptr (const shared_ptr<DiscretisedDens
       Unpredictable results will occur.
   */
 template <typename elemT>
-shared_ptr<DiscretisedDensity<3,elemT> >
+shared_ptr<const DiscretisedDensity<3,elemT> >
 PLSPrior<elemT>::
 get_kappa_sptr() const
 { return this->kappa_ptr; }
@@ -266,7 +266,7 @@ get_kappa_sptr() const
 template <typename elemT>
 void
 PLSPrior<elemT>::
-set_kappa_sptr(const shared_ptr<DiscretisedDensity<3,elemT> >& k)
+set_kappa_sptr(const shared_ptr<const DiscretisedDensity<3,elemT> >& k)
 {
     this->kappa_ptr = k;
     kappa_filename = ""; // Clear filename in case it was set.

--- a/src/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMeanAndListModeDataWithProjMatrixByBin.cxx
+++ b/src/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMeanAndListModeDataWithProjMatrixByBin.cxx
@@ -188,7 +188,7 @@ actual_subsets_are_approximately_balanced(std::string& warning_message) const
 template <typename TargetT>  
 Succeeded 
 PoissonLogLikelihoodWithLinearModelForMeanAndListModeDataWithProjMatrixByBin<TargetT>::
-set_up_before_sensitivity(shared_ptr <TargetT > const& target_sptr) 
+set_up_before_sensitivity(shared_ptr <const TargetT > const& target_sptr) 
 { 
 #ifdef STIR_MPI
     //broadcast objective_function (100=PoissonLogLikelihoodWithLinearModelForMeanAndListModeDataWithProjMatrixByBin)

--- a/src/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMeanAndProjData.cxx
+++ b/src/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMeanAndProjData.cxx
@@ -531,7 +531,7 @@ actual_subsets_are_approximately_balanced(std::string& warning_message) const
 template<typename TargetT>
 Succeeded 
 PoissonLogLikelihoodWithLinearModelForMeanAndProjData<TargetT>::
-set_up_before_sensitivity(shared_ptr<TargetT > const& target_sptr)
+set_up_before_sensitivity(shared_ptr<const TargetT > const& target_sptr)
 {
   if (is_null_ptr(this->proj_data_sptr))
 	error("you need to set the input data before calling set_up");

--- a/src/recon_buildblock/PostsmoothingBackProjectorByBin.cxx
+++ b/src/recon_buildblock/PostsmoothingBackProjectorByBin.cxx
@@ -89,7 +89,7 @@ PostsmoothingBackProjectorByBin::
 void
 PostsmoothingBackProjectorByBin::
 set_up(const shared_ptr<const ProjDataInfo>& proj_data_info_ptr,
-       const shared_ptr<DiscretisedDensity<3,float> >& image_info_ptr)
+       const shared_ptr<const DiscretisedDensity<3,float> >& image_info_ptr)
 {
   BackProjectorByBin::set_up(proj_data_info_ptr, image_info_ptr);
   original_back_projector_ptr->set_up(proj_data_info_ptr, image_info_ptr);

--- a/src/recon_buildblock/PresmoothingForwardProjectorByBin.cxx
+++ b/src/recon_buildblock/PresmoothingForwardProjectorByBin.cxx
@@ -90,7 +90,7 @@ PresmoothingForwardProjectorByBin::
 void
 PresmoothingForwardProjectorByBin::
 set_up(const shared_ptr<const ProjDataInfo>& proj_data_info_ptr,
-       const shared_ptr<DiscretisedDensity<3,float> >& image_info_ptr)
+       const shared_ptr<const DiscretisedDensity<3,float> >& image_info_ptr)
 {
   ForwardProjectorByBin::set_up(proj_data_info_ptr, image_info_ptr);
   original_forward_projector_ptr->set_up(proj_data_info_ptr, image_info_ptr);

--- a/src/recon_buildblock/ProjMatrixByBin.cxx
+++ b/src/recon_buildblock/ProjMatrixByBin.cxx
@@ -121,7 +121,7 @@ void
 ProjMatrixByBin::
 set_up(   
     const shared_ptr<const ProjDataInfo>& proj_data_info_sptr,
-    const shared_ptr<DiscretisedDensity<3,float> >& /*density_info_ptr*/ // TODO should be Info only
+    const shared_ptr<const DiscretisedDensity<3,float> >& /*density_info_ptr*/ // TODO should be Info only
     )
 {
   const int min_view_num = proj_data_info_sptr->get_min_view_num();

--- a/src/recon_buildblock/ProjMatrixByBinFromFile.cxx
+++ b/src/recon_buildblock/ProjMatrixByBinFromFile.cxx
@@ -187,7 +187,7 @@ void
 ProjMatrixByBinFromFile::
 set_up(		 
     const shared_ptr<const ProjDataInfo>& proj_data_info_ptr_v,
-    const shared_ptr<DiscretisedDensity<3,float> >& density_info_ptr // TODO should be Info only
+    const shared_ptr<const DiscretisedDensity<3,float> >& density_info_ptr // TODO should be Info only
     )
 {
 

--- a/src/recon_buildblock/ProjMatrixByBinSPECTUB.cxx
+++ b/src/recon_buildblock/ProjMatrixByBinSPECTUB.cxx
@@ -243,7 +243,7 @@ void
 ProjMatrixByBinSPECTUB::
 set_up(		 
     const shared_ptr<const ProjDataInfo>& proj_data_info_ptr_v,
-    const shared_ptr<DiscretisedDensity<3,float> >& density_info_ptr // TODO should be Info only
+    const shared_ptr<const DiscretisedDensity<3,float> >& density_info_ptr // TODO should be Info only
     )
 {
 

--- a/src/recon_buildblock/ProjMatrixByBinUsingInterpolation.cxx
+++ b/src/recon_buildblock/ProjMatrixByBinUsingInterpolation.cxx
@@ -109,7 +109,7 @@ void
 ProjMatrixByBinUsingInterpolation::
 set_up(		 
     const shared_ptr<const ProjDataInfo>& proj_data_info_ptr_v,
-    const shared_ptr<DiscretisedDensity<3,float> >& density_info_ptr // TODO should be Info only
+    const shared_ptr<const DiscretisedDensity<3,float> >& density_info_ptr // TODO should be Info only
     )
 {
   ProjMatrixByBin::set_up(proj_data_info_ptr_v, density_info_ptr);

--- a/src/recon_buildblock/ProjMatrixByBinUsingRayTracing.cxx
+++ b/src/recon_buildblock/ProjMatrixByBinUsingRayTracing.cxx
@@ -268,7 +268,7 @@ void
 ProjMatrixByBinUsingRayTracing::
 set_up(          
     const shared_ptr<const ProjDataInfo>& proj_data_info_ptr_v,
-    const shared_ptr<DiscretisedDensity<3,float> >& density_info_ptr // TODO should be Info only
+    const shared_ptr<const DiscretisedDensity<3,float> >& density_info_ptr // TODO should be Info only
     )
 {
   ProjMatrixByBin::set_up(proj_data_info_ptr_v, density_info_ptr);

--- a/src/recon_buildblock/ProjectorByBinPair.cxx
+++ b/src/recon_buildblock/ProjectorByBinPair.cxx
@@ -46,7 +46,7 @@ ProjectorByBinPair()
 Succeeded
 ProjectorByBinPair::
 set_up(const shared_ptr<const ProjDataInfo>& proj_data_info_sptr,
-       const shared_ptr<DiscretisedDensity<3,float> >& image_info_sptr)
+       const shared_ptr<const DiscretisedDensity<3,float> >& image_info_sptr)
 
 {    	 
   _already_set_up = true;

--- a/src/recon_buildblock/ProjectorByBinPairUsingProjMatrixByBin.cxx
+++ b/src/recon_buildblock/ProjectorByBinPairUsingProjMatrixByBin.cxx
@@ -87,7 +87,7 @@ ProjectorByBinPairUsingProjMatrixByBin(
 Succeeded
 ProjectorByBinPairUsingProjMatrixByBin::
 set_up(const shared_ptr<const ProjDataInfo>& proj_data_info_sptr,
-       const shared_ptr<DiscretisedDensity<3,float> >& image_info_sptr)
+       const shared_ptr<const DiscretisedDensity<3,float> >& image_info_sptr)
 {    	 
   // proj_matrix_sptr->set_up()  not needed as the projection matrix will be set_up indirectly by
   // the forward_projector->set_up (which is called in the base class)

--- a/src/recon_buildblock/QuadraticPrior.cxx
+++ b/src/recon_buildblock/QuadraticPrior.cxx
@@ -112,7 +112,7 @@ QuadraticPrior<elemT>::post_processing()
 
 template <typename elemT>
 Succeeded
-QuadraticPrior<elemT>::set_up (shared_ptr<DiscretisedDensity<3,elemT> > const& target_sptr)
+QuadraticPrior<elemT>::set_up (shared_ptr<const DiscretisedDensity<3,elemT> > const& target_sptr)
 {
   base_type::set_up(target_sptr);
 
@@ -176,7 +176,7 @@ set_weights(const Array<3,float>& w)
       Unpredictable results will occur.
   */
 template <typename elemT>
-shared_ptr<DiscretisedDensity<3,elemT> >  
+shared_ptr<const DiscretisedDensity<3,elemT> >  
 QuadraticPrior<elemT>::
 get_kappa_sptr() const
 { return this->kappa_ptr; }
@@ -185,7 +185,7 @@ get_kappa_sptr() const
 template <typename elemT>
 void 
 QuadraticPrior<elemT>::
-set_kappa_sptr(const shared_ptr<DiscretisedDensity<3,elemT> >& k)
+set_kappa_sptr(const shared_ptr<const DiscretisedDensity<3,elemT> >& k)
 { this->kappa_ptr = k; }
 
 

--- a/src/recon_buildblock/distributable.cxx
+++ b/src/recon_buildblock/distributable.cxx
@@ -81,7 +81,7 @@ void setup_distributable_computation(
                                      const shared_ptr<ProjectorByBinPair>& proj_pair_sptr,
                                      const shared_ptr<ExamInfo>& exam_info_sptr,
                                      const shared_ptr<const ProjDataInfo> proj_data_info_sptr,
-                                     const shared_ptr<DiscretisedDensity<3,float> >& target_sptr,
+                                     const shared_ptr<const DiscretisedDensity<3,float> >& target_sptr,
                                      const bool zero_seg0_end_planes,
                                      const bool distributed_cache_enabled)
 {

--- a/src/swig/stir.i
+++ b/src/swig/stir.i
@@ -1268,7 +1268,6 @@ namespace stir {
 
 %ignore *::get_scanner_sptr;
 %rename (get_scanner) *::get_scanner_ptr;
-%ignore *::get_proj_data_info_sptr;
 %rename (get_proj_data_info) *::get_proj_data_info_sptr;
 %ignore *::get_exam_info_ptr;
 %ignore *::get_exam_info_sptr; // we do have get_exam_info in C++


### PR DESCRIPTION
This increases safety, similar to #470