### PR TITLE
axpby signature change and array implementation

### DIFF
--- a/src/include/stir/Array.h
+++ b/src/include/stir/Array.h
@@ -250,6 +250,10 @@ public:
   template <typename elemT2>
     inline void xapyb(const Array& x, const elemT2 a,
                       const Array& y, const elemT2 b);
+
+   //! x*a+y*b, where a, b, x and y are arrays
+    inline void xapyb_vec(const Array& x, const Array& a,
+                          const Array& y, const Array& b);                     
                    
 };
 

--- a/src/include/stir/Array.h
+++ b/src/include/stir/Array.h
@@ -41,6 +41,7 @@
 #include "stir/NumericVectorWithOffset.h"
 #include "stir/ByteOrder.h"
 #include "stir/IndexRange.h"   
+#include "stir/deprecated.h"
 
 START_NAMESPACE_STIR
 class NumericType;
@@ -240,10 +241,16 @@ public:
     at(const BasicCoordinate<num_dimensions,int> &c) const;
   //@}
 
-  //! a*x+b*y, where a and b are scalar, and x and y are arrays
+  //! DEPRECATED a*x+b*y, where a and b are scalar, and x and y are arrays
   template <typename elemT2>
-    inline void axpby(const elemT2 a, const Array& x,
+    DEPRECATED inline void axpby(const elemT2 a, const Array& x,
                       const elemT2 b, const Array& y);
+
+  //! x*a+y*b, where a and b are scalar, and x and y are arrays
+  template <typename elemT2>
+    inline void xapyb(const Array& x, const elemT2 a,
+                      const Array& y, const elemT2 b);
+                   
 };
 
 

--- a/src/include/stir/Array.h
+++ b/src/include/stir/Array.h
@@ -241,18 +241,18 @@ public:
     at(const BasicCoordinate<num_dimensions,int> &c) const;
   //@}
 
-  //! DEPRECATED a*x+b*y, where a and b are scalar, and x and y are arrays
+  //! DEPRECATED a*x+b*y
   template <typename elemT2>
     DEPRECATED inline void axpby(const elemT2 a, const Array& x,
                       const elemT2 b, const Array& y);
 
-  //! x*a+y*b, where a and b are scalar, and x and y are arrays
+  //! set values of the array to x*a+y*b
   template <typename elemT2>
     inline void xapyb(const Array& x, const elemT2 a,
                       const Array& y, const elemT2 b);
 
-   //! x*a+y*b, where a, b, x and y are arrays
-    inline void xapyb_vec(const Array& x, const Array& a,
+   //! set values of the array to x*a+y*b (sizes have to match)
+    inline void xapyb(const Array& x, const Array& a,
                           const Array& y, const Array& b);                     
                    
 };

--- a/src/include/stir/Array.inl
+++ b/src/include/stir/Array.inl
@@ -349,7 +349,7 @@ xapyb(const Array& x, const elemT2 a,
   this->check_state();
   if ((this->get_index_range() != x.get_index_range())
       || (this->get_index_range() != y.get_index_range()))
-       error("Array::axpby: index ranges don't match");
+       error("Array::xapyb: index ranges don't match");
 
   typename Array::iterator this_iter = this->begin();
   typename Array::const_iterator x_iter = x.begin();
@@ -357,6 +357,32 @@ xapyb(const Array& x, const elemT2 a,
   while (this_iter != this->end())
     {
       this_iter->xapyb(*x_iter++, a, *y_iter++, b);
+      ++this_iter;
+    }
+}
+
+template <int num_dimensions, typename elemT>
+void
+Array<num_dimensions,elemT>::
+xapyb_vec(const Array& x, const Array& a,
+          const Array& y, const Array& b)
+{  
+  this->check_state();
+  if ((this->get_index_range() != x.get_index_range())
+      || (this->get_index_range() != y.get_index_range())
+      || (this->get_index_range() != a.get_index_range())
+      || (this->get_index_range() != b.get_index_range()))
+       error("Array::xapyb: index ranges don't match");
+
+  typename Array::iterator this_iter = this->begin();
+  typename Array::const_iterator x_iter = x.begin();
+  typename Array::const_iterator y_iter = y.begin();
+  typename Array::const_iterator a_iter = a.begin();
+  typename Array::const_iterator b_iter = b.begin();
+
+  while (this_iter != this->end())
+    {
+      this_iter->xapyb_vec(*x_iter++, *a_iter++, *y_iter++, *b_iter++);
       ++this_iter;
     }
 }

--- a/src/include/stir/Array.inl
+++ b/src/include/stir/Array.inl
@@ -336,6 +336,16 @@ Array<num_dimensions,elemT>::
 axpby(const elemT2 a, const Array& x,
       const elemT2 b, const Array& y)
 {  
+  Array<num_dimensions,elemT>::xapyb(x,a,y,b);
+}
+
+template <int num_dimensions, typename elemT>
+template <typename elemT2>
+void
+Array<num_dimensions,elemT>::
+xapyb(const Array& x, const elemT2 a,
+      const Array& y, const elemT2 b)
+{  
   this->check_state();
   if ((this->get_index_range() != x.get_index_range())
       || (this->get_index_range() != y.get_index_range()))
@@ -346,7 +356,7 @@ axpby(const elemT2 a, const Array& x,
   typename Array::const_iterator y_iter = y.begin();
   while (this_iter != this->end())
     {
-      this_iter->axpby(a,*x_iter++, b, *y_iter++);
+      this_iter->xapyb(*x_iter++, a, *y_iter++, b);
       ++this_iter;
     }
 }

--- a/src/include/stir/Array.inl
+++ b/src/include/stir/Array.inl
@@ -351,12 +351,12 @@ xapyb(const Array& x, const elemT2 a,
       || (this->get_index_range() != y.get_index_range()))
        error("Array::xapyb: index ranges don't match");
 
-  typename Array::iterator this_iter = this->begin();
-  typename Array::const_iterator x_iter = x.begin();
-  typename Array::const_iterator y_iter = y.begin();
-  while (this_iter != this->end())
+  typename Array::full_iterator this_iter = this->begin_all();
+  typename Array::const_full_iterator x_iter = x.begin_all_const();
+  typename Array::const_full_iterator y_iter = y.begin_all_const();
+  while (this_iter != this->end_all())
     {
-      this_iter->xapyb(*x_iter++, a, *y_iter++, b);
+      *this_iter = (*x_iter++) * a + (*y_iter++) * b;
       ++this_iter;
     }
 }
@@ -364,7 +364,7 @@ xapyb(const Array& x, const elemT2 a,
 template <int num_dimensions, typename elemT>
 void
 Array<num_dimensions,elemT>::
-xapyb_vec(const Array& x, const Array& a,
+xapyb(const Array& x, const Array& a,
           const Array& y, const Array& b)
 {  
   this->check_state();
@@ -374,15 +374,15 @@ xapyb_vec(const Array& x, const Array& a,
       || (this->get_index_range() != b.get_index_range()))
        error("Array::xapyb: index ranges don't match");
 
-  typename Array::iterator this_iter = this->begin();
-  typename Array::const_iterator x_iter = x.begin();
-  typename Array::const_iterator y_iter = y.begin();
-  typename Array::const_iterator a_iter = a.begin();
-  typename Array::const_iterator b_iter = b.begin();
+  typename Array::full_iterator this_iter = this->begin_all();
+  typename Array::const_full_iterator x_iter = x.begin_all_const();
+  typename Array::const_full_iterator y_iter = y.begin_all_const();
+  typename Array::const_full_iterator a_iter = a.begin_all_const();
+  typename Array::const_full_iterator b_iter = b.begin_all_const();
 
-  while (this_iter != this->end())
+  while (this_iter != this->end_all())
     {
-      this_iter->xapyb_vec(*x_iter++, *a_iter++, *y_iter++, *b_iter++);
+      *this_iter = (*x_iter++) * (*a_iter++) + (*y_iter++) * (*b_iter++);
       ++this_iter;
     }
 }

--- a/src/include/stir/NumericVectorWithOffset.h
+++ b/src/include/stir/NumericVectorWithOffset.h
@@ -136,6 +136,10 @@ public:
   template <typename elemT2>
     inline void xapyb(const NumericVectorWithOffset& x, const elemT2 a,
                       const NumericVectorWithOffset& y, const elemT2 b);
+
+  //! x*a+y*b, where a, b, x and y are vectors
+    inline void xapyb_vec(const NumericVectorWithOffset& x, const NumericVectorWithOffset& a,
+                      const NumericVectorWithOffset& y, const NumericVectorWithOffset& b);                      
 };
 
 END_NAMESPACE_STIR

--- a/src/include/stir/NumericVectorWithOffset.h
+++ b/src/include/stir/NumericVectorWithOffset.h
@@ -127,18 +127,18 @@ public:
   //! dividing the elements of the current vector by an \c elemT 
   inline NumericVectorWithOffset & operator/= (const elemT &v);
 
-  //! DEPRECATED a*x+b*y, where a and b are scalar, and x and y are vectors
+  //! DEPRECATED a*x+b*y
   template <typename elemT2>
     DEPRECATED inline void axpby(const elemT2 a, const NumericVectorWithOffset& x,
                       const elemT2 b, const NumericVectorWithOffset& y);
 
-  //! x*a+y*b, where a and b are scalar, and x and y are vectors
+  //! set values of the array to x*a+y*b
   template <typename elemT2>
     inline void xapyb(const NumericVectorWithOffset& x, const elemT2 a,
                       const NumericVectorWithOffset& y, const elemT2 b);
 
-  //! x*a+y*b, where a, b, x and y are vectors
-    inline void xapyb_vec(const NumericVectorWithOffset& x, const NumericVectorWithOffset& a,
+  //! set values of the array to x*a+y*b (sizes have to match)
+    inline void xapyb(const NumericVectorWithOffset& x, const NumericVectorWithOffset& a,
                       const NumericVectorWithOffset& y, const NumericVectorWithOffset& b);                      
 };
 

--- a/src/include/stir/NumericVectorWithOffset.h
+++ b/src/include/stir/NumericVectorWithOffset.h
@@ -34,6 +34,7 @@
 
 
 #include "stir/VectorWithOffset.h"
+#include "stir/deprecated.h"
 
 START_NAMESPACE_STIR
 /*! 
@@ -126,11 +127,15 @@ public:
   //! dividing the elements of the current vector by an \c elemT 
   inline NumericVectorWithOffset & operator/= (const elemT &v);
 
-  //! a*x+b*y, where a and b are scalar, and x and y are vectors
+  //! DEPRECATED a*x+b*y, where a and b are scalar, and x and y are vectors
   template <typename elemT2>
-    inline void axpby(const elemT2 a, const NumericVectorWithOffset& x,
+    DEPRECATED inline void axpby(const elemT2 a, const NumericVectorWithOffset& x,
                       const elemT2 b, const NumericVectorWithOffset& y);
 
+  //! x*a+y*b, where a and b are scalar, and x and y are vectors
+  template <typename elemT2>
+    inline void xapyb(const NumericVectorWithOffset& x, const elemT2 a,
+                      const NumericVectorWithOffset& y, const elemT2 b);
 };
 
 END_NAMESPACE_STIR

--- a/src/include/stir/NumericVectorWithOffset.inl
+++ b/src/include/stir/NumericVectorWithOffset.inl
@@ -299,7 +299,7 @@ xapyb(const NumericVectorWithOffset& x, const NUMBER2 a,
       || (this->get_min_index() != y.get_min_index())
       || (this->get_max_index() != x.get_max_index())
       || (this->get_max_index() != y.get_max_index()))
-       error("NumericVectorWithOffset::axpby: index ranges don't match");
+       error("NumericVectorWithOffset::xapyb: index ranges don't match");
 
   typename NumericVectorWithOffset::iterator this_iter = this->begin();
   typename NumericVectorWithOffset::const_iterator x_iter = x.begin();
@@ -307,6 +307,34 @@ xapyb(const NumericVectorWithOffset& x, const NUMBER2 a,
   while (this_iter != this->end())
     {
       *this_iter++ = (*x_iter++) * a + (*y_iter++) * b;
+    }
+}
+
+template <class T, class NUMBER>
+inline void
+NumericVectorWithOffset<T, NUMBER>::
+xapyb_vec(const NumericVectorWithOffset& x, const NumericVectorWithOffset& a,
+      const NumericVectorWithOffset& y, const NumericVectorWithOffset& b)
+{  
+  this->check_state();
+  if ((this->get_min_index() != x.get_min_index())
+      || (this->get_min_index() != y.get_min_index())
+      || (this->get_min_index() != a.get_min_index())
+      || (this->get_min_index() != b.get_min_index())            
+      || (this->get_max_index() != x.get_max_index())
+      || (this->get_max_index() != y.get_max_index())
+      || (this->get_max_index() != a.get_max_index())
+      || (this->get_max_index() != b.get_max_index()))
+       error("NumericVectorWithOffset::xapyb: index ranges don't match");
+
+  typename NumericVectorWithOffset::iterator this_iter = this->begin();
+  typename NumericVectorWithOffset::const_iterator x_iter = x.begin();
+  typename NumericVectorWithOffset::const_iterator y_iter = y.begin();
+  typename NumericVectorWithOffset::const_iterator a_iter = a.begin();
+  typename NumericVectorWithOffset::const_iterator b_iter = b.begin();  
+  while (this_iter != this->end())
+    {
+      *this_iter++ = (*x_iter++) * (*a_iter++) + (*y_iter++) * (*b_iter++);
     }
 }
 

--- a/src/include/stir/NumericVectorWithOffset.inl
+++ b/src/include/stir/NumericVectorWithOffset.inl
@@ -313,7 +313,7 @@ xapyb(const NumericVectorWithOffset& x, const NUMBER2 a,
 template <class T, class NUMBER>
 inline void
 NumericVectorWithOffset<T, NUMBER>::
-xapyb_vec(const NumericVectorWithOffset& x, const NumericVectorWithOffset& a,
+xapyb(const NumericVectorWithOffset& x, const NumericVectorWithOffset& a,
       const NumericVectorWithOffset& y, const NumericVectorWithOffset& b)
 {  
   this->check_state();

--- a/src/include/stir/NumericVectorWithOffset.inl
+++ b/src/include/stir/NumericVectorWithOffset.inl
@@ -284,6 +284,16 @@ NumericVectorWithOffset<T, NUMBER>::
 axpby(const NUMBER2 a, const NumericVectorWithOffset& x,
       const NUMBER2 b, const NumericVectorWithOffset& y)
 {  
+  NumericVectorWithOffset<T, NUMBER>::xapyb(x,a,y,b);
+}
+
+template <class T, class NUMBER>
+template <class NUMBER2>
+inline void
+NumericVectorWithOffset<T, NUMBER>::
+xapyb(const NumericVectorWithOffset& x, const NUMBER2 a,
+      const NumericVectorWithOffset& y, const NUMBER2 b)
+{  
   this->check_state();
   if ((this->get_min_index() != x.get_min_index())
       || (this->get_min_index() != y.get_min_index())

--- a/src/include/stir/deprecated.h
+++ b/src/include/stir/deprecated.h
@@ -1,0 +1,28 @@
+/*
+    Copyright (C) 2000 PARAPET partners
+    Copyright (C) 2000- 2007, Hammersmith Imanet Ltd
+    Copyright (C) 2018-2019, University College London
+    This file is part of STIR.
+
+    This file is free software; you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.
+
+    This file is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License for more details.
+
+    See STIR/LICENSE.txt for details
+*/
+
+// Deprecation function. With C++14, could use [[deprecated("some message")]]
+#if defined(__GNUC__) || defined(__clang__)
+#define DEPRECATED __attribute__((deprecated))
+#elif defined(_MSC_VER)
+#define DEPRECATED __declspec(deprecated)
+#else
+#pragma message("WARNING: You need to implement DEPRECATED for this compiler")
+#define DEPRECATED
+#endif

--- a/src/include/stir/deprecated.h
+++ b/src/include/stir/deprecated.h
@@ -16,6 +16,16 @@
 
     See STIR/LICENSE.txt for details
 */
+#ifndef __stir_deprecated_H__
+#define __stir_deprecated_H__
+/*!
+  \file 
+  \ingroup buildblock
+  \brief This file declares a deprecation function.
+
+  \author PARAPET project
+*/
+START_NAMESPACE_STIR
 
 // Deprecation function. With C++14, could use [[deprecated("some message")]]
 #if defined(__GNUC__) || defined(__clang__)
@@ -26,3 +36,8 @@
 #pragma message("WARNING: You need to implement DEPRECATED for this compiler")
 #define DEPRECATED
 #endif
+
+END_NAMESPACE_STIR
+
+
+#endif // __stir_deprecated_H__

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -52,6 +52,7 @@ set(buildblock_simple_tests
         test_SeparableGaussianArrayFilter
         test_NestedIterator
         test_VectorWithOffset
+        test_NumericVectorWithOffset
         test_convert_array
 	test_IndexRange
 	test_coordinates

--- a/src/test/test_Array.cxx
+++ b/src/test/test_Array.cxx
@@ -731,14 +731,23 @@ ArrayTests::run_tests()
                      "test operator+(float)");
     }
 
-    // test apxby
+    // test axpby
     {
       Array<4,float> tmp(test4.get_index_range());
       Array<4,float> tmp2(test4+2);
       tmp.axpby(2.F, test4, 3.3F, tmp2);
       const Array<4,float> by_hand = test4*2.F + (test4+2)*3.3F;
-      check_if_equal(tmp, by_hand, "test apxby (Array4D)");
+      check_if_equal(tmp, by_hand, "test axpby (Array4D)");
     }
+
+    // test xapyb
+    {
+      Array<4,float> tmp(test4.get_index_range());
+      Array<4,float> tmp2(test4+2);
+      tmp.xapyb(test4, 2.F, tmp2, 3.3F);
+      const Array<4,float> by_hand = test4*2.F + (test4+2)*3.3F;
+      check_if_equal(tmp, by_hand, "test xapyb (Array4D)");
+    }    
   }
 
 #if 1

--- a/src/test/test_Array.cxx
+++ b/src/test/test_Array.cxx
@@ -747,7 +747,20 @@ ArrayTests::run_tests()
       tmp.xapyb(test4, 2.F, tmp2, 3.3F);
       const Array<4,float> by_hand = test4*2.F + (test4+2)*3.3F;
       check_if_equal(tmp, by_hand, "test xapyb (Array4D)");
-    }    
+    }
+
+    // test xapyb_vec
+    {
+      Array<4,float> tmp(test4.get_index_range());
+      Array<4,float> tmp2(test4+2);
+      Array<4,float> tmpa(test4+4);
+      Array<4,float> tmpb(test4+6);
+
+      tmp.xapyb_vec(test4, tmpa, tmp2, tmpb);
+      const Array<4,float> by_hand = test4*(test4+4) + (test4+2)*(test4+6);
+      check_if_equal(tmp, by_hand, "test xapyb_vec (Array4D)");
+    }   
+
   }
 
 #if 1

--- a/src/test/test_Array.cxx
+++ b/src/test/test_Array.cxx
@@ -749,16 +749,16 @@ ArrayTests::run_tests()
       check_if_equal(tmp, by_hand, "test xapyb (Array4D)");
     }
 
-    // test xapyb_vec
+    // test xapyb
     {
       Array<4,float> tmp(test4.get_index_range());
       Array<4,float> tmp2(test4+2);
       Array<4,float> tmpa(test4+4);
       Array<4,float> tmpb(test4+6);
 
-      tmp.xapyb_vec(test4, tmpa, tmp2, tmpb);
+      tmp.xapyb(test4, tmpa, tmp2, tmpb);
       const Array<4,float> by_hand = test4*(test4+4) + (test4+2)*(test4+6);
-      check_if_equal(tmp, by_hand, "test xapyb_vec (Array4D)");
+      check_if_equal(tmp, by_hand, "test xapyb where a,b are Arrays (Array4D)");
     }   
 
   }

--- a/src/test/test_NumericVectorWithOffset.cxx
+++ b/src/test/test_NumericVectorWithOffset.cxx
@@ -1,0 +1,115 @@
+/*
+    Copyright (C) 2000 PARAPET partners
+    Copyright (C) 2000 - 2007-10-08, Hammersmith Imanet Ltd
+    Copyright (C) 2012-06-01 - 2013, Kris Thielemans
+    This file is part of STIR.
+
+    This file is free software; you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.
+
+    This file is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License for more details.
+    See STIR/LICENSE.txt for details
+*/
+/*!
+
+  \file
+  \ingroup test
+
+  \brief Test program for stir::NumericVectorWithOffset
+
+  \author Kris Thielemans
+  \author PARAPET project
+
+
+*/
+#ifndef NDEBUG
+// set to high level of debugging
+#ifdef _DEBUG
+#undef _DEBUG
+#endif
+#define _DEBUG 2
+#endif
+
+#include "stir/NumericVectorWithOffset.h"
+#include "stir/RunTests.h"
+#include <algorithm>
+#include <numeric>
+#include <functional>
+#include <iostream>
+
+#ifndef STIR_NO_NAMESPACES
+using std::cerr;
+using std::endl;
+using std::sort;
+using std::find;
+using std::greater;
+using std::size_t;
+#endif
+
+START_NAMESPACE_STIR
+
+
+/*!
+  \brief Test class for NumericVectorWithOffset
+  \ingroup test
+
+*/
+class NumericVectorWithOffsetTests : public RunTests
+{
+public:
+  void run_tests();
+};
+
+void
+NumericVectorWithOffsetTests::run_tests()
+{
+  cerr << "Tests for NumericVectorWithOffsetTests\n"
+       << "Everythings is fine if the program runs without any output." << endl;
+  
+  NumericVectorWithOffset<float,float> test(-3, 40);
+  test.fill(1.);
+  /**********************************************************************/
+  // tests on xapyb
+  /**********************************************************************/
+  {
+    NumericVectorWithOffset<float,float> tmp(test);
+    NumericVectorWithOffset<float,float> tmp2(test+2);
+    tmp.axpby(2.F, test, 3.3F, tmp2);
+    NumericVectorWithOffset<float,float> by_hand = test*2.F + (test+2)*3.3F;
+    check_if_equal(tmp, by_hand, "test axpby");    
+  }
+  {
+    NumericVectorWithOffset<float,float> tmp(test);
+    NumericVectorWithOffset<float,float> tmp2(test+2);
+    tmp.xapyb(test, 2.F, tmp2, 3.3F);
+    NumericVectorWithOffset<float,float> by_hand = test*2.F + (test+2)*3.3F;
+    check_if_equal(tmp, by_hand, "test xapyb");    
+  }
+  {
+    NumericVectorWithOffset<float,float> tmp(test);
+    NumericVectorWithOffset<float,float> tmp2(test+2);
+    NumericVectorWithOffset<float,float> tmpa(test+4);
+    NumericVectorWithOffset<float,float> tmpb(test+6);
+
+    tmp.xapyb(test, tmpa, tmp2, tmpb);
+    NumericVectorWithOffset<float,float> by_hand = test*(test+4) + (test+2)*(test+6);
+    check_if_equal(tmp, by_hand, "test xapyb where a,b are vectors");
+  }  
+}
+
+
+END_NAMESPACE_STIR
+
+USING_NAMESPACE_STIR
+
+int main()
+{
+  NumericVectorWithOffsetTests tests;
+  tests.run_tests();
+  return tests.main_return_value();
+}


### PR DESCRIPTION
Implemented in ```NumericVectorWithOffset``` and ```Array``` classes:
```axpby``` marked as deprecated and calls ```xapyb```
```xapyb``` can take a,b as scalars or arrays

Unit tests added for NumericVectorWithOffset

closes #560 