### PR TITLE
[SWIG] If CMake is recent enough, improve SWIG compilation

### DIFF
--- a/src/swig/CMakeLists.txt
+++ b/src/swig/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Copyright 2012 Kris Thielemans
-# Copyright 2014, 2018 University College London
+# Copyright 2014, 2018, 2020 University College London
 # This file is part of STIR.
 #
 # This file is free software; you can redistribute it and/or modify
@@ -64,6 +64,28 @@ if(BUILD_SWIG_PYTHON OR BUILD_SWIG_OCTAVE OR BUILD_SWIG_MATLAB)
 
   endif()
 
+  #if (SWIG_VERSION VERSION_LESS 3.0.11)
+    # Older SWIG versions (checked with 3.0.12) have problems with some templates and private typedefs.
+    # To get round this, some include files in STIR have "#ifdef SWIG" statements.
+    # We need to compile the wrapper with -DSWIG.
+    # However, none of the other STIR files (including the registries) should be compiled with -DSWIG
+    # We will do this using the SWIG_GENERATED_COMPILE_DEFINITIONS property, if supported by CMake
+    if (CMAKE_VERSION VERSION_LESS 3.12)
+      message(WARNING "Our work-around for a SWIG problem needs CMake 3.12 or more recent. We recommend to upgrade CMake to 3.12 or later.")
+      function(SWIG_WORKAROUND module)
+        SET_TARGET_PROPERTIES(${module} PROPERTIES COMPILE_FLAGS -DSWIG)
+        # example attempt to only add it to the source only on older CMake, but KT cannot get it to work
+        # set_property(SOURCE CMakeFiles/_stir.dir/stirPYTHON_wrap.cxx PROPERTY COMPILE_DEFINITIONS SWIG)
+      endfunction()
+    else()
+      # KT thought this would work, but it doesn't. So instead, we use a similar line for each TARGET
+      # set_property(SOURCE stir.i PROPERTY SWIG_GENERATED_COMPILE_DEFINITIONS SWIG)
+      function(SWIG_WORKAROUND module)
+        set_property(TARGET ${module} PROPERTY SWIG_GENERATED_COMPILE_DEFINITIONS SWIG)
+      endfunction()
+    endif()
+
+  #endif()
 endif()
 
 if(BUILD_SWIG_PYTHON)
@@ -76,7 +98,6 @@ if(BUILD_SWIG_PYTHON)
   INCLUDE_DIRECTORIES(${PYTHON_INCLUDE_PATH})
   FIND_PACKAGE(Numpy REQUIRED)
   INCLUDE_DIRECTORIES(${NUMPY_INCLUDE_DIRS})
-  # some include files in STIR have "#ifdef SWIG" statements, so we define the variable here
   # TODO probably better to call the module stirpy or something
   # TODO -builtin option only appropriate for python
   # while the next statement sets it for all modules called stir
@@ -86,9 +107,7 @@ if(BUILD_SWIG_PYTHON)
   else()
     SWIG_ADD_LIBRARY(stir LANGUAGE python TYPE MODULE SOURCES stir.i ${STIR_REGISTRIES})
   endif()
-  SET_TARGET_PROPERTIES(${SWIG_MODULE_stir_REAL_NAME} PROPERTIES
-            COMPILE_FLAGS -DSWIG # some include files in STIR have "#ifdef SWIG" statements, so we define the variable here
-  )
+  SWIG_WORKAROUND(${SWIG_MODULE_stir_REAL_NAME})
   SWIG_LINK_LIBRARIES(stir ${STIR_LIBRARIES} ${PYTHON_LIBRARIES})
   target_link_libraries(${SWIG_MODULE_stir_REAL_NAME} ${OpenMP_EXE_LINKER_FLAGS})
   CONFIGURE_FILE(./pyfragments.swg ./ COPYONLY)
@@ -128,16 +147,14 @@ if (BUILD_SWIG_OCTAVE)
   SET(OCTAVE_SUFFIX ".oct")
   SET(OCTAVE_PREFIX "")
 
-  # some include files in STIR have "#ifdef SWIG" statements, so we define the variable here
   SET(SWIG_MODULE_stiroct_EXTRA_FLAGS -module stiroct ${SWIG_DOXY_OPTIONS})
   if (CMAKE_VERSION VERSION_LESS "3.8")
     SWIG_ADD_MODULE(stiroct octave stir.i ${STIR_REGISTRIES})
   else()
     SWIG_ADD_LIBRARY(stiroct LANGUAGE octave TYPE MODULE SOURCES stir.i ${STIR_REGISTRIES})
   endif()
-  SET_TARGET_PROPERTIES(${SWIG_MODULE_stiroct_REAL_NAME} PROPERTIES SUFFIX ${OCTAVE_SUFFIX} PREFIX "${OCTAVE_PREFIX}"
-            COMPILE_FLAGS -DSWIG # some include files in STIR have "#ifdef SWIG" statements, so we define the variable here
-  )
+  SET_TARGET_PROPERTIES(${SWIG_MODULE_stiroct_REAL_NAME} PROPERTIES SUFFIX ${OCTAVE_SUFFIX} PREFIX "${OCTAVE_PREFIX}")
+  SWIG_WORKAROUND(${SWIG_MODULE_stiroct_REAL_NAME})
   SWIG_LINK_LIBRARIES(stiroct ${STIR_LIBRARIES} ${OCTAVE_LIBRARIES})
 
   # add OCTAVE_INCFLAGS to swig-generated file only, not to all files as 
@@ -167,8 +184,8 @@ if (BUILD_SWIG_MATLAB)
   SET_TARGET_PROPERTIES(${SWIG_MODULE_stirMATLAB_REAL_NAME} PROPERTIES
         SUFFIX "_wrap.${Matlab_MEX_EXT}" PREFIX "${MATLAB_PREFIX}"
         LINK_FLAGS "${Matlab_CXXLINKER_FLAGS}"
-        COMPILE_FLAGS -DSWIG # some include files in STIR have "#ifdef SWIG" statements, so we define the variable here
         FOLDER "Matlab")
+  SWIG_WORKAROUND(${SWIG_MODULE_stirMATLAB_REAL_NAME})
   target_link_libraries(${SWIG_MODULE_stirMATLAB_REAL_NAME} ${OpenMP_EXE_LINKER_FLAGS})
 	
   SWIG_LINK_LIBRARIES(stirMATLAB ${STIR_LIBRARIES}  ${Matlab_LIBRARIES})


### PR DESCRIPTION
registries should not be compiled with -DSWIG. This doesn't seem possible
pre  CMake 3.12, but this fixes it for later versoins.

Fixes #604 for recent CMake