### PR TITLE
add a few explicit conversions to avoid warnings with VS

### DIFF
--- a/src/buildblock/date_time_functions.cxx
+++ b/src/buildblock/date_time_functions.cxx
@@ -27,6 +27,7 @@
 #include "stir/interfile_keyword_functions.h"
 #include "stir/info.h"
 #include "stir/warning.h"
+#include "stir/round.h"
 #include "boost/lexical_cast.hpp"
 #include "boost/format.hpp"
 #include <string>
@@ -49,7 +50,7 @@ int time_zone_offset_in_secs()
       //std::cerr << ", GMT: " << gmt->tm_hour << ',' << gmt->tm_isdst << "\n";
       time_t gm_time = mktime(gmt);
       // std::cerr << " diff Local-GMT: " << difftime(current_time, gm_time)/3600. << "\n";
-      tz_offset =difftime(current_time, gm_time);
+      tz_offset =round(difftime(current_time, gm_time));
     }
   return tz_offset;
 }

--- a/src/include/stir/ExamInfo.h
+++ b/src/include/stir/ExamInfo.h
@@ -57,8 +57,8 @@ public :
 
   ExamInfo()
     : start_time_in_secs_since_1970(0.),
-    low_energy_thres(-1),
-    up_energy_thres(-1)
+    low_energy_thres(-1.F),
+    up_energy_thres(-1.F)
     {
   }
 

--- a/src/include/stir/scatter/ScatterSimulation.h
+++ b/src/include/stir/scatter/ScatterSimulation.h
@@ -116,7 +116,7 @@ public:
     get_output_proj_data_sptr() const;
 
     inline int get_num_scatter_points() const
-    { return this->scatt_points_vector.size();}
+    { return static_cast<int>(this->scatt_points_vector.size());}
     //! Get the template ProjDataInfo
     shared_ptr<const ProjDataInfoCylindricalNoArcCorr> get_template_proj_data_info_sptr() const;
     //! Get the ExamInfo


### PR DESCRIPTION
The Visual Studio compiler warns about conversions with loss of precision. This fixes a few that cause major output (although there's still quite a few to do).