### PR TITLE
interfile reading fixes for Siemens sinograms and attenuation files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -89,10 +89,15 @@ addons:
 before_install:
   - |
     if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then 
-      brew update
+
       # seems to be needed on Travis due to conflicts with gcc otherwise
       # see https://github.com/travis-ci/travis-ci/issues/8826
       brew cask uninstall oclint
+
+      brew update
+      #now upgrade to avoid problems with outdated packages
+      brew upgrade
+
       brew install ccache
       export PATH="/usr/local/opt/ccache/libexec:$PATH"
       # Install ROOT, unless disabled

--- a/src/IO/interfile.cxx
+++ b/src/IO/interfile.cxx
@@ -1072,20 +1072,19 @@ read_interfile_PDFS(istream& input,
         warning("Interfile parsing failed");
         return 0;
       }
+    input.clear(); // clear EOF or other flags before we proceed
     input.seekg(offset);
     if (hdr.get_exam_info_ptr()->imaging_modality.get_modality() ==
         ImagingModality::NM)
       {
         // spect data
-        input.seekg(offset);
         return read_interfile_PDFS_SPECT(input, directory_for_data, open_mode); 
       }
-	  if (!hdr.siemens_mi_version.empty())
+    if (!hdr.siemens_mi_version.empty())
       {
-		     input.seekg(offset);
          return read_interfile_PDFS_Siemens(input, directory_for_data, open_mode);
       }
-	}
+  }
     
   // if we get here, it's PET
 

--- a/src/buildblock/Scanner.cxx
+++ b/src/buildblock/Scanner.cxx
@@ -3,7 +3,7 @@
     Copyright (C) 2000 - 2010-07-21, Hammersmith Imanet Ltd
     Copyright (C) 2011, Kris Thielemans
     Copyright (C) 2010-2013, King's College London
-    Copyright (C) 2013-2016,2019, University College London
+    Copyright (C) 2013-2016,2019,2020 University College London
     Copyright (C) 2017-2018, University of Leeds
     This file is part of STIR.
 
@@ -70,8 +70,8 @@ static list<string>
    string_list(const string&, const string&, const string&);
 static list<string> 
    string_list(const string&, const string&, const string&, const string&);
-
-   
+static list<string>
+   string_list(const string&, const string&, const string&, const string&, const string&);
 
 
   
@@ -212,7 +212,7 @@ Scanner::Scanner(Type scanner_type)
 
   case Siemens_mCT:
     // 13x13 blocks, 1 virtual "crystal" along axial and transaxial direction, 48 blocks along the ring, 4 blocks in axial direction
-    set_params(Siemens_mCT, string_list("Siemens mCT", "mCT", "2011", "1104" /* used in norm files */),
+    set_params(Siemens_mCT, string_list("Siemens mCT", "mCT", "2011", "1104" /* used in norm files */, "1094" /* used in attenuation files */),
                55, 400, (13+1)*48,
                421.0F, 7.0F, 4.054F, 2.005F, 0.0F,
                4, 1, 13+1, 13+1, 0,0, 1 ); // TODO singles info incorrect
@@ -1142,6 +1142,18 @@ string_list(const string& s1, const string& s2, const string& s3, const string& 
   l.push_back(s2);
   l.push_back(s3);
   l.push_back(s4);
+  return l;
+}
+
+static list<string>
+string_list(const string& s1, const string& s2, const string& s3, const string& s4, const string& s5)
+{
+  list<string> l;
+  l.push_back(s1);
+  l.push_back(s2);
+  l.push_back(s3);
+  l.push_back(s4);
+  l.push_back(s5);
   return l;
 }
 


### PR DESCRIPTION
we read the Interfile header multiple times. After the first time, the EOF flag can be set,
causing problems later. Now we clear it explicitly.

Fixes #620