### PR TITLE
CMake: Change UseCXX to specify the minimum C++ version

### DIFF
--- a/src/cmake/SetC++Version.cmake
+++ b/src/cmake/SetC++Version.cmake
@@ -1,8 +1,23 @@
 # A macro to set the C++ version
 # Based on https://stackoverflow.com/questions/10851247/how-to-activate-c-11-in-cmake
+
+# Copyright (C) 2017, 2020 University College London
+# Author Kris Thielemans
+
+# sets minimum C++ version (sorry for the name of the macro)
 macro(UseCXX VERSION)
  if (VERSION)
-  if (CMAKE_VERSION VERSION_LESS "3.1")
+    if (CMAKE_CXX_STANDARD)
+       if (${CMAKE_CXX_STANDARD} GREATER ${VERSION})
+           if (${CMAKE_CXX_STANDARD} STREQUAL 98 OR ${VERSION} STREQUAL 98)
+               message(WARNING "UseCXX macro does not cope well with version 98. Using ${VERSION}")
+           else()
+               set(VERSION ${CMAKE_CXX_STANDARD})
+	       message(STATUS "CMAKE_CXX_STANDARD ${CMAKE_CXX_STANDARD} was already more recent than version ${VERSION} asked. Keeping the former.")
+           endif()
+	 endif()
+    endif()
+    if (CMAKE_VERSION VERSION_LESS "3.1")
     message(WARNING "Your CMake version is older than v3.1. Attempting to set C++ version to ${VERSION} with compiler flags but this might fail. Please upgrade your CMake.")
     if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_EXTENSIONS)
       set (CMAKE_CXX_FLAGS "-std=gnu++${VERSION} ${CMAKE_CXX_FLAGS}")


### PR DESCRIPTION
We were previously forcing C++11 when using ROOT etc, but it could well be that the user asked for a more recent version.