### PR TITLE
add axpby for ProjData

### DIFF
--- a/src/buildblock/ProjData.cxx
+++ b/src/buildblock/ProjData.cxx
@@ -427,38 +427,29 @@ ProjData::
 axpby(const float a, const ProjData& x,
       const float b, const ProjData& y)
 {
-    int n = get_max_segment_num();
-    int nx = x.get_max_segment_num();
-    int ny = y.get_max_segment_num();
-    for (int s = 0; s <= n && s <= nx && s <= ny; ++s)
+    if (*get_proj_data_info_sptr() != *x.get_proj_data_info_sptr() ||
+            *get_proj_data_info_sptr() != *y.get_proj_data_info_sptr())
+        error("ProjData::axpby: ProjDataInfo don't match");
+
+    const int n_min = get_min_segment_num();
+    const int n_max = get_max_segment_num();
+
+    for (int s=n_min; s<=n_max; ++s)
     {
         SegmentBySinogram<float> seg = get_empty_segment_by_sinogram(s);
-        SegmentBySinogram<float> sx = x.get_segment_by_sinogram(s);
-        SegmentBySinogram<float> sy = y.get_segment_by_sinogram(s);
+        const SegmentBySinogram<float> sx = x.get_segment_by_sinogram(s);
+        const SegmentBySinogram<float> sy = y.get_segment_by_sinogram(s);
         SegmentBySinogram<float>::full_iterator seg_iter;
-        SegmentBySinogram<float>::full_iterator sx_iter;
-        SegmentBySinogram<float>::full_iterator sy_iter;
+        SegmentBySinogram<float>::const_full_iterator sx_iter;
+        SegmentBySinogram<float>::const_full_iterator sy_iter;
         for (seg_iter = seg.begin_all(),
             sx_iter = sx.begin_all(), sy_iter = sy.begin_all();
             seg_iter != seg.end_all() &&
             sx_iter != sx.end_all() && sy_iter != sy.end_all();
         /*empty*/) {
-            *seg_iter++ = float(a*double(*sx_iter++) + b*double(*sy_iter++));
+            *seg_iter++ = a*(*sx_iter++) + b*(*sy_iter++);
         }
         set_segment(seg);
-        if (s != 0) {
-            seg = get_empty_segment_by_sinogram(-s);
-            sx = x.get_segment_by_sinogram(-s);
-            sy = y.get_segment_by_sinogram(-s);
-            for (seg_iter = seg.begin_all(),
-                sx_iter = sx.begin_all(), sy_iter = sy.begin_all();
-                seg_iter != seg.end_all() &&
-                sx_iter != sx.end_all() && sy_iter != sy.end_all();
-            /*empty*/) {
-                *seg_iter++ = float(a*double(*sx_iter++) + b*double(*sy_iter++));
-            }
-            set_segment(seg);
-        }
     }
 }
 

--- a/src/buildblock/ProjData.cxx
+++ b/src/buildblock/ProjData.cxx
@@ -422,4 +422,44 @@ write_to_file(const string& output_filename) const
 
 }
 
+void
+ProjData::
+axpby(const float a, const ProjData& x,
+      const float b, const ProjData& y)
+{
+    int n = get_max_segment_num();
+    int nx = x.get_max_segment_num();
+    int ny = y.get_max_segment_num();
+    for (int s = 0; s <= n && s <= nx && s <= ny; ++s)
+    {
+        SegmentBySinogram<float> seg = get_empty_segment_by_sinogram(s);
+        SegmentBySinogram<float> sx = x.get_segment_by_sinogram(s);
+        SegmentBySinogram<float> sy = y.get_segment_by_sinogram(s);
+        SegmentBySinogram<float>::full_iterator seg_iter;
+        SegmentBySinogram<float>::full_iterator sx_iter;
+        SegmentBySinogram<float>::full_iterator sy_iter;
+        for (seg_iter = seg.begin_all(),
+            sx_iter = sx.begin_all(), sy_iter = sy.begin_all();
+            seg_iter != seg.end_all() &&
+            sx_iter != sx.end_all() && sy_iter != sy.end_all();
+        /*empty*/) {
+            *seg_iter++ = float(a*double(*sx_iter++) + b*double(*sy_iter++));
+        }
+        set_segment(seg);
+        if (s != 0) {
+            seg = get_empty_segment_by_sinogram(-s);
+            sx = x.get_segment_by_sinogram(-s);
+            sy = y.get_segment_by_sinogram(-s);
+            for (seg_iter = seg.begin_all(),
+                sx_iter = sx.begin_all(), sy_iter = sy.begin_all();
+                seg_iter != seg.end_all() &&
+                sx_iter != sx.end_all() && sy_iter != sy.end_all();
+            /*empty*/) {
+                *seg_iter++ = float(a*double(*sx_iter++) + b*double(*sy_iter++));
+            }
+            set_segment(seg);
+        }
+    }
+}
+
 END_NAMESPACE_STIR

--- a/src/buildblock/ProjDataInMemory.cxx
+++ b/src/buildblock/ProjDataInMemory.cxx
@@ -31,6 +31,7 @@
 #include "stir/Succeeded.h"
 #include "stir/SegmentByView.h"
 #include "stir/Bin.h"
+#include "stir/is_null_ptr.h"
 #include <fstream>
 #include <cstring>
 
@@ -62,18 +63,19 @@ ProjDataInMemory(shared_ptr<const ExamInfo> const& exam_info_sptr,
   :
   ProjDataFromStream(exam_info_sptr, proj_data_info_ptr, shared_ptr<iostream>()) // trick: first initialise sino_stream_ptr to 0
 {
+  this->_num_elements = size_all();
   this->buffer.reset(create_buffer(initialise_with_0));
   this->sino_stream = this->create_stream();
 }
 
-char *
+float *
 ProjDataInMemory::
 create_buffer(const bool initialise_with_0) const
 {
   char *b = new char[this->get_size_of_buffer()];
   if (initialise_with_0)
       memset(b, 0, this->get_size_of_buffer());
-  return b;
+  return reinterpret_cast<float*>(b);
 }
 
 shared_ptr<std::iostream>
@@ -90,7 +92,7 @@ const
   // However, if basic_string doesn't do reference counting, we would have
   // temporarily 2 strings of a (potentially large) size in memory.
   output_stream_sptr.reset
-          (new boost::interprocess::bufferstream(this->buffer.get(), this->get_size_of_buffer(), ios::in | ios::out | ios::binary));
+          (new boost::interprocess::bufferstream(reinterpret_cast<char*>(this->buffer.get()), this->get_size_of_buffer(), ios::in | ios::out | ios::binary));
 #endif
 
   if (!*output_stream_sptr)
@@ -127,7 +129,7 @@ size_t
 ProjDataInMemory::
 get_size_of_buffer() const
 {
-  return size_all() * sizeof(float);
+  return _num_elements * sizeof(float);
 }
 
 float 
@@ -138,5 +140,34 @@ ProjDataInMemory::get_bin_value(Bin& bin)
    return viewgram[bin.axial_pos_num()][bin.tangential_pos_num()]; 
 
 }
+
+void
+ProjDataInMemory::
+axpby(const float a, const ProjData& x,
+      const float b, const ProjData& y)
+{
+    // To use this method, we require that all three proj data be ProjDataInMemory
+    // So cast them. If any null pointers, fall back to default functionality
+    ProjDataInMemory *x_pdm = dynamic_cast<ProjDataInMemory*>(this);
+    ProjDataInMemory *y_pdm = dynamic_cast<ProjDataInMemory*>(this);
+    // At least one is not ProjDataInMemory, fall back to default
+    if (is_null_ptr(x_pdm) || is_null_ptr(y_pdm)) {
+        ProjData::axpby(a,x,b,y);
+        return;
+    }
+    // Get number of elements
+    std::size_t numel = this->_num_elements;
+    if (numel != x_pdm->_num_elements || numel != y_pdm->_num_elements)
+        error("Expected number of elements to match");
+
+    // Else, all are ProjDataInMemory
+    float *buffer   = this->buffer.get();
+    float *x_buffer = x_pdm->buffer.get();
+    float *y_buffer = y_pdm->buffer.get();
+
+    for (unsigned i=0; i<numel; ++i)
+        buffer[i] = a*x_buffer[i] + b*y_buffer[i];
+}
+
 END_NAMESPACE_STIR
 

--- a/src/buildblock/ProjDataInMemory.cxx
+++ b/src/buildblock/ProjDataInMemory.cxx
@@ -63,7 +63,6 @@ ProjDataInMemory(shared_ptr<const ExamInfo> const& exam_info_sptr,
   :
   ProjDataFromStream(exam_info_sptr, proj_data_info_ptr, shared_ptr<iostream>()) // trick: first initialise sino_stream_ptr to 0
 {
-  this->_num_elements = size_all();
   this->buffer.reset(create_buffer(initialise_with_0));
   this->sino_stream = this->create_stream();
 }
@@ -72,9 +71,9 @@ float *
 ProjDataInMemory::
 create_buffer(const bool initialise_with_0) const
 {
-  char *b = new char[this->get_size_of_buffer()];
+  char *b = new char[this->get_size_of_buffer_in_bytes()];
   if (initialise_with_0)
-      memset(b, 0, this->get_size_of_buffer());
+      memset(b, 0, this->get_size_of_buffer_in_bytes());
   return reinterpret_cast<float*>(b);
 }
 
@@ -85,14 +84,14 @@ const
 {
   shared_ptr<std::iostream> output_stream_sptr;
 #ifdef STIR_USE_OLD_STRSTREAM
-  output_stream_sptr.reset(new strstream(buffer.get(), this->get_size_of_buffer(), ios::in | ios::out | ios::binary));
+  output_stream_sptr.reset(new strstream(buffer.get(), this->get_size_of_buffer_in_bytes(), ios::in | ios::out | ios::binary));
 #else
   // Use boost::bufferstream top reallocate.
   // For std::stringstream, the only way to do this is by passing a string of the appropriate size
   // However, if basic_string doesn't do reference counting, we would have
   // temporarily 2 strings of a (potentially large) size in memory.
   output_stream_sptr.reset
-          (new boost::interprocess::bufferstream(reinterpret_cast<char*>(this->buffer.get()), this->get_size_of_buffer(), ios::in | ios::out | ios::binary));
+          (new boost::interprocess::bufferstream(reinterpret_cast<char*>(this->buffer.get()), this->get_size_of_buffer_in_bytes(), ios::in | ios::out | ios::binary));
 #endif
 
   if (!*output_stream_sptr)
@@ -127,9 +126,9 @@ ProjDataInMemory (const ProjDataInMemory& proj_data)
 
 size_t
 ProjDataInMemory::
-get_size_of_buffer() const
+get_size_of_buffer_in_bytes() const
 {
-  return _num_elements * sizeof(float);
+  return size_all() * sizeof(float);
 }
 
 float 
@@ -148,22 +147,27 @@ axpby(const float a, const ProjData& x,
 {
     // To use this method, we require that all three proj data be ProjDataInMemory
     // So cast them. If any null pointers, fall back to default functionality
-    ProjDataInMemory *x_pdm = dynamic_cast<ProjDataInMemory*>(this);
-    ProjDataInMemory *y_pdm = dynamic_cast<ProjDataInMemory*>(this);
+    const ProjDataInMemory *x_pdm = dynamic_cast<const ProjDataInMemory*>(&x);
+    const ProjDataInMemory *y_pdm = dynamic_cast<const ProjDataInMemory*>(&y);
     // At least one is not ProjDataInMemory, fall back to default
     if (is_null_ptr(x_pdm) || is_null_ptr(y_pdm)) {
         ProjData::axpby(a,x,b,y);
         return;
     }
-    // Get number of elements
-    std::size_t numel = this->_num_elements;
-    if (numel != x_pdm->_num_elements || numel != y_pdm->_num_elements)
-        error("Expected number of elements to match");
 
     // Else, all are ProjDataInMemory
-    float *buffer   = this->buffer.get();
-    float *x_buffer = x_pdm->buffer.get();
-    float *y_buffer = y_pdm->buffer.get();
+
+    // First check that info match
+    if (*get_proj_data_info_sptr() != *x.get_proj_data_info_sptr() ||
+            *get_proj_data_info_sptr() != *y.get_proj_data_info_sptr())
+        error("ProjDataInMemory::axpby: ProjDataInfo don't match");
+
+    // Get number of elements
+    const std::size_t numel = size_all();
+
+    float *buffer = this->buffer.get();
+    const float *x_buffer = x_pdm->buffer.get();
+    const float *y_buffer = y_pdm->buffer.get();
 
     for (unsigned i=0; i<numel; ++i)
         buffer[i] = a*x_buffer[i] + b*y_buffer[i];

--- a/src/include/stir/ProjData.h
+++ b/src/include/stir/ProjData.h
@@ -287,6 +287,7 @@ public:
   //! writes data to a file in Interfile format
   Succeeded write_to_file(const std::string& filename) const;
 
+  /// Implementation of a*x+b*y, where a and b are scalar, and x and y are ProjData
   virtual void axpby(const float a, const ProjData& x,
                      const float b, const ProjData& y);
 

--- a/src/include/stir/ProjData.h
+++ b/src/include/stir/ProjData.h
@@ -287,6 +287,9 @@ public:
   //! writes data to a file in Interfile format
   Succeeded write_to_file(const std::string& filename) const;
 
+  virtual void axpby(const float a, const ProjData& x,
+                     const float b, const ProjData& y);
+
 protected:
 //   shared_ptr<ExamInfo> exam_info_sptr;
 

--- a/src/include/stir/ProjDataInMemory.h
+++ b/src/include/stir/ProjDataInMemory.h
@@ -86,19 +86,27 @@ public:
   //! Returns a  value of a bin
   float get_bin_value(Bin& bin);
     
+  /// axpby where all ProjData are ProjDataInMemory
+  virtual void axpby(const float a, const ProjData& x,
+                     const float b, const ProjData& y);
+
+    
 private:
   // an auto_ptr doesn't work in gcc 2.95.2 because of assignment problems, so we use shared_array
   // note however that the buffer is not shared. we just use it such that its memory gets 
   // deallocated automatically.
-  boost::shared_array<char> buffer;
+  boost::shared_array<float> buffer;
   
   size_t get_size_of_buffer() const;
 
   //! allocates buffer for storing the data. Has to be called by constructors before create_stream()
-  char * create_buffer(const bool initialise_with_0 = false) const;
+  float * create_buffer(const bool initialise_with_0 = false) const;
 
   //! Create a new stream
   shared_ptr<std::iostream> create_stream() const;
+
+  /// Number of elements
+  std::size_t _num_elements;
 };
 
 END_NAMESPACE_STIR

--- a/src/include/stir/ProjDataInMemory.h
+++ b/src/include/stir/ProjDataInMemory.h
@@ -86,7 +86,9 @@ public:
   //! Returns a  value of a bin
   float get_bin_value(Bin& bin);
     
-  /// axpby where all ProjData are ProjDataInMemory
+  /// Implementation of a*x+b*y, where a and b are scalar, and x and y are ProjData.
+  /// This implementation requires that x and y are ProjDataInMemory
+  /// (else falls back on general method)
   virtual void axpby(const float a, const ProjData& x,
                      const float b, const ProjData& y);
 
@@ -97,16 +99,13 @@ private:
   // deallocated automatically.
   boost::shared_array<float> buffer;
   
-  size_t get_size_of_buffer() const;
+  size_t get_size_of_buffer_in_bytes() const;
 
   //! allocates buffer for storing the data. Has to be called by constructors before create_stream()
   float * create_buffer(const bool initialise_with_0 = false) const;
 
   //! Create a new stream
   shared_ptr<std::iostream> create_stream() const;
-
-  /// Number of elements
-  std::size_t _num_elements;
 };
 
 END_NAMESPACE_STIR

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -65,6 +65,7 @@ set(buildblock_simple_tests
 	test_find_fwhm_in_image
 	test_proj_data_info
 	test_proj_data_in_memory
+	test_proj_data_maths
 	test_export_array
         test_GeneralisedPoissonNoiseGenerator
 	test_multiple_proj_data

--- a/src/test/test_proj_data_maths.cxx
+++ b/src/test/test_proj_data_maths.cxx
@@ -1,0 +1,106 @@
+//
+//
+/*!
+
+  \file
+  \ingroup test
+
+  \brief Test maths of stir::ProjData
+
+  \author Richard Brown
+
+*/
+/*
+    Copyright (C) 2020 University College London
+    This file is part of STIR.
+
+    This file is free software; you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.
+
+    This file is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License for more details.
+
+    See STIR/LICENSE.txt for details
+*/
+
+#include "stir/ProjDataInMemory.h"
+#include "stir/ExamInfo.h"
+#include "stir/ProjDataInfo.h"
+#include "stir/Sinogram.h"
+#include "stir/Viewgram.h"
+#include "stir/Succeeded.h"
+#include "stir/RunTests.h"
+#include "stir/Scanner.h"
+
+START_NAMESPACE_STIR
+
+
+/*!
+  \ingroup test
+  \brief Test class for ProjDataInMemory
+*/
+class ProjDataInMemoryTests: public RunTests
+{
+public:
+  void run_tests();
+};
+
+static
+void check_proj_data_are_equal(const ProjData& x, const ProjData& y)
+{
+    const size_t n = x.size_all();
+    const size_t ny = y.size_all();
+    if (n!=ny)
+        error("ProjData::axpby and ProjDataInMemory::axpby mismatch");
+
+    // Create arrays
+    std::vector<float> arr1(n), arr2(n);
+    x.copy_to(arr1.begin());
+    y.copy_to(arr2.begin());
+
+    for (unsigned i=0; i<n; ++i)
+        if (std::abs(arr1[i]-arr2[i]) > 1e-4f)
+            error("ProjData::axpby and ProjDataInMemory::axpby mismatch");
+}
+
+void
+ProjDataInMemoryTests::
+run_tests()
+{
+    // Create scanner and proj data info
+    shared_ptr<Scanner> scanner_sptr(new Scanner(Scanner::E953));
+    shared_ptr<ProjDataInfo> proj_data_info_sptr
+            (ProjDataInfo::ProjDataInfoCTI(scanner_sptr,
+             /*span*/1, 10,/*views*/ 96, /*tang_pos*/128, /*arc_corrected*/ true));
+
+    // Create and fill
+    shared_ptr<ExamInfo> exam_info_sptr(new ExamInfo);
+    ProjDataInMemory pd1(exam_info_sptr, proj_data_info_sptr);
+    const float value = 1.2F;
+    pd1.fill(value);
+
+    // Copy
+    ProjDataInMemory pd2(pd1);
+
+    // Check axpby with general and ProjDataInMemory methods
+    pd1.axpby(2.f,pd1,3.f,pd1);
+    pd2.ProjData::axpby(2.f,pd2,3.f,pd2);
+
+    check_proj_data_are_equal(pd1,pd2);
+}
+
+END_NAMESPACE_STIR
+
+
+USING_NAMESPACE_STIR
+
+int main()
+{
+  ProjDataInMemoryTests tests;
+  tests.run_tests();
+  return tests.main_return_value();
+}


### PR DESCRIPTION
@KrisThielemans - The main thing that you might not be happy with is that I stored `_num_elements` (calculated on construction), which saved me using `size_all`. I can switch back to using `size_all` if you prefer.