### PR TITLE
correct run_test_listmode_recon.sh exit status

### DIFF
--- a/recon_test_pack/run_test_listmode_recon.sh
+++ b/recon_test_pack/run_test_listmode_recon.sh
@@ -73,6 +73,8 @@ fi
 # first delete any files remaining from a previous run
 rm -f my_*v my_*s my_*S
 
+ThereWereErrors=0
+
 echo "=== Simulate normalisation data"
 # For normalisation data we are going to use a cylinder in the center,
 # with water attenuation values


### PR DESCRIPTION
set `ThereWereErrors=0` at the start, as otherwise it is uninitialized when there are no errors.

Fixes #230