### PR TITLE
Modify the computation of the log-likelihood to use doubles.

### DIFF
--- a/documentation/release_4.1.htm
+++ b/documentation/release_4.1.htm
@@ -15,7 +15,7 @@
       <ul>
         <li>Kris Thielemans (UCL) for general overview, fixes, help and maintenance</li>
         <li>Richard Brown (UCL) for wrapping of NiftyPET's GPU functionality for projecting and unlisting</li>
-        <li>Robert Twyman (UCL) for Relative Differnce Prior and compuation log-likelihood modification</li>  
+        <li>Robert Twyman (UCL) for Relative Difference Prior and computation of the log-likelihood modification</li>  
       </ul>
     </p>
 
@@ -36,7 +36,7 @@
 
 <h3>Changed functionality</h3>
 <ul>
-<li>  Modification of log-likelihood computation to use doubles. </li>
+<li>  Modification of log-likelihood computation to use more doubles, improving numerical stability, see <a href="https://github.com/UCL/STIR/pull/528">PR 528</a>.</li>
 </ul>
 <h4>Python (and MATLAB) interface</h4>
 none

--- a/documentation/release_4.1.htm
+++ b/documentation/release_4.1.htm
@@ -15,6 +15,7 @@
       <ul>
         <li>Kris Thielemans (UCL) for general overview, fixes, help and maintenance</li>
         <li>Richard Brown (UCL) for wrapping of NiftyPET's GPU functionality for projecting and unlisting</li>
+        <li>Robert Twyman (UCL) for Relative Differnce Prior and compuation log-likelihood modification</li>  
       </ul>
     </p>
 
@@ -35,7 +36,7 @@
 
 <h3>Changed functionality</h3>
 <ul>
-<li>  </li>
+<li>  Modification of log-likelihood computation to use doubles. </li>
 </ul>
 <h4>Python (and MATLAB) interface</h4>
 none

--- a/src/buildblock/recon_array_functions.cxx
+++ b/src/buildblock/recon_array_functions.cxx
@@ -386,7 +386,7 @@ void accumulate_loglikelihood(Viewgram<float>& projection_data,
 	  if (projection_data[r][b]<=small_value)
 	    sub_result += - double(new_estimate);
 	  else
-	    sub_result += double(projection_data[r][b]*log(new_estimate) - new_estimate);
+	    sub_result += projection_data[r][b]*log(double(new_estimate)) - double(new_estimate);
 	}
     result += sub_result;
   }


### PR DESCRIPTION
Fixes #527

Use doubles in the computation of the log-likelihood value. 

This PR improves the non-smoothness of the likelihood function value in the line search experiments close to convergence, see Fig _(note likelihood y-axis scale is greatly reduced in this PR plot)_.
![image](https://user-images.githubusercontent.com/13292409/81410428-9c052380-9138-11ea-9a2b-1e6d4ba049ed.png)





Possible improvement is to precompute a single double(new_estimate) before multiple calls.
i.e. 
```
new_estimate_double = double(new_estimate);
sub_result += projection_data[r][b]*log(new_estimate_double) - new_estimate_double;
```