### PR TITLE
Gate/root cylindrical PET geometry fixes

### DIFF
--- a/documentation/STIR-UsersGuide.tex
+++ b/documentation/STIR-UsersGuide.tex
@@ -681,11 +681,12 @@ We tend to name this header \texttt{something.hroot} but this is not mandatory.
 We currently support only ROOT output using the CylindricalPET and ECAT systems
 from GATE.
 
-\textbf{Warning:} There is a check of consistent scanner geometry information between \textit{STIR} 
-and OpenGATE as discrepancies can lead to crashes if the actual number of blocks/crystals etc is 
-larger than what is specified in the scanner info.
+\textbf{Warning:} There is a check of consistent scanner geometry information between \textit{STIR}
+and OpenGATE as discrepancies can lead to crashes if the actual number of blocks/crystals etc is
+larger than what is specified in the scanner info. However, this check requires the \texttt{.hroot}
+file to accurately correspond to your GATE macro.
 
-An OpenGATE scanner geometry is modular. For CylindricalPET, \textit{STIR} uses the conversion 
+An OpenGATE scanner geometry is modular. For CylindricalPET, \textit{STIR} uses the conversion
 scheme detailed in Table \ref{tab:STIR-OpenGATE_terminology}.
 
 \begin{table}[h]
@@ -694,13 +695,13 @@ scheme detailed in Table \ref{tab:STIR-OpenGATE_terminology}.
             \hline
             \textbf{GATE} & \textbf{STIR}  \\ 
             \hline
-            Crystal & Crystal  \\  
+            Crystal & Crystal  \\
             Submodule & Block  \\
             Module & Bucket  \\
             Rsector & Buckets around the ring  \\
             \hline
         \end{tabular}
-    \caption{A guide on the terminology equivalents between STIR and OpenGATE for CylindricalPET 
+    \caption{A guide on the terminology equivalents between STIR and OpenGATE for CylindricalPET
     scanner geometries.}
     \label{tab:STIR-OpenGATE_terminology}
 \end{table}
@@ -735,8 +736,8 @@ Average depth of interaction (cm)        := 0.7
 Distance between rings (cm)              := 0.40625
 Default bin size (cm)                    := 0.208626
 Maximum number of non-arc-corrected bins := 344
-Default number of arc-corrected bins     := 344
-View offset (degrees)                    := 0
+Default number of arc-corrected bins     := 344 ; default is same as previous value
+View offset (degrees)                    := 0 ; default
 
 GATE scanner type := GATE_Cylindrical_PET
 GATE_Cylindrical_PET Parameters :=
@@ -760,8 +761,8 @@ GATE_Cylindrical_PET Parameters :=
 
   Singles readout depth := 1
   exclude scattered events := 0
-  exclude random events := 0 
-  offset (num of detectors) := 0 
+  exclude random events := 0
+  offset (num of detectors) := 0
 
   low energy window (keV) := 0      ; Default 0
   upper energy window (keV):= 10000 ; Default 10000
@@ -770,6 +771,8 @@ End GATE_Cylindrical_PET Parameters :=
 
 end ROOT header := 
 \end{verbatim}
+
+See \texttt{examples/samples/root\_headerECAT.hroot} for an example using the ECAT system.
 
 There are some unfinished classes
 available on the \textit{STIR} web-site to read \textit{LMF} format files,

--- a/documentation/STIR-UsersGuide.tex
+++ b/documentation/STIR-UsersGuide.tex
@@ -678,12 +678,33 @@ You need to create a text file header for your ROOT file
 to specify the scanner (as this information is not stored in the ROOT file).
 We tend to name this header \texttt{something.hroot} but this is not mandatory.
 
-\textbf{Warning:} There is currently no check if the scanner information is correct. This
-  is dangerous for the geometry, but can also lead to crashes if the actual number of 
-  blocks/crystals etc is larger than what is specified in the scanner info.
-
 We currently support only ROOT output using the CylindricalPET and ECAT systems
 from GATE.
+
+\textbf{Warning:} There is a check of consistent scanner geometry information between \textit{STIR} 
+and OpenGATE as discrepancies can lead to crashes if the actual number of blocks/crystals etc is 
+larger than what is specified in the scanner info.
+
+An OpenGATE scanner geometry is modular. For CylindricalPET, \textit{STIR} uses the conversion 
+scheme detailed in Table \ref{tab:STIR-OpenGATE_terminology}.
+
+\begin{table}[h]
+    \centering
+        \begin{tabular}{ |c | c| }
+            \hline
+            \textbf{GATE} & \textbf{STIR}  \\ 
+            \hline
+            Crystal & Crystal  \\  
+            Submodule & Block  \\
+            Module & Bucket  \\
+            Rsector & Buckets around the ring  \\
+            \hline
+        \end{tabular}
+    \caption{A guide on the terminology equivalents between STIR and OpenGATE for CylindricalPET 
+    scanner geometries.}
+    \label{tab:STIR-OpenGATE_terminology}
+\end{table}
+
 
 A full example is given in \texttt{examples/samples/root\_header.hroot}. Below are
 2 shorter examples.
@@ -714,13 +735,37 @@ Average depth of interaction (cm)        := 0.7
 Distance between rings (cm)              := 0.40625
 Default bin size (cm)                    := 0.208626
 Maximum number of non-arc-corrected bins := 344
+Default number of arc-corrected bins     := 344
+View offset (degrees)                    := 0
 
 GATE scanner type := GATE_Cylindrical_PET
 GATE_Cylindrical_PET Parameters :=
   ; name of the actual ROOT file
   name of data file := mysim.root
 
-  ; See elsewhere for other parameters
+  ; root tree chain to use
+  name of input TChain := Coincidences
+
+  ; Gate scanner geometry terminology used to check scanner properties
+  number of Rsectors := 504 
+  number of modules_X := 1 
+  number of modules_Y := 1
+  number of modules_Z := 1
+  number of submodules_X := 1
+  number of submodules_Y := 1
+  number of submodules_Z := 1
+  number of crystals_X := 1
+  number of crystals_Y := 1
+  number of crystals_Z := 4
+
+  Singles readout depth := 1
+  exclude scattered events := 0
+  exclude random events := 0 
+  offset (num of detectors) := 0 
+
+  low energy window (keV) := 0      ; Default 0
+  upper energy window (keV):= 10000 ; Default 10000
+
 End GATE_Cylindrical_PET Parameters :=
 
 end ROOT header := 

--- a/documentation/release_4.1.htm
+++ b/documentation/release_4.1.htm
@@ -24,7 +24,7 @@
           DOI: <a href=https://doi.org/10.1016/j.ymeth.2020.01.005>10.1016/j.ymeth.2020.01.005</a>
         </li>
         <li>Richard Brown (UCL) for wrapping of NiftyPET's GPU functionality for projecting and unlisting</li>
-        <li>Robert Twyman (UCL) for Relative Difference Prior and computation of the log-likelihood modification</li>  
+        <li>Robert Twyman (UCL) for Relative Difference Prior, computation of the log-likelihood modification, and GATE geometry check fixes. </li>  
       </ul>
     </p>
 
@@ -93,6 +93,8 @@ We have currently no work-around (aside from using <code>GRAPHICS=PGM</code> or
 <h3>Minor bug fixes</h3>
 <ul>
 <li>
+  Changes to GATE/root cylindrical PET geometr interpretation, 
+  see <a href="https://github.com/UCL/STIR/pull/569">PR 569</a>.</li>
 </li>
 </ul>
 

--- a/documentation/release_4.1.htm
+++ b/documentation/release_4.1.htm
@@ -93,7 +93,7 @@ We have currently no work-around (aside from using <code>GRAPHICS=PGM</code> or
 <h3>Minor bug fixes</h3>
 <ul>
 <li>
-  Changes to GATE/root cylindrical PET geometr interpretation, 
+  Changes to GATE/root cylindrical PET geometry interpretation,
   see <a href="https://github.com/UCL/STIR/pull/569">PR 569</a>.</li>
 </li>
 </ul>

--- a/examples/samples/root_header.hroot
+++ b/examples/samples/root_header.hroot
@@ -37,9 +37,8 @@ exclude scattered events := 0
 exclude random events := 0 
 offset (num of detectors) := 0 
 
-; If want to deactivate set to [0, 1000]
-low energy window (keV) := 0
-upper energy window (keV):= 1000
+low energy window (keV) := 0  		; Default 0
+upper energy window (keV):= 10000	; Default 10000
 
 End GATE_Cylindrical_PET Parameters :=
 

--- a/examples/samples/root_header.hroot
+++ b/examples/samples/root_header.hroot
@@ -1,5 +1,6 @@
 ROOT header := 
 
+; More information regaring .hroot files may be found in the UsersGuide
 originating system := User_defined_scanner
 Number of rings                          := 4
 Number of detectors per ring             := 504
@@ -8,7 +9,8 @@ Average depth of interaction (cm)        := 0.7
 Distance between rings (cm)              := 0.40625
 Default bin size (cm)                    := 0.208626
 Maximum number of non-arc-corrected bins := 344
-
+Default number of arc-corrected bins 	 := 344
+View offset (degrees)					 := 0
 
 
 GATE scanner type := GATE_Cylindrical_PET
@@ -18,9 +20,7 @@ name of data file := benchmarkPET.root
 
 name of input TChain := Coincidences
 
-; As the GATE repeaters. 
-; If you skip a level in GATE's hierarchy, 
-; use 1.
+; Gate scanner geometry terminology used to check scanner properties
 number of Rsectors := 504 
 number of modules_X := 1 
 number of modules_Y := 1
@@ -32,29 +32,9 @@ number of crystals_X := 1
 number of crystals_Y := 1
 number of crystals_Z := 4
 
-;; From GATE's online documentation: 
-;; (http://wiki.opengatecollaboration.org/index.php/Users_Guide_V7.2:Digitizer_and_readout_parameters)
-;; [...] the readout depth depends upon how the electronic readout functions.
-;; If one PMT reads the four modules in the axial direction, 
-;; the depth should be set with the command:
-;; /gate/digitizer/Singles/readout/setDepth 1 
-;
-; In STIR terminology this will be used to define the number of crystals
-; per singles unit. 
 Singles readout depth := 1
-
-;
-; If set the scattered events will be skipped
 exclude scattered events := 0
-
-;
-; If set the random events will be skipped
 exclude random events := 0 
-
-; 
-; STIR will try to align the data. 
-; If you have used non standart GATE axes, 
-; rotate using: 
 offset (num of detectors) := 0 
 
 ; If want to deactivate set to [0, 1000]

--- a/examples/samples/root_header.hroot
+++ b/examples/samples/root_header.hroot
@@ -1,6 +1,6 @@
 ROOT header := 
 
-; More information regaring .hroot files may be found in the UsersGuide
+; More information regarding .hroot files may be found in the UsersGuide
 originating system := User_defined_scanner
 Number of rings                          := 4
 Number of detectors per ring             := 504

--- a/recon_test_pack/root_header.hroot
+++ b/recon_test_pack/root_header.hroot
@@ -1,5 +1,6 @@
 ROOT header := 
 
+; More information regaring .hroot files may be found in the UsersGuide
 originating system := User_defined_scanner
 Number of rings                          := 4
 Number of detectors per ring             := 504
@@ -8,7 +9,8 @@ Average depth of interaction (cm)        := 0.7
 Distance between rings (cm)              := 0.40625
 Default bin size (cm)                    := 0.208626
 Maximum number of non-arc-corrected bins := 344
-
+Default number of arc-corrected bins 	 := 344
+View offset (degrees)					 := 0
 
 
 GATE scanner type := GATE_Cylindrical_PET
@@ -18,9 +20,7 @@ name of data file := ${INPUT_ROOT_FILE}
 
 name of input TChain := Coincidences
 
-; As the GATE repeaters. 
-; If you skip a level in GATE's hierarchy, 
-; use 1.
+; Gate scanner geometry terminology used to check scanner properties
 number of Rsectors := 504 
 number of modules_X := 1 
 number of modules_Y := 1
@@ -32,29 +32,9 @@ number of crystals_X := 1
 number of crystals_Y := 1
 number of crystals_Z := 4
 
-;; From GATE's online documentation: 
-;; (http://wiki.opengatecollaboration.org/index.php/Users_Guide_V7.2:Digitizer_and_readout_parameters)
-;; [...] the readout depth depends upon how the electronic readout functions.
-;; If one PMT reads the four modules in the axial direction, 
-;; the depth should be set with the command:
-;; /gate/digitizer/Singles/readout/setDepth 1 
-;
-; In STIR terminology this will be used to define the number of crystals
-; per singles unit. 
 Singles readout depth := 1
-
-;
-; If set the scattered events will be skipped
 exclude scattered events := ${EXCLUDE_SCATTERED}
-
-;
-; If set the random events will be skipped
 exclude random events := ${EXCLUDE_RANDOM}
-
-; 
-; STIR will try to align the data. 
-; If you have used non standart GATE axes, 
-; rotate using: 
 offset (num of detectors) := 0 
 
 ; If want to deactivate set to [0, 10000]

--- a/recon_test_pack/root_header.hroot
+++ b/recon_test_pack/root_header.hroot
@@ -1,6 +1,6 @@
 ROOT header := 
 
-; More information regaring .hroot files may be found in the UsersGuide
+; More information regarding .hroot files may be found in the UsersGuide
 originating system := User_defined_scanner
 Number of rings                          := 4
 Number of detectors per ring             := 504

--- a/recon_test_pack/root_header.hroot
+++ b/recon_test_pack/root_header.hroot
@@ -37,9 +37,8 @@ exclude scattered events := ${EXCLUDE_SCATTERED}
 exclude random events := ${EXCLUDE_RANDOM}
 offset (num of detectors) := 0 
 
-; If want to deactivate set to [0, 10000]
-low energy window (keV) := 0
-upper energy window (keV):= 10000
+low energy window (keV) := 0  		; Default 0
+upper energy window (keV):= 10000	; Default 10000
 
 End GATE_Cylindrical_PET Parameters :=
 

--- a/src/include/stir/IO/InputStreamFromROOTFileForCylindricalPET.inl
+++ b/src/include/stir/IO/InputStreamFromROOTFileForCylindricalPET.inl
@@ -1,5 +1,6 @@
 /*
-    Copyright (C) 2016, UCL
+    Copyright (C) 2016, 2020, UCL
+    Copyright (C) 2018 University of Hull
     This file is part of STIR.
 
     This file is free software; you can redistribute it and/or modify
@@ -13,6 +14,15 @@
     GNU Lesser General Public License for more details.
 
     See STIR/LICENSE.txt for details
+*/
+/*!
+  \file
+  \ingroup listmode
+  \brief Implementation of class stir::InputStreamFromROOTFileForCylindricalPET
+
+  \author Nikos Efthimiou
+  \author Kris Thielemans
+  \author Robbie Twyman
 */
 
 START_NAMESPACE_STIR

--- a/src/include/stir/IO/InputStreamFromROOTFileForCylindricalPET.inl
+++ b/src/include/stir/IO/InputStreamFromROOTFileForCylindricalPET.inl
@@ -33,35 +33,32 @@ get_num_dets_per_ring() const
                             this->submodule_repeater_y * this->crystal_repeater_y);
 }
 
+int
+InputStreamFromROOTFileForCylindricalPET::
+get_num_transaxial_blocks_per_bucket_v() const
+{
+    return this->submodule_repeater_y;
+}
 
 int
 InputStreamFromROOTFileForCylindricalPET::
 get_num_axial_blocks_per_bucket_v() const
 {
-    return this->module_repeater_z;
-}
-
-int
-InputStreamFromROOTFileForCylindricalPET::
-get_num_transaxial_blocks_per_bucket_v() const
-{
-    return this->module_repeater_y;
+    return this->submodule_repeater_z;
 }
 
 int
 InputStreamFromROOTFileForCylindricalPET::
 get_num_axial_crystals_per_block_v() const
 {
-    return static_cast<int>(this->crystal_repeater_z *
-                            this->module_repeater_z);
+    return this->crystal_repeater_z;
 }
 
 int
 InputStreamFromROOTFileForCylindricalPET::
 get_num_transaxial_crystals_per_block_v() const
 {
-    return static_cast<int>(this->crystal_repeater_y *
-                            this->module_repeater_y);
+    return this->crystal_repeater_y;
 }
 
 int

--- a/src/include/stir/IO/InputStreamFromROOTFileForCylindricalPET.inl
+++ b/src/include/stir/IO/InputStreamFromROOTFileForCylindricalPET.inl
@@ -17,7 +17,7 @@
 */
 /*!
   \file
-  \ingroup listmode
+  \ingroup IO
   \brief Implementation of class stir::InputStreamFromROOTFileForCylindricalPET
 
   \author Nikos Efthimiou

--- a/src/include/stir/listmode/CListModeDataROOT.h
+++ b/src/include/stir/listmode/CListModeDataROOT.h
@@ -163,6 +163,10 @@ private:
     int num_detectors_per_ring;
     //! Number of non arc corrected bins, set in the hroot file (optional)
     int max_num_non_arccorrected_bins;
+    //! Default number of arc corrected bins, set in the hroot file (optional)
+    int default_num_arccorrected_bins;
+    //! Angle in degrees corresponding to view offset (optional)
+    float view_offset;
     //! Inner ring diameter, set in the hroot file (optional)
     float inner_ring_diameter;
     //! Average depth of interaction, set in the hroot file (optional)

--- a/src/listmode_buildblock/CListModeDataROOT.cxx
+++ b/src/listmode_buildblock/CListModeDataROOT.cxx
@@ -1,6 +1,6 @@
 /*
     Copyright (C) 2015, 2016 University of Leeds
-    Copyright (C) 2016, 2017 University College London
+    Copyright (C) 2016, 2017, 2020 University College London
     Copyright (C) 2018 University of Hull
     This file is part of STIR.
 
@@ -24,6 +24,7 @@
   \author Nikos Efthimiou
   \author Harry Tsoumpas
   \author Kris Thielemans
+  \author Robbie Twyman
 */
 
 #include "stir/listmode/CListModeDataROOT.h"

--- a/src/listmode_buildblock/CListModeDataROOT.cxx
+++ b/src/listmode_buildblock/CListModeDataROOT.cxx
@@ -56,7 +56,9 @@ CListModeDataROOT(const std::string& hroot_filename)
     this->parser.add_key("Average depth of interaction (cm)", &this->average_depth_of_interaction);
     this->parser.add_key("Distance between rings (cm)", &this->ring_spacing);
     this->parser.add_key("Default bin size (cm)", &this->bin_size);
+    this->parser.add_key("View offset (degrees)", &this->view_offset);
     this->parser.add_key("Maximum number of non-arc-corrected bins", &this->max_num_non_arccorrected_bins);
+    this->parser.add_key("Default number of arc-corrected bins", &this->default_num_arccorrected_bins);
     // end Scanner and physical dimensions.
 
     // ROOT related
@@ -115,14 +117,15 @@ CListModeDataROOT(const std::string& hroot_filename)
                                              /* number of non arccor bins */
                                              this->max_num_non_arccorrected_bins,
                                              /* number of maximum arccor bins */
-                                             this->max_num_non_arccorrected_bins,
+                                             this->default_num_arccorrected_bins,
                                              /* inner ring radius */
                                              this->inner_ring_diameter/0.2f,
                                              /* doi */ this->average_depth_of_interaction * 10.f,
                                              /* ring spacing */
                                              this->ring_spacing * 10.f,
                                              this->bin_size * 10.f,
-                                             /* offset*/ 0,
+                                             /* offset*/ 
+                                             this->view_offset * _PI /180,
                                              /*num_axial_blocks_per_bucket_v */
                                              this->root_file_sptr->get_num_axial_blocks_per_bucket_v(),
                                              /*num_transaxial_blocks_per_bucket_v*/
@@ -224,10 +227,12 @@ set_defaults()
     num_rings = -1;
     num_detectors_per_ring = -1;
     max_num_non_arccorrected_bins = -1;
+    default_num_arccorrected_bins = -1;
     inner_ring_diameter = -1.f;
     average_depth_of_interaction = -1.f;
     ring_spacing = -.1f;
     bin_size = -1.f;
+    view_offset = 0.f;
 }
 
 Succeeded
@@ -301,6 +306,7 @@ check_scanner_definition(std::string& ret)
     if ( num_rings == -1 ||
          num_detectors_per_ring == -1 ||
          max_num_non_arccorrected_bins == -1 ||
+         default_num_arccorrected_bins == -1 ||
          inner_ring_diameter == -1.f ||
          average_depth_of_interaction == -1.f ||
          ring_spacing == -.1f ||
@@ -316,6 +322,9 @@ check_scanner_definition(std::string& ret)
 
        if (max_num_non_arccorrected_bins == -1)
            stream << "Maximum number of non-arc-corrected bins := \n";
+
+       if (default_num_arccorrected_bins == -1)
+           stream << "Default number of arc-corrected bins := \n";
 
        if (inner_ring_diameter == -1)
            stream << "Inner ring diameter (cm) := \n";

--- a/src/listmode_buildblock/CListModeDataROOT.cxx
+++ b/src/listmode_buildblock/CListModeDataROOT.cxx
@@ -107,6 +107,10 @@ CListModeDataROOT(const std::string& hroot_filename)
         {
             error(error_str.c_str());
         }
+        if (default_num_arccorrected_bins == -1)
+        {
+            default_num_arccorrected_bins = max_num_non_arccorrected_bins;
+        }
 
         this_scanner_sptr.reset(new Scanner(Scanner::User_defined_scanner,
                                              std::string ("ROOT_defined_scanner"),
@@ -306,7 +310,6 @@ check_scanner_definition(std::string& ret)
     if ( num_rings == -1 ||
          num_detectors_per_ring == -1 ||
          max_num_non_arccorrected_bins == -1 ||
-         default_num_arccorrected_bins == -1 ||
          inner_ring_diameter == -1.f ||
          average_depth_of_interaction == -1.f ||
          ring_spacing == -.1f ||
@@ -322,9 +325,6 @@ check_scanner_definition(std::string& ret)
 
        if (max_num_non_arccorrected_bins == -1)
            stream << "Maximum number of non-arc-corrected bins := \n";
-
-       if (default_num_arccorrected_bins == -1)
-           stream << "Default number of arc-corrected bins := \n";
 
        if (inner_ring_diameter == -1)
            stream << "Inner ring diameter (cm) := \n";


### PR DESCRIPTION
Fixes STIR's interpretation of Gate geometries for cylindrical PET. #563

GATE | STIR
-- | --
crystal | crystal
submodule | block
module | bucket
rsector | (just puts buckets along the ring)


--------
Additionally, adds the ability for `default_num_arccorrected_bins` and `view_offset` to be set from the `.hroot`. I found this was required as for the case of `User_defined_scanner`, where `default_num_arccorrected_bins != max_num_non_arccorrected_bins`, which is where is was previously set from. Similar was found for `view_offset`.

