### PR TITLE
Change treatment of vectorised keys in KeyParser

### DIFF
--- a/documentation/release_4.0.htm
+++ b/documentation/release_4.0.htm
@@ -440,6 +440,10 @@ from the above):</H2>
         This is because the class only exists for the parser to get information about the class.</li>
   </ul>
 </li>
+ <li><code>KeyParser</code> <a href="https://github.com/UCL/STIR/pull/490">has changed</a> to be safer for
+   parsing of vectorised keys. However, the &quot;simple&quot; <code>add_key</code>
+   functions now create non-vectorised keys. Use <code>add_vectorised_key</code> otherwise.
+   </li>
 </ul>
 
 <h3>New functionality</h3>

--- a/src/IO/InterfileHeader.cxx
+++ b/src/IO/InterfileHeader.cxx
@@ -2,7 +2,7 @@
     Copyright (C) 2000 PARAPET partners
     Copyright (C) 2000 - 2009-04-30, Hammersmith Imanet Ltd
     Copyright (C) 2011-07-01 - 2012, Kris Thielemans
-    Copyright (C) 2013, 2016, 2018 University College London
+    Copyright (C) 2013, 2016, 2018, 2020 University College London
     This file is part of STIR.
 
     This file is free software; you can redistribute it and/or modify
@@ -79,8 +79,7 @@ MinimalInterfileHeader::MinimalInterfileHeader()
   add_key("version of keys", &version_of_keys);
 
   // support for siemens interfile
-  add_key("%sms-mi version number",
-    KeyArgument::ASCII, &siemens_mi_version);
+  add_key("%sms-mi version number", &siemens_mi_version);
   add_stop_key("END OF INTERFILE");
 }
 
@@ -158,14 +157,10 @@ InterfileHeader::InterfileHeader()
   lower_en_window_thres = -1.f;
   upper_en_window_thres = -1.f;
 
-  add_key("name of data file", 
-    KeyArgument::ASCII,	&data_file_name);
-  add_key("originating system",
-    KeyArgument::ASCII, &exam_info_sptr->originating_system);
-  add_key("GENERAL DATA", 
-    KeyArgument::NONE,	&KeyParser::do_nothing);
-  add_key("GENERAL IMAGE DATA", 
-    KeyArgument::NONE,	&KeyParser::do_nothing);
+  add_key("name of data file", &data_file_name);
+  add_key("originating system", &exam_info_sptr->originating_system);
+  ignore_key("GENERAL DATA");
+  ignore_key("GENERAL IMAGE DATA");
   add_key("type of data", 
           KeyArgument::ASCIIlist,
           (KeywordProcessor)&InterfileHeader::set_type_of_data,
@@ -173,63 +168,46 @@ InterfileHeader::InterfileHeader()
           &type_of_data_values);
 
   add_key("patient orientation",
-	  KeyArgument::ASCIIlist,
 	  &patient_orientation_index,
 	  &patient_orientation_values);
   add_key("patient rotation",
-	  KeyArgument::ASCIIlist,
 	  &patient_rotation_index,
 	  &patient_rotation_values);
 
 
   add_key("imagedata byte order", 
-    KeyArgument::ASCIIlist,
     &byte_order_index, 
     &byte_order_values);
   
-  add_key("data format", 
-    KeyArgument::ASCII,	&KeyParser::do_nothing);
+  ignore_key("data format");
   add_key("number format", 
-    KeyArgument::ASCIIlist,
     &number_format_index,
     &number_format_values);
-  add_key("number of bytes per pixel", 
-    KeyArgument::INT,	&bytes_per_pixel);
+  add_key("number of bytes per pixel", &bytes_per_pixel);
   add_key("number of dimensions", 
     KeyArgument::INT,	(KeywordProcessor)&InterfileHeader::read_matrix_info,&num_dimensions);
-  add_key("matrix size", 
-    KeyArgument::LIST_OF_INTS,&matrix_size);
-  add_key("matrix axis label", 
-    KeyArgument::ASCII,	&matrix_labels);
-  add_key("scaling factor (mm/pixel)", 
-    KeyArgument::DOUBLE, &pixel_sizes);
+  add_vectorised_key("matrix size", &matrix_size);
+  add_vectorised_key("matrix axis label", &matrix_labels);
+  add_vectorised_key("scaling factor (mm/pixel)", &pixel_sizes);
   add_key("number of time frames", 
     KeyArgument::INT,	(KeywordProcessor)&InterfileHeader::read_frames_info,&num_time_frames);
-  add_key("image relative start time (sec)",
-	  KeyArgument::DOUBLE, &image_relative_start_times);
-  add_key("image duration (sec)",
-	  KeyArgument::DOUBLE, &image_durations);
+  add_vectorised_key("image relative start time (sec)", &image_relative_start_times);
+  add_vectorised_key("image duration (sec)", &image_durations);
     //image start time[<f>] := <TimeFormat>
 
   // ignore these as we'll never use them
-  add_key("maximum pixel count", 
-    KeyArgument::NONE,	&KeyParser::do_nothing);
-  add_key("minimum pixel count", 
-    KeyArgument::NONE,	&KeyParser::do_nothing);
+  ignore_key("maximum pixel count");
+  ignore_key("minimum pixel count");
 
   // TODO move to PET?
-  add_key("image scaling factor", 
-    KeyArgument::LIST_OF_DOUBLES, &image_scaling_factors);
+  add_vectorised_key("image scaling factor", &image_scaling_factors);
 
   // support for Louvain la Neuve's extension of 3.3
-  add_key("quantification units",
-    KeyArgument::DOUBLE, &lln_quantification_units);
+  add_key("quantification units", &lln_quantification_units);
 
-  add_key("energy window lower level",
-         KeyArgument::FLOAT, &lower_en_window_thres);
+  add_key("energy window lower level", &lower_en_window_thres);
 
-  add_key("energy window upper level",
-         KeyArgument::FLOAT, &upper_en_window_thres);
+  add_key("energy window upper level", &upper_en_window_thres);
 
   bed_position_horizontal = 0.F;
   add_key("start horizontal bed position (mm)", &bed_position_horizontal);
@@ -380,36 +358,26 @@ void InterfileHeader::set_type_of_data()
 
   if (type_of_data == "PET")
     {
-      add_key("PET STUDY (Emission data)", 
-              KeyArgument::NONE,	&KeyParser::do_nothing);
-      add_key("PET STUDY (Image data)", 
-              KeyArgument::NONE,	&KeyParser::do_nothing);
-      add_key("PET STUDY (General)", 
-              KeyArgument::NONE,	&KeyParser::do_nothing);
+      ignore_key("PET STUDY (Emission data)");
+      ignore_key("PET STUDY (Image data)");
+      ignore_key("PET STUDY (General)");
       add_key("PET data type", 
-              KeyArgument::ASCIIlist,
               &PET_data_type_index, 
               &PET_data_type_values);
-      add_key("process status", 
-              KeyArgument::NONE,	&KeyParser::do_nothing);
-      add_key("IMAGE DATA DESCRIPTION", 
-              KeyArgument::NONE,	&KeyParser::do_nothing);
+      ignore_key("process status");
+      ignore_key("IMAGE DATA DESCRIPTION");
       // TODO rename keyword 
-      add_key("data offset in bytes", 
-	      KeyArgument::ULONG,	&data_offset_each_dataset);
+      add_vectorised_key("data offset in bytes", &data_offset_each_dataset);
 
     }
   else if (type_of_data == "Tomographic")
     {
-      add_key("SPECT STUDY (General)" , 
-              KeyArgument::NONE,	&KeyParser::do_nothing);  
-      add_key("SPECT STUDY (acquired data)",
-              KeyArgument::NONE,	&KeyParser::do_nothing);
+      ignore_key("SPECT STUDY (General)" );  
+      ignore_key("SPECT STUDY (acquired data)");
 
       process_status_values.push_back("Reconstructed");
       process_status_values.push_back("Acquired");
       add_key("process status", 
-              KeyArgument::ASCIIlist,
               &process_status_index,
               &process_status_values);
 
@@ -440,14 +408,11 @@ InterfileImageHeader::InterfileImageHeader()
   index_nesting_level.resize(1, "");
   image_data_type_description.resize(num_image_data_types, "");
     
-  add_key("first pixel offset (mm)",
-	   KeyArgument::DOUBLE, &first_pixel_offsets);
+  add_vectorised_key("first pixel offset (mm)", &first_pixel_offsets);
   add_key("number of image data types", 
     KeyArgument::INT,	(KeywordProcessor)&InterfileImageHeader::read_image_data_types,&num_image_data_types);
-  add_key("index nesting level", 
-    KeyArgument::LIST_OF_ASCII,	&index_nesting_level);
-  add_key("image data type description", 
-    KeyArgument::ASCII,	&image_data_type_description);
+  add_key("index nesting level", &index_nesting_level);
+  add_vectorised_key("image data type description", &image_data_type_description);
 }
 
 void InterfileImageHeader::read_image_data_types()
@@ -531,11 +496,9 @@ InterfilePDFSHeader::InterfilePDFSHeader()
   
   // warning these keys should match what is in Scanner::parameter_info()
   // TODO get Scanner to parse these
-  add_key("Scanner parameters",
-	  KeyArgument::NONE,	&KeyParser::do_nothing);
+  ignore_key("Scanner parameters");
   // this is currently ignored (use "originating system" instead)
-  add_key("Scanner type",
-	  KeyArgument::NONE,	&KeyParser::do_nothing);
+  ignore_key("Scanner type");
 
   // first set to some crazy values
   num_rings = -1;
@@ -599,14 +562,12 @@ InterfilePDFSHeader::InterfilePDFSHeader()
   add_key("Reference energy (in keV)",
           &reference_energy);
 
-  add_key("end scanner parameters",
-	  KeyArgument::NONE,	&KeyParser::do_nothing);
+  ignore_key("end scanner parameters");
   
   effective_central_bin_size_in_cm = -1;
   add_key("effective central bin size (cm)",
 	  &effective_central_bin_size_in_cm);
-  add_key("applied corrections",
-    KeyArgument::LIST_OF_ASCII, &applied_corrections);
+  add_key("applied corrections", &applied_corrections);
 }
 
 void InterfilePDFSHeader::resize_segments_and_set()

--- a/src/IO/InterfileHeaderSiemens.cxx
+++ b/src/IO/InterfileHeaderSiemens.cxx
@@ -94,17 +94,14 @@ InterfileHeaderSiemens::InterfileHeaderSiemens()
           &type_of_data_values);*/
 
   add_key("%patient orientation",
-	  KeyArgument::ASCIIlist,
 	  &patient_position_index,
 	  &patient_position_values);
   
   add_key("image data byte order", 
-    KeyArgument::ASCIIlist,
     &byte_order_index, 
     &byte_order_values);
   
-  add_key("scale factor (mm/pixel)", 
-    KeyArgument::DOUBLE, &pixel_sizes);
+  add_vectorised_key("scale factor (mm/pixel)", &pixel_sizes);
 
   // only a single time frame supported by Siemens currently
   num_time_frames = 1;
@@ -149,16 +146,12 @@ void InterfileHeaderSiemens::set_type_of_data()
   // already done below
     {
       add_key("PET data type", 
-              KeyArgument::ASCIIlist,
               &PET_data_type_index, 
               &PET_data_type_values);
-      add_key("process status", 
-              KeyArgument::NONE,	&KeyParser::do_nothing);
-      add_key("IMAGE DATA DESCRIPTION", 
-              KeyArgument::NONE,	&KeyParser::do_nothing);
+      ignore_key("process status");
+      ignore_key("IMAGE DATA DESCRIPTION");
       // TODO rename keyword 
-      add_key("data offset in bytes", 
-	      KeyArgument::ULONG,	&data_offset_each_dataset);
+      add_vectorised_key("data offset in bytes", &data_offset_each_dataset);
 
     }
 #endif
@@ -180,73 +173,68 @@ InterfileRawDataHeaderSiemens::InterfileRawDataHeaderSiemens()
   add_key("%axial compression", &axial_compression);
   add_key("%maximum ring difference", &maximum_ring_difference);  
   add_key("%number of segments", &num_segments);
-  add_key("%segment table", KeyArgument::LIST_OF_INTS, &segment_table);
+  add_key("%segment table", &segment_table);
   add_key("%number of tof time bins", &num_tof_bins);
   
   num_energy_windows = -1;
   add_key("number of energy windows",
     KeyArgument::INT, (KeywordProcessor)&InterfileRawDataHeaderSiemens::read_num_energy_windows, &num_energy_windows);
-  add_key("%energy window lower level (keV)",
-    KeyArgument::FLOAT, &lower_en_window_thresholds);
+  add_vectorised_key("%energy window lower level (keV)", &lower_en_window_thresholds);
 
-  add_key("%energy window upper level (keV)",
-    KeyArgument::FLOAT, &upper_en_window_thresholds);
+  add_vectorised_key("%energy window upper level (keV)", &upper_en_window_thresholds);
 
   remove_key("PET data type");
   add_key("PET data type",
-	  KeyArgument::ASCIIlist,
 	  &PET_data_type_index,
 	  &PET_data_type_values);
 
   // TODO should add data format:=CoincidenceList|sinogram and then check its value
   remove_key("process status");
-  add_key("process status",
-	  KeyArgument::NONE, &KeyParser::do_nothing);
+  ignore_key("process status");
   remove_key("IMAGE DATA DESCRIPTION");
-  add_key("IMAGE DATA DESCRIPTION",
-	  KeyArgument::NONE, &KeyParser::do_nothing);
+  ignore_key("IMAGE DATA DESCRIPTION");
   remove_key("data offset in bytes");
   add_key("data offset in bytes",
 	  KeyArgument::ULONG, &data_offset_each_dataset);
 
-  add_key("%comment", KeyArgument::NONE, &KeyParser::do_nothing);
-  add_key("%sms-mi header name space", KeyArgument::NONE, &KeyParser::do_nothing);
-  add_key("%listmode header file", KeyArgument::NONE, &KeyParser::do_nothing);
-  add_key("%listmode data file", KeyArgument::NONE, &KeyParser::do_nothing);
-  add_key("%compressor version", KeyArgument::NONE, &KeyParser::do_nothing);
-  add_key("%study date (yyyy", KeyArgument::NONE, &KeyParser::do_nothing);
-  add_key("%study time (hh", KeyArgument::NONE, &KeyParser::do_nothing);
-  add_key("isotope name", KeyArgument::NONE, &KeyParser::do_nothing);
-  add_key("isotope gamma halflife (sec)", KeyArgument::NONE, &KeyParser::do_nothing);
-  add_key("isotope branching factor", KeyArgument::NONE, &KeyParser::do_nothing);
-  add_key("radiopharmaceutical", KeyArgument::NONE, &KeyParser::do_nothing);
-  add_key("%tracer injection date (yyyy", KeyArgument::NONE, &KeyParser::do_nothing);
-  add_key("%tracer injection time (hh", KeyArgument::NONE, &KeyParser::do_nothing);
-  add_key("relative time of tracer injection (sec)", KeyArgument::NONE, &KeyParser::do_nothing);
-  add_key("tracer activity at time of injection (bq)", KeyArgument::NONE, &KeyParser::do_nothing);
-  add_key("injected volume (ml)", KeyArgument::NONE, &KeyParser::do_nothing);
-  add_key("horizontal bed translation", KeyArgument::NONE, &KeyParser::do_nothing);
-  add_key("end horizontal bed position (mm)", KeyArgument::NONE, &KeyParser::do_nothing);
-  add_key("%coincidence window width (ns)", KeyArgument::NONE, &KeyParser::do_nothing);
-  add_key("gantry tilt angle (degrees)", KeyArgument::NONE, &KeyParser::do_nothing);
-  add_key("method of attenuation correction", KeyArgument::NONE, &KeyParser::do_nothing);
-  add_key("method of scatter correction", KeyArgument::NONE, &KeyParser::do_nothing);
-  add_key("%method of random correction", KeyArgument::NONE, &KeyParser::do_nothing);
-  add_key("%decay correction", KeyArgument::NONE, &KeyParser::do_nothing);
-  add_key("%decay correction reference date (yyyy", KeyArgument::NONE, &KeyParser::do_nothing);
-  add_key("%decay correction reference time (hh", KeyArgument::NONE, &KeyParser::do_nothing);
-  add_key("decay correction factor", KeyArgument::NONE, &KeyParser::do_nothing);
-  add_key("scatter fraction (%)", KeyArgument::NONE, &KeyParser::do_nothing);
-  add_key("scan data type description", KeyArgument::NONE, &KeyParser::do_nothing);
-  add_key("total prompts events", KeyArgument::NONE, &KeyParser::do_nothing);
-  add_key("total prompts", KeyArgument::NONE, &KeyParser::do_nothing);
-  add_key("%total randoms", KeyArgument::NONE, &KeyParser::do_nothing);
-  add_key("%total net trues", KeyArgument::NONE, &KeyParser::do_nothing);
-  add_key("%image duration from timing tags (msec)", KeyArgument::NONE, &KeyParser::do_nothing);
-  add_key("%gim loss fraction", KeyArgument::NONE, &KeyParser::do_nothing);
-  add_key("%pdr loss fraction", KeyArgument::NONE, &KeyParser::do_nothing);
-  add_key("%detector block singles", KeyArgument::NONE, &KeyParser::do_nothing);
-  add_key("%total uncorrected singles rate", KeyArgument::NONE, &KeyParser::do_nothing);
+  ignore_key("%comment");
+  ignore_key("%sms-mi header name space");
+  ignore_key("%listmode header file");
+  ignore_key("%listmode data file");
+  ignore_key("%compressor version");
+  ignore_key("%study date (yyyy");
+  ignore_key("%study time (hh");
+  ignore_key("isotope name");
+  ignore_key("isotope gamma halflife (sec)");
+  ignore_key("isotope branching factor");
+  ignore_key("radiopharmaceutical");
+  ignore_key("%tracer injection date (yyyy");
+  ignore_key("%tracer injection time (hh");
+  ignore_key("relative time of tracer injection (sec)");
+  ignore_key("tracer activity at time of injection (bq)");
+  ignore_key("injected volume (ml)");
+  ignore_key("horizontal bed translation");
+  ignore_key("end horizontal bed position (mm)");
+  ignore_key("%coincidence window width (ns)");
+  ignore_key("gantry tilt angle (degrees)");
+  ignore_key("method of attenuation correction");
+  ignore_key("method of scatter correction");
+  ignore_key("%method of random correction");
+  ignore_key("%decay correction");
+  ignore_key("%decay correction reference date (yyyy");
+  ignore_key("%decay correction reference time (hh");
+  ignore_key("decay correction factor");
+  ignore_key("scatter fraction (%)");
+  ignore_key("scan data type description");
+  ignore_key("total prompts events");
+  ignore_key("total prompts");
+  ignore_key("%total randoms");
+  ignore_key("%total net trues");
+  ignore_key("%image duration from timing tags (msec)");
+  ignore_key("%gim loss fraction");
+  ignore_key("%pdr loss fraction");
+  ignore_key("%detector block singles");
+  ignore_key("%total uncorrected singles rate");
 
 }
 
@@ -331,7 +319,7 @@ InterfilePDFSHeaderSiemens::InterfilePDFSHeaderSiemens()
   // scan data type size depends on the previous field
   // scan data type description[1]: = prompts
   // scan data type description[2] : = randoms
-  add_key("scan data type description", KeyArgument::ASCII, &scan_data_types);
+  add_key("scan data type description", &scan_data_types);
 
   // scan data type size depends on the previous field
   // data offset in bytes[1] : = 24504
@@ -339,12 +327,11 @@ InterfilePDFSHeaderSiemens::InterfilePDFSHeaderSiemens()
 
   add_key("%total number of sinograms", &total_num_sinograms);
   add_key("%compression", &compression_as_string);
-  add_key("applied corrections",
-    KeyArgument::LIST_OF_ASCII, &applied_corrections);
+  add_key("applied corrections", &applied_corrections);
 
   add_key("%number of buckets",
     KeyArgument::INT, (KeywordProcessor)&InterfilePDFSHeaderSiemens::read_bucket_singles_rates, &num_buckets);
-  add_key("%bucket singles rate", KeyArgument::INT, &bucket_singles_rates);
+  add_vectorised_key("%bucket singles rate", &bucket_singles_rates);
   
   
 }
@@ -504,27 +491,27 @@ InterfileListmodeHeaderSiemens::InterfileListmodeHeaderSiemens()
   data_offset_each_dataset.resize(1, 0UL);
   add_key("data offset in bytes", &data_offset_each_dataset[0]);
 
-  add_key("%bed zero offset (mm)", KeyArgument::NONE, &KeyParser::do_nothing);
-  add_key("pet scanner type", KeyArgument::NONE, &KeyParser::do_nothing);
-  add_key("transaxial fov diameter (cm)", KeyArgument::NONE, &KeyParser::do_nothing);
-  add_key("distance between rings (cm)", KeyArgument::NONE, &KeyParser::do_nothing);
-  add_key("gantry crystal radius (cm)", KeyArgument::NONE, &KeyParser::do_nothing);
-  add_key("bin size (cm)", KeyArgument::NONE, &KeyParser::do_nothing);
-  add_key("septa state", KeyArgument::NONE, &KeyParser::do_nothing);
-  add_key("%tof mashing factor", KeyArgument::NONE, &KeyParser::do_nothing);
-  add_key("%preset type", KeyArgument::NONE, &KeyParser::do_nothing);
-  add_key("%preset value", KeyArgument::NONE, &KeyParser::do_nothing);
-  add_key("%preset unit", KeyArgument::NONE, &KeyParser::do_nothing);
-  add_key("%total listmode word counts", KeyArgument::NONE, &KeyParser::do_nothing);
-  add_key("%coincidence list data", KeyArgument::NONE, &KeyParser::do_nothing);
-  add_key("%lm event and tag words format (bits)", KeyArgument::NONE, &KeyParser::do_nothing);
-  add_key("%timing tagwords interval (msec)", KeyArgument::NONE, &KeyParser::do_nothing);
-  add_key("%singles polling method", KeyArgument::NONE, &KeyParser::do_nothing);
-  add_key("%singles polling interval (sec)", KeyArgument::NONE, &KeyParser::do_nothing);
-  add_key("%singles scale factor", KeyArgument::NONE, &KeyParser::do_nothing);
-  add_key("%total number of singles blocks", KeyArgument::NONE, &KeyParser::do_nothing);
-  add_key("%time sync", KeyArgument::NONE, &KeyParser::do_nothing);
-  add_key("%comment", KeyArgument::NONE, &KeyParser::do_nothing);
+  ignore_key("%bed zero offset (mm)");
+  ignore_key("pet scanner type");
+  ignore_key("transaxial fov diameter (cm)");
+  ignore_key("distance between rings (cm)");
+  ignore_key("gantry crystal radius (cm)");
+  ignore_key("bin size (cm)");
+  ignore_key("septa state");
+  ignore_key("%tof mashing factor");
+  ignore_key("%preset type");
+  ignore_key("%preset value");
+  ignore_key("%preset unit");
+  ignore_key("%total listmode word counts");
+  ignore_key("%coincidence list data");
+  ignore_key("%lm event and tag words format (bits)");
+  ignore_key("%timing tagwords interval (msec)");
+  ignore_key("%singles polling method");
+  ignore_key("%singles polling interval (sec)");
+  ignore_key("%singles scale factor");
+  ignore_key("%total number of singles blocks");
+  ignore_key("%time sync");
+  ignore_key("%comment");
   }
 
 int InterfileListmodeHeaderSiemens::find_storage_order()

--- a/src/buildblock/KeyParser.cxx
+++ b/src/buildblock/KeyParser.cxx
@@ -2,6 +2,7 @@
     Copyright (C) 2000 PARAPET partners
     Copyright (C) 2000 - 2009-04-30, Hammersmith Imanet Ltd
     Copyright (C) 2011-07-01 - 2012-01-29, Kris Thielemans
+    Copyright (C) 2020 University College London
     This file is part of STIR.
 
     This file is free software; you can redistribute it and/or modify
@@ -194,23 +195,26 @@ static void read_line(istream& input, string& line,
 // map_element implementation;
 
 map_element::map_element()
-{
-  type=KeyArgument::NONE;
-  p_object_member=0;
-  p_object_variable=0;
-  p_object_list_of_values=0;
-}
+  :
+  type(KeyArgument::NONE),
+  p_object_member(0),
+  p_object_variable(0),
+  vectorised_key_level(0),
+  p_object_list_of_values(0)
+{}
 
 map_element::map_element(KeyArgument::type t, 
 			 KeyParser::KeywordProcessor pom, 
 			 void* pov,
+                         const int vectorised_key_level_v,
 			 const ASCIIlist_type *list_of_values)
-{
-  type=t;
-  p_object_member=pom;
-  p_object_variable=pov;
-  p_object_list_of_values=list_of_values;
-}
+  :
+  type(t),
+  p_object_member(pom),
+  p_object_variable(pov),
+  vectorised_key_level(vectorised_key_level_v),
+  p_object_list_of_values(list_of_values)
+{}
 
 map_element::map_element(void (KeyParser::*pom)(),
 	      RegisteredObjectBase** pov, 
@@ -219,6 +223,8 @@ map_element::map_element(void (KeyParser::*pom)(),
   type(KeyArgument::PARSINGOBJECT),
   p_object_member(pom),
   p_object_variable(pov),
+  vectorised_key_level(0),
+  p_object_list_of_values(0),
   parser(parser)//static_cast<Parser *>(parser))
   {}
 
@@ -229,6 +235,8 @@ map_element::map_element(void (KeyParser::*pom)(),
   type(KeyArgument::SHARED_PARSINGOBJECT),
   p_object_member(pom),
   p_object_variable(pov),
+  vectorised_key_level(0),
+  p_object_list_of_values(0),
   parser(parser)//static_cast<Parser *>(parser))
   {}
 
@@ -242,6 +250,7 @@ map_element& map_element::operator=(const map_element& me)
   type=me.type;
   p_object_member=me.p_object_member;
   p_object_variable=me.p_object_variable;
+  vectorised_key_level=me.vectorised_key_level;
   p_object_list_of_values=me.p_object_list_of_values;
   parser = me.parser;
   return *this;
@@ -360,11 +369,29 @@ KeyParser::add_key(const string& keyword, float * variable)
   {
     add_key(keyword, KeyArgument::FLOAT, variable);
   }
-  
+
+void
+KeyParser::add_vectorised_key(const string& keyword, vector<float> * variable)
+  {
+    add_key(keyword, KeyArgument::FLOAT, variable, 1);
+  }
+
 void
 KeyParser::add_key(const string& keyword, double * variable)
   {
     add_key(keyword, KeyArgument::DOUBLE, variable);
+  }
+
+void
+KeyParser::add_vectorised_key(const string& keyword, vector<double> * variable)
+  {
+    add_key(keyword, KeyArgument::DOUBLE, variable, 1);
+  }
+
+void
+KeyParser::add_vectorised_key(const string& keyword, vector<vector<double> > * variable)
+  {
+    add_key(keyword, KeyArgument::LIST_OF_DOUBLES, variable, 1);
   }
 
 void
@@ -374,9 +401,33 @@ KeyParser::add_key(const string& keyword, int * variable)
   }
 
 void
+KeyParser::add_key(const string& keyword, vector<int> * variable)
+  {
+    add_key(keyword, KeyArgument::LIST_OF_INTS, variable);
+  }
+
+void
+KeyParser::add_vectorised_key(const string& keyword, vector<int> * variable)
+  {
+    add_key(keyword, KeyArgument::INT, variable, 1);
+  }
+
+void
+KeyParser::add_vectorised_key(const string& keyword, vector<vector<int> > * variable)
+  {
+    add_key(keyword, KeyArgument::LIST_OF_INTS, variable, 1);
+  }
+
+void
 KeyParser::add_key(const string& keyword, unsigned int * variable)
   {
     add_key(keyword, KeyArgument::UINT, variable);
+  }
+
+void
+KeyParser::add_vectorised_key(const string& keyword, vector<unsigned int> * variable)
+  {
+    add_key(keyword, KeyArgument::UINT, variable, 1);
   }
 
 void
@@ -389,6 +440,12 @@ void
 KeyParser::add_key(const string& keyword, unsigned long * variable)
   {
     add_key(keyword, KeyArgument::ULONG, variable);
+  }
+
+void
+KeyParser::add_vectorised_key(const string& keyword, vector<unsigned long> * variable)
+  {
+    add_key(keyword, KeyArgument::ULONG, variable, 1);
   }
 
 void
@@ -439,6 +496,13 @@ KeyParser::add_key(const string& keyword, string * variable)
     add_key(keyword, KeyArgument::ASCII, variable);
   }
 
+
+void
+KeyParser::add_vectorised_key(const string& keyword, vector<string> * variable)
+  {
+    add_key(keyword, KeyArgument::ASCII, variable, 1);
+  }
+
 void
 KeyParser::add_key(const string& keyword, int * variable,
                    const ASCIIlist_type * list_of_values_ptr)
@@ -446,6 +510,12 @@ KeyParser::add_key(const string& keyword, int * variable,
     add_key(keyword, KeyArgument::ASCIIlist, variable, list_of_values_ptr);
   }
  
+void
+KeyParser::ignore_key(const string& keyword)
+  {
+    add_key(keyword, KeyArgument::NONE, &KeyParser::do_nothing);
+  }
+
 void
 KeyParser::add_start_key(const string& keyword)
   {
@@ -466,7 +536,17 @@ void KeyParser::add_key(const string& keyword,
 			void* variable,
 			const ASCIIlist_type * const list_of_values)
 {
-  add_in_keymap(keyword, map_element(t, function, variable, list_of_values));
+  add_in_keymap(keyword, map_element(t, function, variable, 0, list_of_values));
+}
+
+void KeyParser::add_key(const string& keyword, 
+			KeyArgument::type t, 
+			KeywordProcessor function,
+			void* variable,
+                        const int vectorised_key_level,
+			const ASCIIlist_type * const list_of_values)
+{
+  add_in_keymap(keyword, map_element(t, function, variable, vectorised_key_level, list_of_values));
 }
 
 void KeyParser::add_key(const string& keyword, 
@@ -474,8 +554,18 @@ void KeyParser::add_key(const string& keyword,
 			void* variable,
 			const ASCIIlist_type * const list_of_values)
 {
-  add_in_keymap(keyword, map_element(t, &KeyParser::set_variable, variable, list_of_values));
+  add_in_keymap(keyword, map_element(t, &KeyParser::set_variable, variable, 0, list_of_values));
 }
+
+void KeyParser::add_key(const string& keyword, 
+			KeyArgument::type t, 
+			void* variable,
+                        const int vectorised_key_level,
+			const ASCIIlist_type * const list_of_values)
+{
+  add_in_keymap(keyword, map_element(t, &KeyParser::set_variable, variable, vectorised_key_level, list_of_values));
+}
+
 
 void
 KeyParser::print_keywords_to_stream(ostream& out) const
@@ -727,9 +817,9 @@ static int get_index(const string& line)
     if (eok == string::npos)
     {
       // TODO do something more graceful
-      warning("Interfile warning: invalid vectored key in line \n'%s'.\n%s",
+      warning("Interfile warning: invalid vectorised key in line \n'%s'.\n%s",
         line.c_str(), 
-        "Assuming this is not a vectored key.");
+        "Assuming this is not a vectorised key.");
       return 0;
     }
     in=atoi(line.substr(sok,eok-sok).c_str());
@@ -877,11 +967,11 @@ void KeyParser::set_parsing_object()
   if (!keyword_has_a_value)
     return;
 
-  // TODO this does not handle the vectored key convention
+  // TODO this does not handle the vectorised key convention
   
   // current_index is set to 0 when there was no index
   if(current_index!=0)
-    error("KeyParser::PARSINGOBJECT can't handle vectored keys yet\n");
+    error("KeyParser::PARSINGOBJECT can't handle vectorised keys yet\n");
   const std::string& par_ascii = *boost::any_cast<std::string>(&this->parameter);
   *reinterpret_cast<RegisteredObjectBase **>(current->p_object_variable) =
     (*current->parser)(input, par_ascii);	    
@@ -895,11 +985,11 @@ void KeyParser::set_shared_parsing_object()
   if (!keyword_has_a_value)
     return;
   
-  // TODO this does not handle the vectored key convention
+  // TODO this does not handle the vectorised key convention
   
   // current_index is set to 0 when there was no index
   if(current_index!=0)
-    error("KeyParser::SHARED_PARSINGOBJECT can't handle vectored keys yet");
+    error("KeyParser::SHARED_PARSINGOBJECT can't handle vectorised keys yet");
   const std::string& par_ascii = *boost::any_cast<std::string>(&this->parameter);
   reinterpret_cast<shared_ptr<RegisteredObjectBase> *>(current->p_object_variable)->
     reset((*current->parser)(input, par_ascii));
@@ -926,11 +1016,14 @@ void KeyParser::set_variable()
   if (!keyword_has_a_value)
     return;
 
-  // TODO this does not handle the vectored key convention
+  // TODO this does not handle the vectorised key convention
   
   // current_index is set to 0 when there was no index
   if(!current_index)
     {
+      if (current->vectorised_key_level>0)
+        error(boost::format("Error parsing: expected a vectorised key as in \"%1%[1]\", but no bracket found") % keyword);
+
       switch(current->type)
 	{	  
 #define KP_case_assign(KeyArgumentValue, type) \
@@ -998,6 +1091,9 @@ void KeyParser::set_variable()
     }
   else	// Sets vector elements using current_index
     {
+      if (current->vectorised_key_level==0)
+        error(boost::format("Error parsing: encountered unexpected \"vectorisation\" of key: \"%1%[%2%]\"") % keyword % current_index);
+
       switch(current->type)
 	{
 #define KP_case_assign(KeyArgumentValue, type) \
@@ -1122,8 +1218,6 @@ namespace detail
   }
 }
 
-// TODO breaks with vectored keys (as there is no way of finding out if the
-// variable is actually a vector of the relevant type
 string KeyParser::parameter_info() const
 {  
 #ifdef BOOST_NO_STRINGSTREAM
@@ -1147,10 +1241,15 @@ string KeyParser::parameter_info() const
          i->second.p_object_member == &KeyParser::stop_parsing)
          continue;
 
+      if (i->second.vectorised_key_level > 0)
+        {
+          warning("KeyParser: cannot handle vectorised key yet");//TODO
+          continue;
+        }
       s << i->first << " := ";
       switch(i->second.type)
       {
-        // TODO will break with vectored keys
+        // TODO will break with vectorised keys
       case KeyArgument::DOUBLE:
         s << *reinterpret_cast<double*>(i->second.p_object_variable); break;
       case KeyArgument::FLOAT:
@@ -1251,9 +1350,6 @@ string KeyParser::parameter_info() const
     return s.str();
   }
 
-// KT 13/03/2001 new 
-// TODO breaks with vectored keys (as there is no way of finding out if the
-// variable is actually a vector of the relevant type
 void KeyParser::ask_parameters()
 {   
   // This is necessary for set_parsing_object. It will allow the 
@@ -1270,6 +1366,12 @@ void KeyParser::ask_parameters()
           i->second.p_object_member == &KeyParser::start_parsing ||
           i->second.p_object_member == &KeyParser::stop_parsing)
           continue;
+
+      if (i->second.vectorised_key_level > 0)
+        {
+          warning("KeyParser: cannot handle vectorised key yet");//TODO
+          continue;
+        }
 
       keyword = i->first;
 

--- a/src/buildblock/MultipleDataSetHeader.cxx
+++ b/src/buildblock/MultipleDataSetHeader.cxx
@@ -56,9 +56,7 @@ initialise_keymap()
                   KeyArgument::INT,
                   static_cast<KeywordProcessor>(&MultipleDataSetHeader::read_num_data_sets),
                   &_num_data_sets);
-    this->add_key("data set",
-                  KeyArgument::ASCII,
-                  &_filenames);
+    this->add_vectorised_key("data set", &_filenames);
 }
 
 bool MultipleDataSetHeader::

--- a/src/include/stir/IO/InterfileHeader.h
+++ b/src/include/stir/IO/InterfileHeader.h
@@ -154,7 +154,7 @@ public :
   int			num_dimensions;
   std::vector<std::string>	matrix_labels;
   std::vector<std::vector<int> > matrix_size; 
-  std::vector<double>	pixel_sizes;
+  std::vector<float>	pixel_sizes;
   std::vector<std::vector<double> > image_scaling_factors;
   std::vector<unsigned long> data_offset_each_dataset;
 

--- a/src/include/stir/KeyParser.h
+++ b/src/include/stir/KeyParser.h
@@ -1,7 +1,7 @@
 /*
     Copyright (C) 2000 PARAPET partners
     Copyright (C) 2000 - 2007-10-08, Hammersmith Imanet Ltd
-    Copyright (C) 2013, University College London
+    Copyright (C) 2013, 2020, University College London
     This file is part of STIR.
 
     This file is free software; you can redistribute it and/or modify
@@ -88,15 +88,18 @@ public :
   void (KeyParser::*p_object_member)();	// pointer to a member function
   //TODO void (*p_object_member)();
   void *p_object_variable;		// pointer to a variable 
-  const ASCIIlist_type *p_object_list_of_values;// only used by ASCIIlist
+  int vectorised_key_level;
+  const ASCIIlist_type * p_object_list_of_values;// only used by ASCIIlist
   // TODO should really not be here, but it works for now
   typedef RegisteredObjectBase * (Parser)(std::istream*, const std::string&);
   Parser* parser;
 
   map_element();
 
-  map_element(KeyArgument::type t, void (KeyParser::*pom)(),
-	      void* pov= 0, const ASCIIlist_type *list_of_valid_keywords = 0);
+  // map_element(KeyArgument::type t, void (KeyParser::*object_member_ptr)());
+  
+  map_element(KeyArgument::type t, void (KeyParser::*object_member_ptr)(),
+	      void* variable_ptr, const int vectorised_key_level, const ASCIIlist_type *list_of_valid_keywords = 0);
   map_element(void (KeyParser::*pom)(),
 	      RegisteredObjectBase** pov, 
               Parser *);
@@ -135,9 +138,7 @@ public :
   \warning For end-of-line continuation, the backslash HAS to be
   the last character. Even spaces after it will stop the 'continuation'.
   
-  \warning Vectored keys are treated very dangerously: when a keyword
-  is assumed to be vectored, run-time errors occur when it is used without [].
-  \warning The use of the [*] index for vectored keys is NOT supported.
+  \warning The use of the [*] index for vectorised keys is NOT supported.
 
   Main problem: when non-trivial callback functions have to be used, you need to do it
   via a derived class (as KeyParser requires  pointers to member functions.)
@@ -173,20 +174,35 @@ public:
 
   //! add a keyword. When parsing, parse its value as a float and put it in *variable_ptr
   void add_key(const std::string& keyword, float * variable_ptr);
+  //! add a vectorised keyword. When parsing, parse its value as a float and put it in \c (*variable_ptr)[current_index]
+  void add_vectorised_key(const std::string& keyword, std::vector<float> * variable_ptr);
   //! add a keyword. When parsing, parse its value as a double and put it in *variable_ptr
   void add_key(const std::string& keyword, double * variable_ptr);
+  //! add a vectorised keyword. When parsing, parse its value as a double and put it in \c (*variable_ptr)[current_index]
+  void add_vectorised_key(const std::string& keyword, std::vector<double> * variable_ptr);
+  //! add a vectorised keyword. When parsing, parse its value as a list of doubles and put it in \c (*variable_ptr)[current_index]
+  void add_vectorised_key(const std::string& keyword, std::vector<std::vector<double> > * variable_ptr);
 
   //! add a keyword. When parsing, parse its value as a int and put it in *variable_ptr
   void add_key(const std::string& keyword, int * variable_ptr);
+  //! add a keyword. When parsing, parse its value as a int and put it in *variable_ptr
+  void add_key(const std::string& keyword, std::vector<int> * variable_ptr);
+  //! add a vectorised keyword. When parsing, parse its value as a int and put it in \c (*variable_ptr)[current_index]
+  void add_vectorised_key(const std::string& keyword, std::vector<int> * variable_ptr);
+  //! add a vectorised keyword. When parsing, parse its value as a list of ints and put it in \c (*variable_ptr)[current_index]
+  void add_vectorised_key(const std::string& keyword, std::vector<std::vector<int> > * variable_ptr);
 
   //! add a keyword. When parsing, parse its value as a int and put it in *variable_ptr
   void add_key(const std::string& keyword, long int * variable_ptr);
 
   //! add a keyword. When parsing, parse its value as a int and put it in *variable_ptr
   void add_key(const std::string& keyword, unsigned int * variable_ptr);
-
+  //! add a vectorised keyword. When parsing, parse its value as an unsigned int and put it in \c (*variable_ptr)[current_index]
+  void add_vectorised_key(const std::string& keyword, std::vector<unsigned int> * variable);
   //! add a keyword. When parsing, parse its value as an unsigned long and put it in *variable_ptr
   void add_key(const std::string& keyword, unsigned long * variable_ptr);
+  //! add a vectorised keyword. When parsing, parse its value as an unsigned long and put it in \c (*variable_ptr)[current_index]
+  void add_vectorised_key(const std::string& keyword, std::vector<unsigned long> * variable_ptr);
 
   //! add a keyword. When parsing, parse its value as a int  and put the bool value in *variable_ptr
   /*! The integer should be 0 or 1, corresponding to false and true resp. */
@@ -210,9 +226,11 @@ public:
   //! add a keyword. When parsing, parse its value as a 3d BasicCoordinate of a 3d array of floats and put its value in *variable_ptr
   void add_key(const std::string& keyword, BasicCoordinate<3,Array<3,float> >* variable_ptr);
 
-  //! add a keyword. When parsing, parse its value as a string and put it in *variable_ptr
   /*! The 'value' can contain spaces. */
   void add_key(const std::string& keyword, std::string * variable_ptr);
+  //! add a vectorised keyword. When parsing, parse its value as a string and put it in \c (*variable_ptr)[current_index]
+  /*! The 'value' can contain spaces. */
+  void add_vectorised_key(const std::string& keyword, std::vector<std::string> * variable_ptr);
   /*!
     \brief add a keyword. When parsing, its string value is checked against 
     a list of strings. The corresponding index is stored in 
@@ -224,6 +242,8 @@ public:
   void add_key(const std::string& keyword, 
     int* variable_ptr, const ASCIIlist_type * const list_of_values);
 
+  //! Add keyword this is just ignored by the parser
+  void ignore_key(const std::string& keyword);
   //! add keyword that has to occur before all others
   /*! Example of such a key: INTERFILE*/
   void add_start_key(const std::string& keyword);
@@ -300,7 +320,7 @@ public:
   /*! Keywords are listed in the order they are inserted in the keymap 
       (except for start and stop keys which are listed first and last).
 
-      \bug breaks with 'vectored' keys.
+      \bug breaks with 'vectorised' keys.
       */
   virtual std::string parameter_info() const;
 
@@ -312,7 +332,7 @@ public:
       end of the parsing. It should be possible to have checks after every question
       such that it can be repeated.
 
-      \bug breaks with  for 'vectored' keys.
+      \bug breaks with  for 'vectorised' keys.
       */
   virtual void ask_parameters();
 
@@ -331,6 +351,7 @@ protected :
   //! This will be called at the end of the parsing
   /*! \return false if everything OK, true if not 
     \todo return Succeeded instead.
+    \todo rename to \c post_parsing()
   */
   virtual bool post_processing() 
    { return false; }
@@ -366,11 +387,23 @@ protected :
   void add_key(const std::string& keyword, 
     KeyArgument::type t, KeywordProcessor function,
     void* variable= 0, const ASCIIlist_type * const list = 0);
+  //! add a keyword to the list, together with its call_back function
+  /*! This provides a more flexible way to add keys with specific call_backs.
+      Can currently only be used by derived classes, as KeywordProcessor has to be a 
+      pointer to member function.
+      \warning this interface to KeyParser will change in a future release */
+  void add_key(const std::string& keyword, 
+    KeyArgument::type t, KeywordProcessor function,
+               void* variable, const int vectorised_key_level, const ASCIIlist_type * const list = 0);
   
   //! version that defaults 'function' to set_variable
   /*! \warning this interface to KeyParser will change in a future release */
   void add_key(const std::string& keyword, KeyArgument::type t, 
 	      void* variable, const ASCIIlist_type * const list = 0);
+  //! version that defaults 'function' to set_variable
+  /*! \warning this interface to KeyParser will change in a future release */
+  void add_key(const std::string& keyword, KeyArgument::type t, 
+               void* variable, const int vectorised_key_level, const ASCIIlist_type * const list = 0);
 
   //! Removes a key from the kep map
   /*! \return \c true if it was found, \c false otherwise */

--- a/src/recon_buildblock/BinNormalisationFromECAT8.cxx
+++ b/src/recon_buildblock/BinNormalisationFromECAT8.cxx
@@ -258,8 +258,7 @@ MatrixFile* mptr = matrix_open(filename.c_str(),  MAT_READ_ONLY, Norm3d);
 #endif
 #if 0
   InterfileHeader interfile_parser;
- add_key("data format", 
-    KeyArgument::ASCII,	&KeyParser::do_nothing);
+ ignore_key("data format");
   interfile_parser.parse(filename.c_str());
 
 #else

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -55,6 +55,7 @@ set(buildblock_simple_tests
 	test_IndexRange
 	test_coordinates
 	test_filename_functions
+        test_KeyParser
 	test_VoxelsOnCartesianGrid
 	test_zoom_image
 	test_ByteOrder

--- a/src/test/test_KeyParser.cxx
+++ b/src/test/test_KeyParser.cxx
@@ -1,0 +1,147 @@
+//
+//
+/*
+    Copyright (C) 2020, University College London
+    This file is part of STIR.
+ 
+    This file is free software; you can redistribute it and/or modify 
+    it under the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.
+
+    This file is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License for more details.
+
+    See STIR/LICENSE.txt for details
+*/
+/*!
+  \file
+  \ingroup test
+
+  \brief Test program for stir::KeyParser
+
+  \author Kris Thielemans
+
+*/
+
+#include "stir/KeyParser.h"
+
+#include <sstream>
+#include "stir/RunTests.h"
+
+START_NAMESPACE_STIR
+
+template <typename elemT>
+class TestKP : public KeyParser
+{
+public:
+  TestKP()
+    :
+    scalar_v(0),
+    vector_v(2,0)
+  {
+    add_start_key("start");
+    add_stop_key("stop");
+    add_key("scalar", &scalar_v);
+    add_vectorised_key("vector", &vector_v);
+  }
+  elemT scalar_v;
+  std::vector<elemT> vector_v;
+};
+
+/*!
+  \ingroup test
+  \brief Test class for KeyParser
+
+*/
+class KeyParserTests : public RunTests
+{
+public:
+  template <typename elemT> void run_tests_one_type();
+  void run_tests();
+};
+
+void
+KeyParserTests::run_tests()
+{
+  std::cerr << "Tests for KeyParser\n";
+  std::cerr << "... int parsing\n";
+  run_tests_one_type<int>();
+  std::cerr << "... unsigned int parsing\n";
+  run_tests_one_type<unsigned int>();
+  std::cerr << "... float parsing\n";
+  run_tests_one_type<float>();
+  std::cerr << "... double parsing\n";
+  run_tests_one_type<double>();
+}
+
+template <typename elemT>
+void
+KeyParserTests::run_tests_one_type()
+{
+
+  TestKP<elemT>  parser;
+  // basic test if parsing ok
+  {
+    std::stringstream str;
+    str << "start:=\n"
+        << "scalar:=2\n"
+        << "vector[1] := 3\n"
+        << "stop     :=\n";
+    parser.parse(str);
+    check_if_equal(parser.scalar_v, static_cast<elemT>(2), "parsing int");
+    check_if_equal(parser.vector_v[0], static_cast<elemT>(3), "parsing int vector");
+  }
+  // test 1 if parsing catches errors
+  {
+    std::stringstream str;
+    str << "start:=\n"
+        << "scalar[1]:=2\n"
+        << "vector[1] := 3\n"
+        << "stop     :=\n";
+    try
+      {
+        std::cerr <<  "Next test should write an error (but not crash!)"  << std::endl;
+        parser.parse(str);
+        check(false, "parsing non-vectorised key with vector should have failed");
+      }
+    catch (...)
+      {
+        // ok
+      }
+  }
+  // test 2 if parsing catches errors
+  {
+    std::stringstream str;
+    str << "start:=\n"
+        << "scalar:=2\n"
+        << "vector := 3\n"
+        << "stop     :=\n";
+    try
+      {
+        std::cerr <<  "Next test should write an error (but not crash!)"  << std::endl;
+        parser.parse(str);
+        check(false, "parsing vectorised key with non-vector should have failed");
+      }
+    catch (...)
+      {
+        // ok
+      }
+  }
+
+}
+
+END_NAMESPACE_STIR
+
+
+USING_NAMESPACE_STIR
+
+
+int main()
+{
+  KeyParserTests tests;
+  tests.run_tests();
+  return tests.main_return_value();
+}

--- a/src/utilities/generate_image.cxx
+++ b/src/utilities/generate_image.cxx
@@ -212,11 +212,9 @@ initialise_keymap()
     KeyArgument::ASCII, (KeywordProcessor)&GenerateImage::set_imaging_modality,
     &imaging_modality_as_string);
   add_key("patient orientation",
-	  KeyArgument::ASCIIlist,
 	  &patient_orientation_index,
 	  &patient_orientation_values);
   add_key("patient rotation",
-	  KeyArgument::ASCIIlist,
 	  &patient_rotation_index,
 	  &patient_rotation_values);
   patient_orientation_values.push_back("head_in");


### PR DESCRIPTION
`KeyParser` did not store if a key is vectorised or not, but just assumed
that the stream it parsed was correct. This led to segmentation faults when
the stream used a vectorised key when KeyParser did not expect it, or vice versa.

This commit forces the developer to explicitly say what the level of vectorisation
is for a certain keyword (i.e. key, key[1], or key[1][1]).

This means that the change is backwards incompatible.

Classes using KeyParser have been rewritten to use the "shorter" form
of `add_key`, such that the vectorisation can be found by type-matching.

Also introduced a new `ignore_key()` member to make things more concise.

Fixes #148