### PR TITLE
Removes duplication of RDP in swig.

### DIFF
--- a/src/swig/stir.i
+++ b/src/swig/stir.i
@@ -1706,8 +1706,3 @@ namespace stir {
   stir::RegisteredParsingObject<stir::BackProjectorByBinUsingProjMatrixByBin,
      stir::BackProjectorByBin>;
 %include "stir/recon_buildblock/BackProjectorByBinUsingProjMatrixByBin.h"
-
-%include "stir/recon_buildblock/RelativeDifferencePrior.h"
-#define elemT float
-%template (RelativeDifferencePrior3DFloat) stir::RelativeDifferencePrior<elemT >;
-


### PR DESCRIPTION
This was causing a warning. These line are already defined https://github.com/UCL/STIR/blob/d1cd05cf53db8332924991c142cc42969472885f/src/swig/stir.i#L1591 and https://github.com/UCL/STIR/blob/d1cd05cf53db8332924991c142cc42969472885f/src/swig/stir.i#L1646