### PR TITLE
no graphviz warning if documentation not being built

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -281,7 +281,7 @@ if(BUILD_DOCUMENTATION)
     endif()
 endif()
 
-if(DOXYGEN_FOUND)
+if(BUILD_DOCUMENTATION AND DOXYGEN_FOUND)
     if(DOXYGEN_DOT_FOUND)
         set(HAVE_DOT 1)
         message(STATUS "Graphviz dot found. It will be used for the Doxygen documentation.")
@@ -315,18 +315,14 @@ if(DOXYGEN_FOUND)
     # If BUILD_DOCUMENTATION, we add this target to the dependency list of "ALL"
     # to make sure it always gets run.
     # Otheriwse, the user has to build the target manually.
-    if(BUILD_DOCUMENTATION)
-        set(DOXY_ALL ALL)
-    endif()
+    set(DOXY_ALL ALL)
       
     add_custom_target(
         RUN_DOXYGEN ${DOXY_ALL}
         DEPENDS doxygen.stamp)
 
-    if(BUILD_DOCUMENTATION)
-        # Doxyfile.in currently tells doxygen to output in PROJECT_BINARY_DIR
-        install(DIRECTORY ${PROJECT_BINARY_DIR}/html DESTINATION ${STIR_DOC_DIR})
-    endif()
+    # Doxyfile.in currently tells doxygen to output in PROJECT_BINARY_DIR
+    install(DIRECTORY ${PROJECT_BINARY_DIR}/html DESTINATION ${STIR_DOC_DIR})
 endif()
 
 #### SWIG settings


### PR DESCRIPTION
Keep getting warnings that documentation would be better with Graphviz, even though documentation was disabled.

P.S. Accidentally pushed this to release_4 branch, so reverted it. Sorry.