### PR TITLE
provide more defaults for ScatterEstimation

### DIFF
--- a/examples/samples/scatter_estimation_par_files/scatter_estimation.par
+++ b/examples/samples/scatter_estimation_par_files/scatter_estimation.par
@@ -43,7 +43,10 @@ mask projdata filename := ${mask_projdata_filename}
 ; Input or output filename - depends on recompute  
 recompute mask image := 1
 mask image filename := ${mask_image}
+; threshold to be applied after filtering (in cm^-1). Default value is below
 mask attenuation image min threshold  := 0.003
+; optional filename to specify a filter before thresholding the attenuation image
+; By default a Gaussian filter with FWHM (15,20,20) will be used. Here we use an explicit file as an example.
 mask attenuation image filter filename := ${scatter_pardir}/postfilter_Gaussian_for_mask.par
 ;End of Mask
 

--- a/src/include/stir/PostFiltering.h
+++ b/src/include/stir/PostFiltering.h
@@ -45,6 +45,7 @@ public:
 
     virtual ~PostFiltering(){}
 
+    void set_filter_sptr(shared_ptr<DataProcessor< DataT > > filter_sptr);
     Succeeded process_data(DataT& arg);
 
     //! Check if filter exists

--- a/src/include/stir/PostFiltering.inl
+++ b/src/include/stir/PostFiltering.inl
@@ -32,6 +32,13 @@ PostFiltering<DataT>::post_processing()
 }
 
 template <class DataT>
+void
+PostFiltering<DataT>::set_filter_sptr(shared_ptr<DataProcessor< DataT > > filter_sptr_v)
+{
+  this->filter_sptr = filter_sptr_v;
+}
+
+template <class DataT>
 Succeeded
 PostFiltering<DataT>::process_data(DataT& arg)
 {


### PR DESCRIPTION
Trying to make it easier to run scatter estimation by removing need for files...

would be nice to get rid of need for `run_reconstruction.par` but difficulty is number of subsets.