### PR TITLE
Logcosh amendments

### DIFF
--- a/documentation/STIR-UsersGuide.tex
+++ b/documentation/STIR-UsersGuide.tex
@@ -4200,7 +4200,7 @@ This implements a quadratic Gibbs prior. The gradient of the prior is computed a
   \end{verbatim}
 
 
-{ \subsubsubsection{Relative Difference}
+{ \subsubsubsection{Relative Difference} \label{sec:priors:Relative_Difference}
 }
 This implements a Relative Difference Prior RDP, proposed by J. Nuyts, et.al., 2002. The gradient of the prior is computed as follows:
   \[g_r = \sum_{dr} w_{dr} *
@@ -4244,6 +4244,45 @@ This implements a Relative Difference Prior RDP, proposed by J. Nuyts, et.al., 2
   \end{verbatim}
 
 
+{ \subsubsubsection{Logcosh} \label{sec:priors:Logcosh}
+}
+This implements a Logcosh. The gradient of the prior is computed as follows:
+  \[g_r = \sum_{dr} w_{dr} * \frac{1}{s} * \tanh(s*(\lambda_{r} - \lambda_{dr})) *
+  \kappa_r * \kappa_{r+dr}\]
+
+  \noindent where $\lambda$ is the image where the gradient is computed
+   and $r$ and $dr$ are indices and the sum
+  is over the neighbourhood where the weights $w_{dr}$ are non-zero.
+  $s$ (a.k.a. scalar) controls the transition between the quadratic (smooth) and linear (edge-preserving) nature of the prior.
+
+  The $\kappa$ image is the same as that of \ref{sec:priors:Quadratic}.
+
+  By default, a 3x3 or 3x3x3 neigbourhood is used where the weights are set to 
+  x-voxel\_size divided by the Euclidean distance between the points.
+ 
+{ \subsubsubsubsection{Parameters}
+}
+  These are the keywords that can be used in addition to the ones listed in \ref{sec:priors}..
+  \begin{verbatim}
+  prior type := Logcosh Prior
+  Logcosh Prior Parameters:=
+  ; next defaults to 0, set to 1 for 2D inverse Euclidean weights, 0 for 3D 
+  only 2D:= 0
+  ; next can be used to set weights explicitly. Needs to be a 3D array (of floats).
+  ' value of only_2D is ignored
+  ; following example uses 2D 'nearest neighbour' penalty
+  ; weights:={{{0,1,0},{1,0,1},{0,1,0}}}
+  ; use next parameter to specify an image with penalisation factors (a la Fessler)
+  ; see class documentation for more info
+  ; kappa filename:=
+  ; use next parameter to get gradient images at every subiteration
+  ; see class documentation
+  ; scalar is a parameter used to control edge preservation
+  ; scalar value := 1
+  END Logcosh Prior Parameters:=
+  \end{verbatim}
+
+
 { \subsubsubsection{PLS}
 This implements the  anatomical penalty function, Parallel Level Sets (PLS),  proposed by Matthias J. Ehrhardt et. al [Ehr16]. Note that
   PLS becomes smoothed TV when an uniform anatomical image is provided.  
@@ -4280,6 +4319,7 @@ The prior has 2 parameters alpha and eta. It is computed for an image $ f $ as
   only_2D:=0
   END PLS Prior Parameters:=
   \end{verbatim}
+
 \subsubsection{
 Selecting different projector pairs}
 \label{sec:projectorpairs}

--- a/documentation/STIR-UsersGuide.tex
+++ b/documentation/STIR-UsersGuide.tex
@@ -4264,7 +4264,7 @@ This implements a Logcosh. The gradient of the prior is computed as follows:
 }
   These are the keywords that can be used in addition to the ones listed in \ref{sec:priors}..
   \begin{verbatim}
-  prior type := Logcosh Prior
+  prior type := Logcosh
   Logcosh Prior Parameters:=
   ; next defaults to 0, set to 1 for 2D inverse Euclidean weights, 0 for 3D 
   only 2D:= 0

--- a/src/recon_buildblock/LogcoshPrior.cxx
+++ b/src/recon_buildblock/LogcoshPrior.cxx
@@ -125,7 +125,7 @@ LogcoshPrior<elemT>::set_defaults()
 template <>
 const char * const
         LogcoshPrior<float>::registered_name =
-        "Logcosh Prior";
+        "Logcosh";
 
 template <typename elemT>
 LogcoshPrior<elemT>::LogcoshPrior()

--- a/src/recon_buildblock/LogcoshPrior.cxx
+++ b/src/recon_buildblock/LogcoshPrior.cxx
@@ -125,7 +125,7 @@ LogcoshPrior<elemT>::set_defaults()
 template <>
 const char * const
         LogcoshPrior<float>::registered_name =
-        "Logcosh";
+        "Logcosh Prior";
 
 template <typename elemT>
 LogcoshPrior<elemT>::LogcoshPrior()

--- a/src/recon_buildblock/recon_buildblock_registries.cxx
+++ b/src/recon_buildblock/recon_buildblock_registries.cxx
@@ -96,6 +96,7 @@ static FilterRootPrior<DiscretisedDensity<3,float> >::RegisterIt dummy4;
 static QuadraticPrior<float>::RegisterIt dummy5;
 static PLSPrior<float>::RegisterIt dummyPLS;
 static RelativeDifferencePrior<float>::RegisterIt dummyRelativeDifference;
+static LogcoshPrior<float>::RegisterIt dummyLogcosh;
 
 static ProjMatrixByBinUsingRayTracing::RegisterIt dummy11;
 static ProjMatrixByBinUsingInterpolation::RegisterIt dummy12;


### PR DESCRIPTION
Minor changes to Logcosh I forgot. 

- Logcosh was not setup properly in `recon_buildblock_registries` and therefore methods such as `OSMAPOSL` could not use it. The error was:
```
FactoryRegistry: key LogCosh not found in current registry
5 possible values are:
FilterRootPrior
None
PLS
Quadratic
Relative Difference Prior
```
 - Renamed `Logcosh` to `Logcosh Prior`

 - Updated the `UsersGuide` to have a Logcosh subsection and example usage.