### PR TITLE
added get_sinograms() and size_all() to ProjDataInfo

### DIFF
--- a/documentation/release_4.1.htm
+++ b/documentation/release_4.1.htm
@@ -137,6 +137,7 @@ from the above):</H2>
 <ul>
   <li>Addition of <code>axpby</code> method for <code>Array</code> and all inherited classes.</li>
   <li><code>ProjDataInMemory</code> now provides iterators.</li>
+  <li>added <code>get_sinograms()</code> and <code>size_all()</code> to <code>ProjDataInfo</code></li>
 </ul>
   
 <h3>Other code changes</h3>

--- a/src/include/stir/ProjData.h
+++ b/src/include/stir/ProjData.h
@@ -1,7 +1,7 @@
 /*
     Copyright (C) 2000 PARAPET partners
     Copyright (C) 2000- 2012, Hammersmith Imanet Ltd
-    Copyright (C) 2013, 2015, University College London
+    Copyright (C) 2013, 2015-2017, 2020, University College London
     This file is part of STIR.
 
     This file is free software; you can redistribute it and/or modify
@@ -127,18 +127,6 @@ public:
     shared pointer will be affected. */
   inline shared_ptr<ProjDataInfo>
     get_proj_data_info_sptr() const;
-//  //! Get pointer to exam info
-//  inline const ExamInfo*
-//    get_exam_info_ptr() const;
-//  //! Get shared pointer to exam info
-//  /*! \warning Use with care. If you modify the object in a shared ptr, everything using the same
-//    shared pointer will be affected. */
-//  inline shared_ptr<ExamInfo>
-//    get_exam_info_sptr() const;
-//  //! change exam info
-//  /*! This will allocate a new ExamInfo object and copy the data in there. */
-//  void
-//    set_exam_info(ExamInfo const&);
   //! Get viewgram
   virtual Viewgram<float> 
     get_viewgram(const int view, const int segment_num,const bool make_num_tangential_poss_odd = false) const=0;
@@ -297,7 +285,7 @@ public:
   inline int get_min_tangential_pos_num() const;
   //! Get maximum tangential position number
   inline int get_max_tangential_pos_num() const;
-  //! Get the number of sinograms
+  //! Get the total number of sinograms
   inline int get_num_sinograms() const;
   //! Get the total size of the data
   inline std::size_t size_all() const;
@@ -309,7 +297,6 @@ public:
                      const float b, const ProjData& y);
 
 protected:
-//   shared_ptr<ExamInfo> exam_info_sptr;
 
    shared_ptr<ProjDataInfo> proj_data_info_ptr; // TODO fix name to _sptr
 };

--- a/src/include/stir/ProjData.inl
+++ b/src/include/stir/ProjData.inl
@@ -42,18 +42,6 @@ ProjData::get_proj_data_info_sptr() const
   return proj_data_info_ptr;
 }
 
-//const ExamInfo*
-//ProjData::get_exam_info_ptr() const
-//{
-//  return exam_info_sptr.get();
-//}
-
-//shared_ptr<ExamInfo>
-//ProjData::get_exam_info_sptr() const
-//{
-//  return exam_info_sptr;
-//}
-
 int ProjData::get_num_segments() const
 { return proj_data_info_ptr->get_num_segments(); }
 
@@ -91,15 +79,9 @@ int ProjData::get_max_tangential_pos_num() const
 { return proj_data_info_ptr->get_max_tangential_pos_num(); }
 
 int ProjData::get_num_sinograms() const
-{
-    int num_sinos = proj_data_info_ptr->get_num_axial_poss(0);
-    for (int s=1; s<= this->get_max_segment_num(); ++s)
-        num_sinos += 2* this->get_num_axial_poss(s);
-
-    return num_sinos;
-}
+{ return proj_data_info_ptr->get_num_sinograms(); }
 
 std::size_t ProjData::size_all() const
-{ return this->get_num_sinograms() * this->get_num_views() * this->get_num_tangential_poss(); }
+{ return proj_data_info_ptr->size_all(); }
 
 END_NAMESPACE_STIR

--- a/src/include/stir/ProjDataInfo.h
+++ b/src/include/stir/ProjDataInfo.h
@@ -4,6 +4,7 @@
     Copyright (C) 2000 PARAPET partners
     Copyright (C) 2000 - 2011-10-14, Hammersmith Imanet Ltd
     Copyright (C) 2011-07-01 - 2011, Kris Thielemans
+    Copyright (C) 2017-2018, 2020, University College London
     This file is part of STIR.
 
     This file is free software; you can redistribute it and/or modify
@@ -203,6 +204,10 @@ public:
   inline int get_min_tangential_pos_num() const;
   //! Get maximum tangential position number
   inline int get_max_tangential_pos_num() const;
+  //! Get the total number of sinograms
+  inline int get_num_sinograms() const;
+  //! Get the total size of the data
+  inline std::size_t size_all() const;
   //@}
 
   //| \name Functions that return geometrical info for a Bin

--- a/src/include/stir/ProjDataInfo.inl
+++ b/src/include/stir/ProjDataInfo.inl
@@ -4,6 +4,7 @@
     Copyright (C) 2000 PARAPET partners
     Copyright (C) 2000 - 2011-10-14, Hammersmith Imanet Ltd
     Copyright (C) 2011-07-01 - 2011, Kris Thielemans
+    Copyright (C) 2016, 2020, University College London
     This file is part of STIR.
 
     This file is free software; you can redistribute it and/or modify
@@ -24,6 +25,7 @@
 
   \author Sanida Mustafovic
   \author Kris Thielemans
+  \author Nikos Efthimiou
   \author PARAPET project
 
 */
@@ -117,6 +119,21 @@ ProjDataInfo::get_scanner_sptr() const
   return scanner_ptr;
 }
 
+
+int
+ProjDataInfo::get_num_sinograms() const
+{
+  int num_sinos = 0;
+  for (int s=this->get_min_segment_num(); s<= this->get_max_segment_num(); ++s)
+    num_sinos += this->get_num_axial_poss(s);
+
+  return num_sinos;
+}
+
+std::size_t
+ProjDataInfo::size_all() const
+{ return static_cast<std::size_t>(this->get_num_sinograms()) *
+    static_cast<std::size_t>(this->get_num_views() * this->get_num_tangential_poss()); }
 
 END_NAMESPACE_STIR
 


### PR DESCRIPTION
Moved implementation from `ProjData` to `ProjDataInfo` (forwarding in`ProjData`)

Also removed some commented out lines related to an old exam_info move
from ProjData.h/inl

Fixes #586