### PR TITLE
add get_num_tof_poss() etc from TOF branch

### DIFF
--- a/src/include/stir/ProjData.h
+++ b/src/include/stir/ProjData.h
@@ -285,6 +285,8 @@ public:
   inline int get_num_views() const;
   //! Get number of tangential positions
   inline int get_num_tangential_poss() const;
+  //! Get number of TOF positions
+  inline int get_num_tof_poss() const;
   //! Get minimum segment number
   inline int get_min_segment_num() const;
   //! Get maximum segment number
@@ -303,6 +305,11 @@ public:
   inline int get_max_tangential_pos_num() const;
   //! Get the total number of sinograms
   inline int get_num_sinograms() const;
+  //! Get the number of non-tof sinograms
+  /*! Note that this is the sum of the number of axial poss over all segments.
+      \see get_num_sinograms()
+  */
+  inline int get_num_non_tof_sinograms() const;
   //! Get the total size of the data
   inline std::size_t size_all() const;
   //! writes data to a file in Interfile format

--- a/src/include/stir/ProjData.inl
+++ b/src/include/stir/ProjData.inl
@@ -3,6 +3,7 @@
   \ingroup projdata
   \brief Implementations for inline functions of class stir::ProjData
 
+  \author Nikos Efthimiou
   \author Sanida Mustafovic
   \author Kris Thielemans
   \author PARAPET project
@@ -11,6 +12,7 @@
     Copyright (C) 2000 PARAPET partners
     Copyright (C) 2000-2009, Hammersmith Imanet Ltd
     Copyright (C) 2013, 2015 University College London
+    Copyright (C) 2016, University of Hull
     This file is part of STIR.
 
     This file is free software; you can redistribute it and/or modify
@@ -54,6 +56,9 @@ int ProjData::get_num_views() const
 int ProjData::get_num_tangential_poss() const
 { return proj_data_info_ptr->get_num_tangential_poss(); }
 
+int ProjData::get_num_tof_poss() const
+{ return proj_data_info_ptr->get_num_tof_poss(); }
+
 int ProjData::get_min_segment_num() const
 { return proj_data_info_ptr->get_min_segment_num(); }
 
@@ -77,6 +82,9 @@ int ProjData::get_min_tangential_pos_num() const
 
 int ProjData::get_max_tangential_pos_num() const
 { return proj_data_info_ptr->get_max_tangential_pos_num(); }
+
+int ProjData::get_num_non_tof_sinograms() const
+{ return proj_data_info_ptr->get_num_non_tof_sinograms(); }
 
 int ProjData::get_num_sinograms() const
 { return proj_data_info_ptr->get_num_sinograms(); }

--- a/src/include/stir/ProjDataInfo.h
+++ b/src/include/stir/ProjDataInfo.h
@@ -188,6 +188,8 @@ public:
   inline int get_num_views() const;
   //! Get number of tangential positions
   inline int get_num_tangential_poss() const;
+  //! Get number of TOF bins
+  inline int get_num_tof_poss() const;
   //! Get minimum segment number
   inline int get_min_segment_num() const;
   //! Get maximum segment number
@@ -206,6 +208,11 @@ public:
   inline int get_max_tangential_pos_num() const;
   //! Get the total number of sinograms
   inline int get_num_sinograms() const;
+  //! Get the number of non-tof sinograms
+  /*! Note that this is the sum of the number of axial poss over all segments.
+      \see get_num_sinograms()
+  */
+  inline int get_num_non_tof_sinograms() const;
   //! Get the total size of the data
   inline std::size_t size_all() const;
   //@}

--- a/src/include/stir/ProjDataInfo.inl
+++ b/src/include/stir/ProjDataInfo.inl
@@ -57,6 +57,10 @@ int
 ProjDataInfo::get_num_tangential_poss() const
 { return  max_tangential_pos_num - min_tangential_pos_num + 1; }
 
+int
+ProjDataInfo::get_num_tof_poss() const
+{ return 1; /* always 1 at the moment */ }
+
 int 
 ProjDataInfo::get_min_segment_num() const
 { return (max_axial_pos_per_seg.get_min_index()); }
@@ -121,13 +125,19 @@ ProjDataInfo::get_scanner_sptr() const
 
 
 int
-ProjDataInfo::get_num_sinograms() const
+ProjDataInfo::get_num_non_tof_sinograms() const
 {
   int num_sinos = 0;
   for (int s=this->get_min_segment_num(); s<= this->get_max_segment_num(); ++s)
     num_sinos += this->get_num_axial_poss(s);
 
   return num_sinos;
+}
+
+int
+ProjDataInfo::get_num_sinograms() const
+{
+    return this->get_num_non_tof_sinograms()*this->get_num_tof_poss();
 }
 
 std::size_t


### PR DESCRIPTION
These functions currently return the non-TOF values of course, but
they are identical to what is on the TOF branch, so makes it easier
for people (including) SIRF to be compatible with the future