### PR TITLE
add axpby to Array and related changes in ProjData

### DIFF
--- a/src/buildblock/ProjData.cxx
+++ b/src/buildblock/ProjData.cxx
@@ -2,7 +2,7 @@
     Copyright (C) 2000 PARAPET partners
     Copyright (C) 2000 - 2010-10-15, Hammersmith Imanet Ltd
     Copyright (C) 2011-07-01 -2013, Kris Thielemans
-    Copyright (C) 2015, University College London
+    Copyright (C) 2015, 2020 University College London
     This file is part of STIR.
 
     This file is free software; you can redistribute it and/or modify
@@ -439,16 +439,7 @@ axpby(const float a, const ProjData& x,
         SegmentBySinogram<float> seg = get_empty_segment_by_sinogram(s);
         const SegmentBySinogram<float> sx = x.get_segment_by_sinogram(s);
         const SegmentBySinogram<float> sy = y.get_segment_by_sinogram(s);
-        SegmentBySinogram<float>::full_iterator seg_iter;
-        SegmentBySinogram<float>::const_full_iterator sx_iter;
-        SegmentBySinogram<float>::const_full_iterator sy_iter;
-        for (seg_iter = seg.begin_all(),
-            sx_iter = sx.begin_all(), sy_iter = sy.begin_all();
-            seg_iter != seg.end_all() &&
-            sx_iter != sx.end_all() && sy_iter != sy.end_all();
-        /*empty*/) {
-            *seg_iter++ = a*(*sx_iter++) + b*(*sy_iter++);
-        }
+        seg.axpby(a, sx, b, sy);
         set_segment(seg);
     }
 }

--- a/src/buildblock/ProjDataInMemory.cxx
+++ b/src/buildblock/ProjDataInMemory.cxx
@@ -9,7 +9,7 @@
 /*
     Copyright (C) 2002 - 2011-02-23, Hammersmith Imanet Ltd
     Copyright (C) 2011, Kris Thielemans
-    Copyright (C) 2019, UCL
+    Copyright (C) 2019, 2020, UCL
     This file is part of STIR.
 
     This file is free software; you can redistribute it and/or modify
@@ -55,7 +55,10 @@ START_NAMESPACE_STIR
 
 ProjDataInMemory::
 ~ProjDataInMemory()
-{}
+{
+  // release such that it can deallocate safely
+  this->buffer.release_data_ptr();
+}
 
 ProjDataInMemory::
 ProjDataInMemory(shared_ptr<ExamInfo> const& exam_info_sptr,
@@ -63,41 +66,44 @@ ProjDataInMemory(shared_ptr<ExamInfo> const& exam_info_sptr,
   :
   ProjDataFromStream(exam_info_sptr, proj_data_info_ptr, shared_ptr<iostream>()) // trick: first initialise sino_stream_ptr to 0
 {
-  this->buffer.reset(create_buffer(initialise_with_0));
-  this->sino_stream = this->create_stream();
+  this->create_buffer(initialise_with_0);
+  this->create_stream();
 }
 
-float *
+void
 ProjDataInMemory::
-create_buffer(const bool initialise_with_0) const
+create_buffer(const bool initialise_with_0)
 {
+#if 0  
   float *b = new float[this->get_size_of_buffer_in_bytes()/sizeof(float)];
   if (initialise_with_0)
       memset(b, 0, this->get_size_of_buffer_in_bytes());
   return b;
+#else
+  this->buffer = Array<1,float>(0, static_cast<int>(this->get_size_of_buffer_in_bytes()/sizeof(float))-1);
+#endif
 }
 
-shared_ptr<std::iostream>
+void
 ProjDataInMemory::
 create_stream()
-const
 {
   shared_ptr<std::iostream> output_stream_sptr;
 #ifdef STIR_USE_OLD_STRSTREAM
-  output_stream_sptr.reset(new strstream(buffer.get(), this->get_size_of_buffer_in_bytes(), ios::in | ios::out | ios::binary));
+  output_stream_sptr.reset(new strstream(buffer.get_data_ptr(), this->get_size_of_buffer_in_bytes(), ios::in | ios::out | ios::binary));
 #else
-  // Use boost::bufferstream top reallocate.
+  // Use boost::bufferstream to avoid reallocate.
   // For std::stringstream, the only way to do this is by passing a string of the appropriate size
   // However, if basic_string doesn't do reference counting, we would have
   // temporarily 2 strings of a (potentially large) size in memory.
   output_stream_sptr.reset
-          (new boost::interprocess::bufferstream(reinterpret_cast<char*>(this->buffer.get()), this->get_size_of_buffer_in_bytes(), ios::in | ios::out | ios::binary));
+          (new boost::interprocess::bufferstream(reinterpret_cast<char*>(this->buffer.get_data_ptr()), this->get_size_of_buffer_in_bytes(), ios::in | ios::out | ios::binary));
 #endif
 
   if (!*output_stream_sptr)
     error("ProjDataInMemory error initialising stream");
 
-  return output_stream_sptr;
+  this->sino_stream = output_stream_sptr;
 }
 
 ProjDataInMemory::
@@ -105,8 +111,8 @@ ProjDataInMemory(const ProjData& proj_data)
   : ProjDataFromStream(proj_data.get_exam_info_sptr(),
 		       proj_data.get_proj_data_info_ptr()->create_shared_clone(), shared_ptr<iostream>())
 {
-  this->buffer.reset(this->create_buffer());
-  this->sino_stream = this->create_stream();
+  this->create_buffer();
+  this->create_stream();
 
   // copy data
   this->fill(proj_data);
@@ -117,8 +123,8 @@ ProjDataInMemory (const ProjDataInMemory& proj_data)
     : ProjDataFromStream(proj_data.get_exam_info_sptr(),
                  proj_data.get_proj_data_info_ptr()->create_shared_clone(), shared_ptr<iostream>())
 {
-  this->buffer.reset(this->create_buffer());
-  this->sino_stream = this->create_stream();
+  this->create_buffer();
+  this->create_stream();
 
   // copy data
   this->fill(proj_data);
@@ -162,6 +168,7 @@ axpby(const float a, const ProjData& x,
             *get_proj_data_info_sptr() != *y.get_proj_data_info_sptr())
         error("ProjDataInMemory::axpby: ProjDataInfo don't match");
 
+#if 0
     // Get number of elements
     const std::size_t numel = size_all();
 
@@ -171,6 +178,9 @@ axpby(const float a, const ProjData& x,
 
     for (unsigned i=0; i<numel; ++i)
         buffer[i] = a*x_buffer[i] + b*y_buffer[i];
+#else
+    this->buffer.axpby(a, x_pdm->buffer, b, y_pdm->buffer);
+#endif
 }
 
 END_NAMESPACE_STIR

--- a/src/include/stir/Array.h
+++ b/src/include/stir/Array.h
@@ -241,8 +241,9 @@ public:
   //@}
 
   //! a*x+b*y, where a and b are scalar, and x and y are arrays
-  inline virtual void axpby(const elemT a, const Array& x,
-                            const elemT b, const Array& y);
+  template <typename elemT2>
+    inline void axpby(const elemT2 a, const Array& x,
+                      const elemT2 b, const Array& y);
 };
 
 

--- a/src/include/stir/Array.h
+++ b/src/include/stir/Array.h
@@ -239,6 +239,10 @@ public:
   inline const elemT&
     at(const BasicCoordinate<num_dimensions,int> &c) const;
   //@}
+
+  //! a*x+b*y, where a and b are scalar, and x and y are arrays
+  inline virtual void axpby(const elemT a, const Array& x,
+                            const elemT b, const Array& y);
 };
 
 
@@ -425,8 +429,6 @@ public:
   inline const elemT&
     at(const BasicCoordinate<1,int> &c) const;
   //@}
-
-  
 };
 
 

--- a/src/include/stir/Array.inl
+++ b/src/include/stir/Array.inl
@@ -330,10 +330,11 @@ Array<num_dimensions,elemT>::at(const BasicCoordinate<num_dimensions,int> &c) co
 }				    
 
 template <int num_dimensions, typename elemT>
+template <typename elemT2>
 void
 Array<num_dimensions,elemT>::
-axpby(const elemT a, const Array& x,
-      const elemT b, const Array& y)
+axpby(const elemT2 a, const Array& x,
+      const elemT2 b, const Array& y)
 {  
   this->check_state();
   if ((this->get_index_range() != x.get_index_range())

--- a/src/include/stir/Array.inl
+++ b/src/include/stir/Array.inl
@@ -329,6 +329,27 @@ Array<num_dimensions,elemT>::at(const BasicCoordinate<num_dimensions,int> &c) co
   return (*this).at(c[1]).at(cut_first_dimension(c)); 
 }				    
 
+template <int num_dimensions, typename elemT>
+void
+Array<num_dimensions,elemT>::
+axpby(const elemT a, const Array& x,
+      const elemT b, const Array& y)
+{  
+  this->check_state();
+  if ((this->get_index_range() != x.get_index_range())
+      || (this->get_index_range() != y.get_index_range()))
+       error("Array::axpby: index ranges don't match");
+
+  typename Array::iterator this_iter = this->begin();
+  typename Array::const_iterator x_iter = x.begin();
+  typename Array::const_iterator y_iter = y.begin();
+  while (this_iter != this->end())
+    {
+      this_iter->axpby(a,*x_iter++, b, *y_iter++);
+      ++this_iter;
+    }
+}
+
 /**********************************************
  inlines for Array<1, elemT>
  **********************************************/

--- a/src/include/stir/NumericVectorWithOffset.h
+++ b/src/include/stir/NumericVectorWithOffset.h
@@ -4,6 +4,7 @@
     Copyright (C) 2000 PARAPET partners
     Copyright (C) 2000 - 2005-06-03, Hammersmith Imanet Ltd
     Copyright (C) 2011-07-01 - 2012, Kris Thielemans
+    Copyright (C) 2020, UCL
     This file is part of STIR.
 
     This file is free software; you can redistribute it and/or modify
@@ -124,6 +125,10 @@ public:
 
   //! dividing the elements of the current vector by an \c elemT 
   inline NumericVectorWithOffset & operator/= (const elemT &v);
+
+  //! a*x+b*y, where a and b are scalar, and x and y are vectors
+  inline virtual void axpby(const elemT a, const NumericVectorWithOffset& x,
+                            const elemT b, const NumericVectorWithOffset& y);
 
 };
 

--- a/src/include/stir/NumericVectorWithOffset.h
+++ b/src/include/stir/NumericVectorWithOffset.h
@@ -127,8 +127,9 @@ public:
   inline NumericVectorWithOffset & operator/= (const elemT &v);
 
   //! a*x+b*y, where a and b are scalar, and x and y are vectors
-  inline virtual void axpby(const elemT a, const NumericVectorWithOffset& x,
-                            const elemT b, const NumericVectorWithOffset& y);
+  template <typename elemT2>
+    inline void axpby(const elemT2 a, const NumericVectorWithOffset& x,
+                      const elemT2 b, const NumericVectorWithOffset& y);
 
 };
 

--- a/src/include/stir/NumericVectorWithOffset.inl
+++ b/src/include/stir/NumericVectorWithOffset.inl
@@ -278,10 +278,11 @@ NumericVectorWithOffset<T, NUMBER>::operator/= (const NUMBER &v)
 }
 
 template <class T, class NUMBER>
+template <class NUMBER2>
 inline void
 NumericVectorWithOffset<T, NUMBER>::
-axpby(const NUMBER a, const NumericVectorWithOffset& x,
-      const NUMBER b, const NumericVectorWithOffset& y)
+axpby(const NUMBER2 a, const NumericVectorWithOffset& x,
+      const NUMBER2 b, const NumericVectorWithOffset& y)
 {  
   this->check_state();
   if ((this->get_min_index() != x.get_min_index())

--- a/src/include/stir/NumericVectorWithOffset.inl
+++ b/src/include/stir/NumericVectorWithOffset.inl
@@ -4,6 +4,7 @@
     Copyright (C) 2000 PARAPET partners
     Copyright (C) 2000 - 2005-06-03, Hammersmith Imanet Ltd
     Copyright (C) 2011-07-01 - 2012, Kris Thielemans
+    Copyright (C) 2013, 2020 University College London
     This file is part of STIR.
 
     This file is free software; you can redistribute it and/or modify
@@ -274,6 +275,28 @@ NumericVectorWithOffset<T, NUMBER>::operator/= (const NUMBER &v)
     this->num[i] /= v;
   this->check_state();
   return *this;
+}
+
+template <class T, class NUMBER>
+inline void
+NumericVectorWithOffset<T, NUMBER>::
+axpby(const NUMBER a, const NumericVectorWithOffset& x,
+      const NUMBER b, const NumericVectorWithOffset& y)
+{  
+  this->check_state();
+  if ((this->get_min_index() != x.get_min_index())
+      || (this->get_min_index() != y.get_min_index())
+      || (this->get_max_index() != x.get_max_index())
+      || (this->get_max_index() != y.get_max_index()))
+       error("NumericVectorWithOffset::axpby: index ranges don't match");
+
+  typename NumericVectorWithOffset::iterator this_iter = this->begin();
+  typename NumericVectorWithOffset::const_iterator x_iter = x.begin();
+  typename NumericVectorWithOffset::const_iterator y_iter = y.begin();
+  while (this_iter != this->end())
+    {
+      *this_iter++ = (*x_iter++) * a + (*y_iter++) * b;
+    }
 }
 
 END_NAMESPACE_STIR

--- a/src/include/stir/ProjDataInMemory.h
+++ b/src/include/stir/ProjDataInMemory.h
@@ -1,6 +1,6 @@
 /*
     Copyright (C) 2002 - 2011-02-23, Hammersmith Imanet Ltd
-    Copyright (C) 2019, UCL
+    Copyright (C) 2019-2020, UCL
     This file is part of STIR.
 
     This file is free software; you can redistribute it and/or modify
@@ -27,7 +27,7 @@
 #define __stir_ProjDataInMemory_H__
 
 #include "stir/ProjDataFromStream.h" 
-#include "boost/shared_array.hpp"
+#include "stir/Array.h"
 #include <string>
 
 /* Implementation note (KT)
@@ -94,18 +94,15 @@ public:
 
     
 private:
-  // an auto_ptr doesn't work in gcc 2.95.2 because of assignment problems, so we use shared_array
-  // note however that the buffer is not shared. we just use it such that its memory gets 
-  // deallocated automatically.
-  boost::shared_array<float> buffer;
+  Array<1,float> buffer;
   
   size_t get_size_of_buffer_in_bytes() const;
 
   //! allocates buffer for storing the data. Has to be called by constructors before create_stream()
-  float * create_buffer(const bool initialise_with_0 = false) const;
+  void create_buffer(const bool initialise_with_0 = false);
 
   //! Create a new stream
-  shared_ptr<std::iostream> create_stream() const;
+  void create_stream();
 };
 
 END_NAMESPACE_STIR

--- a/src/include/stir/VectorWithOffset.inl
+++ b/src/include/stir/VectorWithOffset.inl
@@ -70,8 +70,6 @@ VectorWithOffset<T>::check_state() const
   assert(begin_allocated_memory <= num+start);
   assert(end_allocated_memory>=begin_allocated_memory);
   assert(static_cast<unsigned>(end_allocated_memory-begin_allocated_memory) >= length);
-  // check if data is being accessed via a pointer (see get_data_ptr())
-  assert(pointer_access == false);
 }
 
 template <class T>
@@ -79,6 +77,8 @@ void
 VectorWithOffset<T>::
 _destruct_and_deallocate() 
 {
+  // check if data is being accessed via a pointer (see get_data_ptr())
+  assert(pointer_access == false);
   // TODO when reserve() no longer initialises new elements,
   // we'll have to be careful to delete only initialised elements
   // and just de-allocate the rest
@@ -306,6 +306,8 @@ VectorWithOffset(const int min_index, const int max_index,
 template <class T>
 VectorWithOffset<T>::~VectorWithOffset()
 { 
+  // check if data is being accessed via a pointer (see get_data_ptr())
+  assert(pointer_access == false);
   _destruct_and_deallocate();
 }		
 
@@ -379,6 +381,9 @@ reserve(const int new_capacity_min_index, const int new_capacity_max_index)
     static_cast<unsigned>(actual_capacity_max_index - actual_capacity_min_index) + 1;
   if (new_capacity <= this->capacity())
     return;
+
+  // check if data is being accessed via a pointer (see get_data_ptr())
+  assert(pointer_access == false);
   // TODO use allocator here instead of new
   T *newmem = new T[new_capacity];
   const unsigned extra_at_the_left =

--- a/src/test/test_Array.cxx
+++ b/src/test/test_Array.cxx
@@ -2,7 +2,7 @@
     Copyright (C) 2000 PARAPET partners
     Copyright (C) 2000-2011, Hammersmith Imanet Ltd
     Copyright (C) 2013 Kris Thielemans
-    Copyright (C) 2013 University College London
+    Copyright (C) 2013, 2020 University College London
 
     This file is part of STIR.
 
@@ -729,6 +729,15 @@ ArrayTests::run_tests()
       // KT 20/12/2001 made check_if_zero compare relative to 1 by dividing
       check_if_zero( (test4.sum() + 2*tmp2.sum() - tmp.sum())/test4.sum(), 
                      "test operator+(float)");
+    }
+
+    // test apxby
+    {
+      Array<4,float> tmp(test4.get_index_range());
+      Array<4,float> tmp2(test4+2);
+      tmp.axpby(2.F, test4, 3.3F, tmp2);
+      const Array<4,float> by_hand = test4*2.F + (test4+2)*3.3F;
+      check_if_equal(tmp, by_hand, "test apxby (Array4D)");
     }
   }
 


### PR DESCRIPTION
- add axpby to NumericVectorWithOffset and Array
- use Array::axbpy in ProjData::axbpy
- change buffer in ProjDataInMemory to Array<1,float> such that we have axbpy for free (and remove boost dependency)

Fixes #560 although pending decision on signature of axpby
