### PR TITLE
[CMake] fix dependency on nlohmann_json in exported config

### DIFF
--- a/src/buildblock/CMakeLists.txt
+++ b/src/buildblock/CMakeLists.txt
@@ -101,7 +101,19 @@ include(stir_lib_target)
 
 
 if (HAVE_JSON)
-  target_link_libraries(buildblock PRIVATE nlohmann_json::nlohmann_json)
+  # Add the header-only nlohman_json header-only library
+  # Unfortunately, the simple line below exports the dependency while this is really not
+  # necessary.
+  #
+  # target_link_libraries(buildblock PRIVATE "$<BUILD_INTERFACE:nlohmann_json::nlohmann_json>")
+
+  # So, we currently use an ugly work-around from
+  # https://gitlab.kitware.com/cmake/cmake/-/issues/15415#note_334852
+  # Warning: this will fail once nlohman_json stops being header-only!
+  # In that case, we will need to add it in STIRConfig.cmake.in
+  #
+  get_target_property(TMP nlohmann_json::nlohmann_json INTERFACE_INCLUDE_DIRECTORIES)
+  target_include_directories(buildblock PRIVATE "${TMP}")
 endif()
 
 # TODO Remove but currently needed for ProjData.cxx, DynamicDisc*cxx, TimeFrameDef

--- a/src/cmake/STIRConfig.cmake.in
+++ b/src/cmake/STIRConfig.cmake.in
@@ -104,6 +104,12 @@ if (@AVW_FOUND@)
   set(STIR_BUILT_WITH_AVW TRUE)
 endif()
 
+
+if (@nlohmann_json_FOUND@)
+  find_package(nlohmann_json 3.2.0 ${STIR_FIND_TYPE})
+  set(STIR_BUILD_WITH_nlohmann_json TRUE)
+endif()
+
 if (@STIR_MPI@)
   find_package(MPI ${STIR_FIND_TYPE})
   if(NOT MPI_FOUND)

--- a/src/cmake/STIRConfig.cmake.in
+++ b/src/cmake/STIRConfig.cmake.in
@@ -104,11 +104,14 @@ if (@AVW_FOUND@)
   set(STIR_BUILT_WITH_AVW TRUE)
 endif()
 
-
-if (@nlohmann_json_FOUND@)
-  find_package(nlohmann_json 3.2.0 ${STIR_FIND_TYPE})
-  set(STIR_BUILD_WITH_nlohmann_json TRUE)
-endif()
+# Following lines are currently not necessary but would need to be enabled
+# if nlohmann_json stops being a header-only library.
+# See buildblock/CMakeLists.xt
+#
+#if (@nlohmann_json_FOUND@)
+#  find_package(nlohmann_json 3.2.0 ${STIR_FIND_TYPE})
+#  set(STIR_BUILD_WITH_nlohmann_json TRUE)
+#endif()
 
 if (@STIR_MPI@)
   find_package(MPI ${STIR_FIND_TYPE})


### PR DESCRIPTION
Packages that depend on STIR also need to depend on nlohmann_json
if STIR was built with it, otherwise their CMake config will fail.

Fixes https://github.com/SyneRBI/SIRF-SuperBuild/issues/440