### PR TITLE
GatedProjData multi format and read_from_file returns unique_ptr

### DIFF
--- a/src/buildblock/GatedProjData.cxx
+++ b/src/buildblock/GatedProjData.cxx
@@ -136,7 +136,7 @@ read_from_file(const string& filename) // The written image is read in respect t
   if (strncmp(signature, "Multi", 5) == 0) {
 
 #ifndef NDEBUG
-        info(boost::format("DynamicProjData::read_from_file trying to read %s as a Multi file.") % filename);
+        info(boost::format("GatedProjData::read_from_file trying to read %s as a Multi file.") % filename);
 #endif
 
       unique_ptr<MultipleProjData> multi_proj_data(MultipleProjData::read_from_file(filename));

--- a/src/buildblock/GatedProjData.cxx
+++ b/src/buildblock/GatedProjData.cxx
@@ -38,7 +38,7 @@ using std::string;
 
 START_NAMESPACE_STIR
 
-GatedProjData*
+unique_ptr<GatedProjData>
 GatedProjData::
 read_from_file(const string& filename) // The written image is read in respect to its center as origin!!!
 {
@@ -46,13 +46,13 @@ read_from_file(const string& filename) // The written image is read in respect t
   if (!input)
     {
       warning("GatedProjData::read_from_file cannot read file '%s'. Will now attempt to append .gdef", filename.c_str());
-      return read_from_gdef(filename);
+      return unique_ptr<GatedProjData>(read_from_gdef(filename));
     }
 
   const FileSignature file_signature(input);
   const char * signature = file_signature.get_signature();
 
-  GatedProjData * gated_proj_data_ptr = 0;
+  unique_ptr<GatedProjData> gated_proj_data_sptr;
 
 #ifdef HAVE_LLN_MATRIX
   if (strncmp(signature, "MATRIX", 6) == 0)
@@ -117,27 +117,36 @@ read_from_file(const string& filename) // The written image is read in respect t
 	   return 0;
 	 }
     
-       gated_proj_data_ptr = new GatedProjData;
+       gated_proj_data_sptr.reset(new GatedProjData);
        const unsigned int num_gates =
 	 static_cast<unsigned int>(filenames.size());
-       gated_proj_data_ptr->_proj_datas.resize(num_gates); 
+       gated_proj_data_sptr->_proj_datas.resize(num_gates);
 
        for (unsigned int gate_num=1; gate_num <= num_gates; ++ gate_num)
 	 {
 	   std::cerr<<" Reading " << filenames[gate_num-1]<<'\n';
-	   gated_proj_data_ptr->_proj_datas[gate_num-1] =
+	   gated_proj_data_sptr->_proj_datas[gate_num-1] =
 	     ProjData::read_from_file(filenames[gate_num-1]);
 	 }
        // Get the exam info (from the first ProjData)
        if (num_gates>0)
-         gated_proj_data_ptr->set_exam_info(gated_proj_data_ptr->_proj_datas[0]->get_exam_info());
-      return gated_proj_data_ptr;
+         gated_proj_data_sptr->set_exam_info(gated_proj_data_sptr->_proj_datas[0]->get_exam_info());
+      return gated_proj_data_sptr;
      }    
+  if (strncmp(signature, "Multi", 5) == 0) {
+
+#ifndef NDEBUG
+        info(boost::format("DynamicProjData::read_from_file trying to read %s as a Multi file.") % filename);
+#endif
+
+      unique_ptr<MultipleProjData> multi_proj_data(MultipleProjData::read_from_file(filename));
+      gated_proj_data_sptr.reset(new GatedProjData(*multi_proj_data));
+  }
   
-  if (is_null_ptr(gated_proj_data_ptr))   
+  if (is_null_ptr(gated_proj_data_sptr))
     error("GatedProjData::read_from_file unrecognised file format for file '%s'",
 	  filename.c_str());
-  return gated_proj_data_ptr;
+  return gated_proj_data_sptr;
 }
 
 GatedProjData* 

--- a/src/buildblock/GatedProjData.cxx
+++ b/src/buildblock/GatedProjData.cxx
@@ -31,8 +31,10 @@
 #include "stir/Succeeded.h"
 #include "stir/KeyParser.h"
 #include "stir/is_null_ptr.h"
+#include "stir/info.h"
 #include <fstream>
 #include <sstream>
+#include <boost/format.hpp>
 
 using std::string;
 

--- a/src/buildblock/GatedProjData.cxx
+++ b/src/buildblock/GatedProjData.cxx
@@ -69,27 +69,27 @@ read_from_file(const string& filename) // The written image is read in respect t
       if (read_ECAT7_main_header(mhead, filename) == Succeeded::no)
 	{
 	  warning("GatedProjData::read_from_file cannot read %s as ECAT7\n", filename.c_str());
-	  return 0;
+	  return unique_ptr<GatedProjData>();
 	}
-      gated_proj_data_ptr = new GatedProjData;
+      gated_proj_data_sptr.reset(new GatedProjData);
 
       const unsigned int num_gates =
 	static_cast<unsigned int>(mhead.num_gates); // TODO +1?
-      gated_proj_data_ptr->_proj_datas.resize(num_gates); 
+      gated_proj_data_sptr->_proj_datas.resize(num_gates); 
 
       for (unsigned int gate_num=1; gate_num <= num_gates; ++ gate_num)
 	{
-	  gated_proj_data_ptr->_proj_datas[gate_num-1].reset(
+	  gated_proj_data_sptr->_proj_datas[gate_num-1].reset(
 	    ECAT7_to_PDFS(filename,
 			  1,
 			  gate_num, 
 			  /*  data_num, bed_num, */ 0,0));
 	}
-      if (is_null_ptr(gated_proj_data_ptr->_proj_datas[0]))
+      if (is_null_ptr(gated_proj_data_sptr->_proj_datas[0]))
 	      error("GatedProjData: No gate available\n");
       // Get the exam info (from the first ProjData)
       if (num_gates>0)
-        gated_proj_data_ptr->set_exam_info(gated_proj_data_ptr->_proj_datas[0]->get_exam_info());
+        gated_proj_data_sptr->set_exam_info(gated_proj_data_sptr->_proj_datas[0]->get_exam_info());
     }
     else
     {
@@ -114,7 +114,7 @@ read_from_file(const string& filename) // The written image is read in respect t
        if (parser.parse(filename.c_str()) == false)
 	 {
 	   warning("GatedProjData:::read_from_file: Error parsing %s", filename.c_str());
-	   return 0;
+	   return unique_ptr<GatedProjData>();
 	 }
     
        gated_proj_data_sptr.reset(new GatedProjData);

--- a/src/experimental/motion/PoissonLogLikelihoodWithLinearModelForMeanAndGatedProjDataWithMotion.cxx
+++ b/src/experimental/motion/PoissonLogLikelihoodWithLinearModelForMeanAndGatedProjDataWithMotion.cxx
@@ -219,7 +219,7 @@ post_processing()
   if (this->_input_filename.length() == 0)
   { warning("You need to specify an input file"); return true; }
  
-  this->_gated_proj_data_sptr.reset(GatedProjData::read_from_file(this->_input_filename));
+  this->_gated_proj_data_sptr = GatedProjData::read_from_file(this->_input_filename);
 
  // image stuff
   if (this->zoom <= 0)
@@ -233,8 +233,8 @@ post_processing()
 
   if (this->_additive_projection_data_filename != "0")
   {
-    this->_gated_additive_proj_data_sptr
-      .reset(GatedProjData::read_from_file(this->_additive_projection_data_filename));
+    this->_gated_additive_proj_data_sptr =
+              GatedProjData::read_from_file(this->_additive_projection_data_filename);
   };
 
   // read time frame def 

--- a/src/include/stir/GatedProjData.h
+++ b/src/include/stir/GatedProjData.h
@@ -38,10 +38,14 @@ class GatedProjData :
 {
 public:
   static
-  GatedProjData*
+  unique_ptr<GatedProjData>
     read_from_file(const std::string& filename);
 
   GatedProjData() {};
+
+  GatedProjData(const MultipleProjData& m):
+    MultipleProjData(m)
+  {}
 
   unsigned int get_num_gates() const
   {

--- a/src/include/stir/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMeanAndGatedProjDataWithMotion.txx
+++ b/src/include/stir/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMeanAndGatedProjDataWithMotion.txx
@@ -143,7 +143,7 @@ post_processing()
   if (this->_input_filename.length() == 0)
     { warning("You need to specify an input filename"); return true; }
   
-  this->_gated_proj_data_sptr.reset(GatedProjData::read_from_file(this->_input_filename));
+  this->_gated_proj_data_sptr = GatedProjData::read_from_file(this->_input_filename);
   
   // image stuff
   this->target_parameter_parser.check_values();
@@ -151,14 +151,14 @@ post_processing()
   if (this->_additive_gated_proj_data_filename != "0")
     {
       info(boost::format("Reading additive projdata data %1%") % this->_additive_gated_proj_data_filename);
-      this->_additive_gated_proj_data_sptr.reset(
-                                                 GatedProjData::read_from_file(this->_additive_gated_proj_data_filename));
+      this->_additive_gated_proj_data_sptr =
+              GatedProjData::read_from_file(this->_additive_gated_proj_data_filename);
     }
   if (this->_normalisation_gated_proj_data_filename != "1")
     {
       info(boost::format("Reading normalisation projdata data %1%") % this->_normalisation_gated_proj_data_filename);
-      this->_normalisation_gated_proj_data_sptr.reset(
-                                                      GatedProjData::read_from_file(this->_normalisation_gated_proj_data_filename));
+      this->_normalisation_gated_proj_data_sptr =
+              GatedProjData::read_from_file(this->_normalisation_gated_proj_data_filename);
     }
 
   this->_time_gate_definitions.read_gdef_file(this->_gate_definitions_filename);


### PR DESCRIPTION
In https://github.com/UCL/STIR/pull/208, we introduced a new format called `Multi`, which is just a list of files:

```
Multi :=
  total number of data sets := 2
  data set[1] := sino1.hs
  data set[2] := sino2.hs
end :=
```
Here, we extend this format to `GatedProjData`, to mirror `DynamicProjData`. 

Also, `read_from_file` returns `unique_ptr` as opposed to raw pointer (again mirroring changes to `DynamicProjData`).