### PR TITLE
Root data energy information is converted to keV instead of MeV

### DIFF
--- a/documentation/STIR-UsersGuide.tex
+++ b/documentation/STIR-UsersGuide.tex
@@ -774,6 +774,10 @@ end ROOT header :=
 
 See \texttt{examples/samples/root\_headerECAT.hroot} for an example using the ECAT system.
 
+OpenGATE energy information is recorded in MeV units into the ROOT file.
+For STIR files, e.g. \texttt{.hroot} and \texttt{.hs}, should use keV units.
+STIR assumes this convention and will convert this automatically.
+
 There are some unfinished classes
 available on the \textit{STIR} web-site to read \textit{LMF} format files,
 in conjunction with the \textit{LMF} library. However, these might be obsolete

--- a/documentation/release_4.1.htm
+++ b/documentation/release_4.1.htm
@@ -117,6 +117,10 @@ We have currently no work-around (aside from using <code>GRAPHICS=PGM</code> or
   Changes to GATE/root cylindrical PET geometry interpretation,
   see <a href="https://github.com/UCL/STIR/pull/569">PR 569</a>.</li>
 </li>
+<li>
+    OpenGATE energy information is MeV. Added a method to convert between MeV to (STIR convention) keV units when
+    reading root files.
+</li>
 </ul>
 
 <h3>Documentation changes</h3>

--- a/src/IO/InputStreamFromROOTFileForCylindricalPET.cxx
+++ b/src/IO/InputStreamFromROOTFileForCylindricalPET.cxx
@@ -82,10 +82,10 @@ get_next_record(CListRecordROOT& record)
         if ( (this->eventID1 != this->eventID2) && this->exclude_randoms)
             continue;
       //multiply here by 1000 to convert the list mode energy from MeV to keV
-        if (this->energy1*1000 < this->low_energy_window ||
-                 this->energy1*1000 > this->up_energy_window ||
-                 this->energy2*1000 < this->low_energy_window ||
-                 this->energy2*1000 > this->up_energy_window)
+        if (this->get_energy1_in_keV() < this->low_energy_window ||
+                this->get_energy1_in_keV() > this->up_energy_window ||
+                this->get_energy2_in_keV() < this->low_energy_window ||
+                this->get_energy2_in_keV() > this->up_energy_window)
             continue;
 
         break;

--- a/src/IO/InputStreamFromROOTFileForCylindricalPET.cxx
+++ b/src/IO/InputStreamFromROOTFileForCylindricalPET.cxx
@@ -16,6 +16,7 @@
     See STIR/LICENSE.txt for details
 */
 #include "stir/IO/InputStreamFromROOTFileForCylindricalPET.h"
+#include <TChain.h>
 
 START_NAMESPACE_STIR
 
@@ -81,10 +82,11 @@ get_next_record(CListRecordROOT& record)
             continue;
         if ( (this->eventID1 != this->eventID2) && this->exclude_randoms)
             continue;
-        if (this->energy1 < this->low_energy_window ||
-                 this->energy1 > this->up_energy_window ||
-                 this->energy2 < this->low_energy_window ||
-                 this->energy2 > this->up_energy_window)
+      //multiply here by 1000 to convert the list mode energy from MeV to keV
+        if (this->energy1*1000 < this->low_energy_window ||
+                 this->energy1*1000 > this->up_energy_window ||
+                 this->energy2*1000 < this->low_energy_window ||
+                 this->energy2*1000 > this->up_energy_window)
             continue;
 
         break;

--- a/src/IO/InputStreamFromROOTFileForCylindricalPET.cxx
+++ b/src/IO/InputStreamFromROOTFileForCylindricalPET.cxx
@@ -16,7 +16,6 @@
     See STIR/LICENSE.txt for details
 */
 #include "stir/IO/InputStreamFromROOTFileForCylindricalPET.h"
-#include <TChain.h>
 
 START_NAMESPACE_STIR
 

--- a/src/IO/InputStreamFromROOTFileForECATPET.cxx
+++ b/src/IO/InputStreamFromROOTFileForECATPET.cxx
@@ -78,10 +78,10 @@ get_next_record(CListRecordROOT& record)
         if ( eventID1 != eventID2 && exclude_randoms )
             continue;
         //multiply here by 1000 to convert the list mode energy from MeV to keV
-        if (energy1*1000 < low_energy_window ||
-                 energy1*1000 > up_energy_window ||
-                 energy2*1000 < low_energy_window ||
-                 energy2*1000 > up_energy_window)
+        if (this->get_energy1_in_keV() < low_energy_window ||
+                this->get_energy1_in_keV() > up_energy_window ||
+                this->get_energy2_in_keV() < low_energy_window ||
+                this->get_energy2_in_keV() > up_energy_window)
             continue;
 
         break;

--- a/src/IO/InputStreamFromROOTFileForECATPET.cxx
+++ b/src/IO/InputStreamFromROOTFileForECATPET.cxx
@@ -17,7 +17,6 @@
 */
 
 #include "stir/IO/InputStreamFromROOTFileForECATPET.h"
-#include <TChain.h>
 
 START_NAMESPACE_STIR
 

--- a/src/IO/InputStreamFromROOTFileForECATPET.cxx
+++ b/src/IO/InputStreamFromROOTFileForECATPET.cxx
@@ -17,6 +17,7 @@
 */
 
 #include "stir/IO/InputStreamFromROOTFileForECATPET.h"
+#include <TChain.h>
 
 START_NAMESPACE_STIR
 
@@ -77,10 +78,11 @@ get_next_record(CListRecordROOT& record)
             continue;
         if ( eventID1 != eventID2 && exclude_randoms )
             continue;
-        if (energy1 < low_energy_window ||
-                 energy1 > up_energy_window ||
-                 energy2 < low_energy_window ||
-                 energy2 > up_energy_window)
+        //multiply here by 1000 to convert the list mode energy from MeV to keV
+        if (energy1*1000 < low_energy_window ||
+                 energy1*1000 > up_energy_window ||
+                 energy2*1000 < low_energy_window ||
+                 energy2*1000 > up_energy_window)
             continue;
 
         break;

--- a/src/include/stir/IO/InputStreamFromROOTFile.h
+++ b/src/include/stir/IO/InputStreamFromROOTFile.h
@@ -204,6 +204,12 @@ protected:
     //! (<a href="http://wiki.opengatecollaboration.org/index.php/Users_Guide_V7.2:Digitizer_and_readout_parameters">here</a> )
     //! > the readout depth depends upon how the electronic readout functions.
     int singles_readout_depth;
+
+    //! OpenGATE output ROOT energy information is given in MeV, these methods convert to keV
+    float get_energy1_in_keV() const
+    { return energy1 * 1e3; };
+    float get_energy2_in_keV() const
+    { return energy2 * 1e3; };
 };
 
 END_NAMESPACE_STIR


### PR DESCRIPTION
Addresses #356. @ludovicabrusaferri I cannot figure out how you handled this issue in #722.

This is done when properties of the list mode event are queeried to be between `upper/low energy window (keV)`.

Edit: Our work around by setting `upper/low energy window (keV)` to an MeV value (e.g. 0.65) no longer works. This energy information is needed for scatter estimation code. Using `lm_to_projdata` to unlist a root file, the `upper/low energy window (keV)` information in the output sinogram is set from the hroot file, overwriting that in the `template sinogram`.