### PR TITLE
prevent build error for ctac_to_mu_values if BUILD_EXECUTABLES=OFF

### DIFF
--- a/src/utilities/CMakeLists.txt
+++ b/src/utilities/CMakeLists.txt
@@ -86,6 +86,6 @@ endif()
 
 include(stir_exe_targets)
 
-if (nlohmann_json_FOUND)
+if (BUILD_EXECUTABLES AND nlohmann_json_FOUND)
   target_link_libraries(ctac_to_mu_values nlohmann_json::nlohmann_json)
 endif()


### PR DESCRIPTION
closes #515