### PR TITLE
Optional KL Divergence Computation

### DIFF
--- a/src/buildblock/recon_array_functions.cxx
+++ b/src/buildblock/recon_array_functions.cxx
@@ -262,7 +262,8 @@ void poisson_divide_and_truncate(Viewgram<float>& numerator,
             if (log_likelihood_ptr != NULL)
             {
               // Substitute denominator[r][b] (i.e. ybar) for num / max_quotient (i.e. y/ max_quotient)
-              sub_result += compute_Poisson_data_fit(numerator[r][b], numerator[r][b] / max_quotient, use_KL_divergence, small_value);
+              sub_result += compute_Poisson_data_fit(numerator[r][b], numerator[r][b] / max_quotient,
+                                                     use_KL_divergence);
             }
             // Compute Division (WITH divide by zero correction)
             if (do_division)
@@ -271,7 +272,7 @@ void poisson_divide_and_truncate(Viewgram<float>& numerator,
 	      else
 		{
 		  if (log_likelihood_ptr != NULL) 
-              sub_result += compute_Poisson_data_fit(numerator[r][b], denominator[r][b], use_KL_divergence, small_value);
+              sub_result += compute_Poisson_data_fit(double(numerator[r][b]), double(denominator[r][b]), use_KL_divergence);
 
             // Compute Division (WITHOUT divide by zero correction)
             if (do_division)
@@ -418,21 +419,20 @@ void accumulate_loglikelihood(Viewgram<float>& projection_data,
 #endif
 }
 
-float compute_Poisson_data_fit(float y, const float ybar, bool use_KL_divergence, const float lower_threshold)
+double compute_Poisson_data_fit(double y, const double ybar, bool use_KL_divergence)
 {
-  if (y <= lower_threshold)
-    return -double(ybar);
+  return use_KL_divergence ? negativeKLDivergence(y, ybar) : LogLikelihood(y, ybar);
+}
 
-  if ( use_KL_divergence )
-  {
-    // Compute the KL divergence
-    return - (y * log(y / double(ybar)) + double(ybar) - y);
-  }
-  else
-  {
-    //Compute the Log-Likelihood
-    return y * log(double(ybar)) - double(ybar);
-  }
+double LogLikelihood(const double y, const double ybar)
+{
+  return y * log(ybar) - ybar;
+}
+
+double negativeKLDivergence(const double y, const double ybar)
+{
+  return - (y * log(y / ybar) + ybar - y);
+
 }
 
 

--- a/src/buildblock/recon_array_functions.cxx
+++ b/src/buildblock/recon_array_functions.cxx
@@ -235,8 +235,8 @@ void divide_and_truncate(Viewgram<float>& numerator,
 	}
       else
 	{
-	  float& num = numerator[r][b];
-	  if (num<=small_value) // KT Feb2011 was "num<small_value", resulting in a BUG if the whole numerator viewgram was zero
+//	  float& num = numerator[r][b];
+	  if (numerator[r][b]<=small_value) // KT Feb2011 was "num<small_value", resulting in a BUG if the whole numerator viewgram was zero
 	    { 
 	      // we think num was really 0 
 	      // (we compare with small_value due to rounding errors)
@@ -402,21 +402,20 @@ void accumulate_loglikelihood(Viewgram<float>& projection_data,
   *accum += result;
 }
 
-float compute_Poisson_data_fit(float y, const float ybar, bool use_KL_divergence, const float small_value)
+float compute_Poisson_data_fit(float y, const float ybar, bool use_KL_divergence, const float lower_threshold)
 {
-
-  if (y <= small_value)
+  if (y <= lower_threshold)
     return -double(ybar);
 
-  if ( !use_KL_divergence )
-  {
-    //Compute the Log-Likelihood
-    return y * log(double(ybar)) - double(ybar);
-  }
-  else
+  if ( use_KL_divergence )
   {
     // Compute the KL divergence
     return - (y * log(y / double(ybar)) + double(ybar) - y);
+  }
+  else
+  {
+    //Compute the Log-Likelihood
+    return y * log(double(ybar)) - double(ybar);
   }
 }
 

--- a/src/buildblock/recon_array_functions.cxx
+++ b/src/buildblock/recon_array_functions.cxx
@@ -197,6 +197,7 @@ void poisson_divide_and_truncate(Viewgram<float>& numerator,
 
   const float small_value= 
     max(numerator.find_max()*SMALL_NUM, 0.F);
+  const float max_quotient = 10000.F;
   
   double result=0; // use this for total result for this viewgram, reducing numerical error
 
@@ -243,12 +244,10 @@ void poisson_divide_and_truncate(Viewgram<float>& numerator,
 	      // (we compare with small_value due to rounding errors)
 	      // this case includes 0/0, but also num<0	     
           numerator[r][b] = 0;
-          if (numerator[r][b]<0)
-            count2++;
+          if (numerator[r][b]<0) count2++;
         }
         else
         {
-          const float max_quotient = 10000.F;
 	      // set quotient to min(numerator/denominator, max_quotient)
 	      // a bit tricky to avoid division by 0	  
 	      // we do this by effectively using
@@ -364,20 +363,20 @@ void divide_array(DiscretisedDensity<3,float>& numerator, const DiscretisedDensi
 // KT 21/05/2001 make sure it returns same result as divide_and_truncate above
 // RT 17/02/2021 explicitly make sure that it returns the same value as (possion_)divide_and_truncate above by using
 // the same functionality
-void accumulate_loglikelihood(Viewgram<float>& projection_data, 
-			 const Viewgram<float>& estimated_projections,
-			 const int rim_truncation_sino,
-			 double* log_likelihood_ptr,
-			 const bool use_KL_divergence)
+void accumulate_Poisson_data_fit(Viewgram<float>& projection_data,
+                                 const Viewgram<float>& estimated_projections,
+                                 const int rim_truncation_sino,
+                                 double* log_likelihood_ptr,
+                                 const bool use_KL_divergence)
 {
 #if 1
   int count = 0;
   int count2 = 0;
-      poisson_divide_and_truncate(projection_data,
-                                  estimated_projections,
-                                  rim_truncation_sino,
-                                  count, count2,
-                                  log_likelihood_ptr, use_KL_divergence, false);
+  poisson_divide_and_truncate(projection_data,
+                              estimated_projections,
+                              rim_truncation_sino,
+                              count, count2,
+                              log_likelihood_ptr, use_KL_divergence, false);
 
 #else
   // Old method that does not use poisson_divide_and_truncate and therefore the same thresholding as gradient.

--- a/src/buildblock/recon_array_functions.cxx
+++ b/src/buildblock/recon_array_functions.cxx
@@ -261,7 +261,7 @@ void divide_and_truncate(Viewgram<float>& numerator,
             if (log_likelihood_ptr != NULL)
             {
               // Substitute denominator[r][b] (i.e. ybar) for num / max_quotient (i.e. y/ max_quotient)
-              sub_result += compute_data_fit_term(numerator[r][b], numerator[r][b] / max_quotient, use_KL_divergence, small_value);
+              sub_result += compute_Poisson_data_fit(numerator[r][b], numerator[r][b] / max_quotient, use_KL_divergence, small_value);
             }
             // Compute Division (WITH divide by zero correction)
             numerator[r][b] = max_quotient;
@@ -269,7 +269,7 @@ void divide_and_truncate(Viewgram<float>& numerator,
 	      else
 		{
 		  if (log_likelihood_ptr != NULL) 
-              sub_result += compute_data_fit_term(numerator[r][b], denominator[r][b], use_KL_divergence, small_value);
+              sub_result += compute_Poisson_data_fit(numerator[r][b], denominator[r][b], use_KL_divergence, small_value);
 
             // Compute Division (WITHOUT divide by zero correction)
             numerator[r][b] = numerator[r][b]/denominator[r][b];
@@ -394,7 +394,7 @@ void accumulate_loglikelihood(Viewgram<float>& projection_data,
 	   b>be-rim_truncation_sino ))
 	{
         const float new_estimate = max(estimated_projections[r][b], projection_data[r][b]/max_quotient);
-        sub_result += compute_data_fit_term(projection_data[r][b], new_estimate, use_KL_divergence, small_value);
+        sub_result += compute_Poisson_data_fit(projection_data[r][b], new_estimate, use_KL_divergence, small_value);
       }
     result += sub_result;
   }
@@ -402,7 +402,7 @@ void accumulate_loglikelihood(Viewgram<float>& projection_data,
   *accum += result;
 }
 
-float compute_data_fit_term(float y, const float ybar, bool use_KL_divergence, const float small_value)
+float compute_Poisson_data_fit(float y, const float ybar, bool use_KL_divergence, const float small_value)
 {
 
   if (y <= small_value)

--- a/src/include/stir/recon_array_functions.h
+++ b/src/include/stir/recon_array_functions.h
@@ -116,7 +116,7 @@ void accumulate_loglikelihood(Viewgram<float>& projection_data,
 			 double* accum,
 			 const bool use_KL_divergence);
 
-float compute_Poisson_data_fit(float y, float ybar, bool use_KL_divergence, float small_value);
+float compute_Poisson_data_fit(float y, float ybar, bool use_KL_divergence, float lower_threshold);
 
 END_NAMESPACE_STIR
 #endif // __recon_array_functions_h_

--- a/src/include/stir/recon_array_functions.h
+++ b/src/include/stir/recon_array_functions.h
@@ -116,7 +116,11 @@ void accumulate_loglikelihood(Viewgram<float>& projection_data,
 			 double* accum,
 			 const bool use_KL_divergence);
 
-float compute_Poisson_data_fit(float y, float ybar, bool use_KL_divergence, float lower_threshold);
+double compute_Poisson_data_fit(const double y, const double ybar, bool use_KL_divergence);
+
+double LogLikelihood(const double y, const double ybar);
+
+double negativeKLDivergence(const double y, const double ybar);
 
 END_NAMESPACE_STIR
 #endif // __recon_array_functions_h_

--- a/src/include/stir/recon_array_functions.h
+++ b/src/include/stir/recon_array_functions.h
@@ -116,7 +116,7 @@ void accumulate_loglikelihood(Viewgram<float>& projection_data,
 			 double* accum,
 			 const bool use_KL_divergence);
 
-float compute_data_fit_term(float y, float ybar, bool use_KL_divergence, float small_value);
+float compute_Poisson_data_fit(float y, float ybar, bool use_KL_divergence, float small_value);
 
 END_NAMESPACE_STIR
 #endif // __recon_array_functions_h_

--- a/src/include/stir/recon_array_functions.h
+++ b/src/include/stir/recon_array_functions.h
@@ -76,12 +76,14 @@ void divide_and_truncate(DiscretisedDensity<3,float>& numerator,
 //! divide viewgrams and set 'edge bins' to zero, put answer in numerator
 void divide_and_truncate(Viewgram<float>& numerator, const Viewgram<float>& denominator,
 			 const int rim_truncation_sino,
-			 int& count, int& count2, double* f = NULL);
+			 int& count, int& count2, double* f = NULL,
+			 const bool use_KL_divergence= false);
 
 //! divide related viewgrams and set 'edge bins' to zero, put answer in numerator
 void divide_and_truncate(RelatedViewgrams<float>& numerator, const RelatedViewgrams<float>& denominator,
 			 const int rim_truncation_sino,
-			 int& count, int& count2, double* f = NULL);
+			 int& count, int& count2, double* f = NULL,
+			 const bool use_KL_divergence = false);
 
 //! sets to zero voxels within rim_truncation_image of the FOV rim
 void truncate_rim(DiscretisedDensity<3,float>& image_input, 
@@ -111,8 +113,10 @@ void divide_array(DiscretisedDensity<3,float>& numerator, const DiscretisedDensi
 void accumulate_loglikelihood(Viewgram<float>& projection_data, 
 			 const Viewgram<float>& estimated_projections,
 			 const int rim_truncation_sino,
-			 double* accum);
+			 double* accum,
+			 const bool use_KL_divergence);
 
+float compute_data_fit_term(float y, float ybar, bool use_KL_divergence, float small_value);
 
 END_NAMESPACE_STIR
 #endif // __recon_array_functions_h_

--- a/src/include/stir/recon_array_functions.h
+++ b/src/include/stir/recon_array_functions.h
@@ -109,17 +109,20 @@ void divide_array(DiscretisedDensity<3,float>& numerator, const DiscretisedDensi
 
 //MJ 03/01/2000  Trying to adhoc parallelize a loglikelihood computation
 
-//! compute the log term of the loglikelihood function for given part of the projection space
-void accumulate_loglikelihood(Viewgram<float>& projection_data, 
-			 const Viewgram<float>& estimated_projections,
-			 const int rim_truncation_sino,
-			 double* accum,
-			 const bool use_KL_divergence);
+//! compute the Poisson data fit function for given part of the projection space
+void accumulate_Poisson_data_fit(Viewgram<float>& projection_data,
+                                 const Viewgram<float>& estimated_projections,
+                                 const int rim_truncation_sino,
+                                 double* accum,
+                                 const bool use_KL_divergence);
 
+//! compute the Poisson data fit function for a single bin
 double compute_Poisson_data_fit(const double y, const double ybar, bool use_KL_divergence);
 
+//! compute the LogLikelihood for a single bin
 double LogLikelihood(const double y, const double ybar);
 
+//! compute the negative KL divergence for a single bin
 double negativeKLDivergence(const double y, const double ybar);
 
 END_NAMESPACE_STIR

--- a/src/include/stir/recon_array_functions.h
+++ b/src/include/stir/recon_array_functions.h
@@ -74,16 +74,16 @@ void divide_and_truncate(DiscretisedDensity<3,float>& numerator,
 #endif
 
 //! divide viewgrams and set 'edge bins' to zero, put answer in numerator
-void divide_and_truncate(Viewgram<float>& numerator, const Viewgram<float>& denominator,
-			 const int rim_truncation_sino,
-			 int& count, int& count2, double* f = NULL,
-			 const bool use_KL_divergence= false);
+void poisson_divide_and_truncate(Viewgram<float>& numerator, const Viewgram<float>& denominator,
+                                 const int rim_truncation_sino,
+                                 int& count, int& count2, double* f = NULL,
+                                 const bool use_KL_divergence= false,
+                                 const bool do_division=true);
 
 //! divide related viewgrams and set 'edge bins' to zero, put answer in numerator
-void divide_and_truncate(RelatedViewgrams<float>& numerator, const RelatedViewgrams<float>& denominator,
-			 const int rim_truncation_sino,
-			 int& count, int& count2, double* f = NULL,
-			 const bool use_KL_divergence = false);
+    void possion_divide_and_truncate(RelatedViewgrams<float> &numerator, const RelatedViewgrams<float> &denominator,
+                                     const int rim_truncation_sino, int &count, int &count2, double *f,
+                                     const bool use_KL_divergence, const bool do_division);
 
 //! sets to zero voxels within rim_truncation_image of the FOV rim
 void truncate_rim(DiscretisedDensity<3,float>& image_input, 

--- a/src/include/stir/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMean.h
+++ b/src/include/stir/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMean.h
@@ -237,12 +237,17 @@ public  GeneralisedObjectiveFunction<TargetT>
   void 
     fill_nonidentifiable_target_parameters(TargetT& target, const float value ) const;
 
+  bool get_use_KL_divergence();
+
+  void set_use_KL_divergence(const bool KL);
+
  private:
 
   std::string sensitivity_filename;
   std::string subsensitivity_filenames;
   bool recompute_sensitivity;
   bool use_subset_sensitivities;
+  bool use_KL_divergence;
 
   VectorWithOffset<shared_ptr<TargetT> > subsensitivity_sptrs;
   shared_ptr<TargetT> sensitivity_sptr;

--- a/src/include/stir/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMean.h
+++ b/src/include/stir/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMean.h
@@ -237,8 +237,13 @@ public  GeneralisedObjectiveFunction<TargetT>
   void 
     fill_nonidentifiable_target_parameters(TargetT& target, const float value ) const;
 
+  //! See set_use_KL_divergence()
   bool get_use_KL_divergence();
 
+  //! Sets the use_KL_divergence bool
+  /*! use_KL_divergence bool indicates what poisson data fit term to use, Kullback-Leibler Divergence or
+  Log-likelihhood.
+  */
   void set_use_KL_divergence(const bool KL);
 
  private:
@@ -247,7 +252,7 @@ public  GeneralisedObjectiveFunction<TargetT>
   std::string subsensitivity_filenames;
   bool recompute_sensitivity;
   bool use_subset_sensitivities;
-  bool use_KL_divergence;
+  bool use_KL_divergence; //! See set_use_KL_divergence()
 
   VectorWithOffset<shared_ptr<TargetT> > subsensitivity_sptrs;
   shared_ptr<TargetT> sensitivity_sptr;

--- a/src/include/stir/recon_buildblock/distributable.h
+++ b/src/include/stir/recon_buildblock/distributable.h
@@ -99,7 +99,8 @@ typedef  void RPC_process_related_viewgrams_type (
                                                   RelatedViewgrams<float>* measured_viewgrams_ptr,
                                                   int& count, int& count2, double* log_likelihood_ptr,
                                                   const RelatedViewgrams<float>* additive_binwise_correction_ptr,
-                                                  const RelatedViewgrams<float>* mult_viewgrams_ptr);
+                                                  const RelatedViewgrams<float>* mult_viewgrams_ptr,
+                                                  const bool use_KL_divergence);
 
 /*!
   \brief This function essentially implements a loop over segments and all views in the current subset.
@@ -179,7 +180,8 @@ void distributable_computation(
                                const double start_time_of_frame,
                                const double end_time_of_frame,
                                RPC_process_related_viewgrams_type * RPC_process_related_viewgrams,
-                               DistributedCachingInformation* caching_info_ptr);
+                               DistributedCachingInformation* caching_info_ptr,
+                               const bool use_KL_divergence);
 
 
   /*! \name Tag-names currently used by stir::distributable_computation and related functions0

--- a/src/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMean.cxx
+++ b/src/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMean.cxx
@@ -54,6 +54,7 @@ set_defaults()
   this->recompute_sensitivity = false;
   this->use_subset_sensitivities = true;
   this->subsensitivity_sptrs.resize(0);
+  this->use_KL_divergence = false;
 }
 
 template<typename TargetT>
@@ -67,6 +68,7 @@ initialise_keymap()
   this->parser.add_key("subset sensitivity filenames", &this->subsensitivity_filenames);
   this->parser.add_key("recompute sensitivity", &this->recompute_sensitivity);
   this->parser.add_key("use_subset_sensitivities", &this->use_subset_sensitivities);
+  this->parser.add_key("use KL divergence", &this->use_KL_divergence);
 
 }
 
@@ -187,6 +189,22 @@ PoissonLogLikelihoodWithLinearModelForMean<TargetT>::
 set_subset_sensitivity_sptr(const shared_ptr<TargetT>& arg, const int subset_num)
 {
   this->subsensitivity_sptrs[subset_num] = arg;
+}
+
+template<typename TargetT>
+void
+PoissonLogLikelihoodWithLinearModelForMean<TargetT>::
+set_use_KL_divergence(const bool KL)
+{
+  this->use_KL_divergence = KL;
+}
+
+template<typename TargetT>
+bool
+PoissonLogLikelihoodWithLinearModelForMean<TargetT>::
+get_use_KL_divergence()
+{
+  return this->use_KL_divergence;
 }
 
 template<typename TargetT>

--- a/src/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMeanAndProjData.cxx
+++ b/src/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMeanAndProjData.cxx
@@ -874,8 +874,8 @@ actual_add_multiplication_with_approximate_sub_Hessian_without_penalty(TargetT& 
           
           // now divide by the data term
           {
-            int tmp1=0, tmp2=0;// ignore counters returned by divide_and_truncate
-            divide_and_truncate(tmp_viewgrams, viewgrams, 0, tmp1, tmp2);
+            int tmp1=0, tmp2=0;// ignore counters returned by poisson_divide_and_truncate
+            possion_divide_and_truncate(tmp_viewgrams, viewgrams, 0, tmp1, tmp2, nullptr, false, true);
           }
 
           // back-project
@@ -1081,7 +1081,8 @@ void RPC_process_related_viewgrams_gradient(
 
 
   // for sinogram division
-  divide_and_truncate(*measured_viewgrams_ptr, estimated_viewgrams, rim_truncation_sino, count, count2, log_likelihood_ptr, use_KL_divergence);
+  possion_divide_and_truncate(*measured_viewgrams_ptr, estimated_viewgrams, rim_truncation_sino, count, count2,
+                              log_likelihood_ptr, use_KL_divergence, true);
   back_projector_sptr->back_project(*measured_viewgrams_ptr);
 };      
 

--- a/src/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMeanAndProjData.cxx
+++ b/src/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMeanAndProjData.cxx
@@ -903,7 +903,7 @@ actual_add_multiplication_with_approximate_sub_Hessian_without_penalty(TargetT& 
 //! Call-back function for compute_gradient
 RPC_process_related_viewgrams_type RPC_process_related_viewgrams_gradient;
 
-//! Call-back function for accumulate_loglikelihood
+//! Call-back function for accumulate_Poisson_data_fit
 RPC_process_related_viewgrams_type RPC_process_related_viewgrams_accumulate_loglikelihood;
 
 //! Call-back function for sensitivity_computation
@@ -913,7 +913,7 @@ RPC_process_related_viewgrams_type RPC_process_related_viewgrams_sensitivity_com
 //! Call-back function for compute_gradient
 static RPC_process_related_viewgrams_type RPC_process_related_viewgrams_gradient;
 
-//! Call-back function for accumulate_loglikelihood
+//! Call-back function for accumulate_Poisson_data_fit
 static RPC_process_related_viewgrams_type RPC_process_related_viewgrams_accumulate_loglikelihood;
 
 //! Call-back function for sensitivity_computation
@@ -1121,10 +1121,10 @@ void RPC_process_related_viewgrams_accumulate_loglikelihood(
   for (;
        meas_viewgrams_iter != measured_viewgrams_ptr->end();
        ++meas_viewgrams_iter, ++est_viewgrams_iter)
-    accumulate_loglikelihood(*meas_viewgrams_iter, 
-                             *est_viewgrams_iter, 
-                             rim_truncation_sino,
-                             log_likelihood_ptr, use_KL_divergence);
+    accumulate_Poisson_data_fit(*meas_viewgrams_iter,
+                                *est_viewgrams_iter,
+                                rim_truncation_sino,
+                                log_likelihood_ptr, use_KL_divergence);
 };      
 
 void RPC_process_related_viewgrams_sensitivity_computation(

--- a/src/recon_buildblock/distributable.cxx
+++ b/src/recon_buildblock/distributable.cxx
@@ -294,7 +294,8 @@ void distributable_computation(
                                const double start_time_of_frame,
                                const double end_time_of_frame,
                                RPC_process_related_viewgrams_type * RPC_process_related_viewgrams,
-                               DistributedCachingInformation* caching_info_ptr)
+                               DistributedCachingInformation* caching_info_ptr,
+                               const bool use_KL_divergence)
 
 {
 #ifdef STIR_MPI 
@@ -486,7 +487,8 @@ void distributable_computation(
                                         local_counts[thread_num], local_count2s[thread_num], 
                                         is_null_ptr(log_likelihood_ptr)? NULL : &local_log_likelihoods[thread_num], 
                                         additive_binwise_correction_viewgrams.get(),
-                                        mult_viewgrams_sptr.get());
+                                        mult_viewgrams_sptr.get(),
+                                        use_KL_divergence);
             
 #else
           RPC_process_related_viewgrams(forward_projector_ptr,

--- a/src/recon_buildblock/distributable.cxx
+++ b/src/recon_buildblock/distributable.cxx
@@ -495,7 +495,8 @@ void distributable_computation(
                                         back_projector_ptr,
                                         y.get(), count, count2, log_likelihood_ptr,
                                         additive_binwise_correction_viewgrams.get(),
-                                        mult_viewgrams_sptr.get());
+                                        mult_viewgrams_sptr.get(),
+                                        use_KL_divergence);
 #endif // OPENMP                                    
 #endif // MPI
       } // end of for-loop 


### PR DESCRIPTION
Addresses #697 

Combines the objective function value computation to run through the same code as the gradient computation. For numerical computational reasons, when computing a single function/gradient evaluation (i.e. a single bin) an upper and lower threshold are appiled to prevent singlarities (divide by ~zero) and negative values. Both the functional and gradient values should be subject to the same bounds and therefore this PR combines these evaluations into `poisson_divide_and_truncate`. 

If a `log_likelihood_ptr` is parsed, the function will compute the function. Likewise, if the `do_division == true` the function will compute the gradient. 

Adds bool `use_KL_divergence` that is parsed from `PoissonLogLikelihoodWithLinearModelForMean` methods through to a set of functions in `recon_array_functions.cxx`. `use_KL_divergence` can be set at objective function level and by default this is off, so backward compatable. 

- [x] Test with evaluation of objective functions (Compare STIR master, and branch LL and KL computations). 

STIR master and branch LL are identical. KL produces value ~1000x smaller than LL.

- [ ] Documentation: Release notes, Users guide.
- [ ] Check mismatch between STIR master LL and this PR LL values (https://github.com/UCL/STIR/pull/760#issuecomment-780743088)

- [ ] Test MPI Code