### PR TITLE
Axpby fix

### DIFF
--- a/src/swig/stir.i
+++ b/src/swig/stir.i
@@ -985,7 +985,7 @@ T * operator-> () const;
 #endif
 
 %ignore stir::NumericVectorWithOffset::xapyb;
-%ignore stir::NumericVectorWithOffset::axpby;
+//%ignore stir::NumericVectorWithOffset::axpby;
 %include "stir/NumericVectorWithOffset.h"
 
 #ifdef SWIGPYTHON

--- a/src/swig/stir.i
+++ b/src/swig/stir.i
@@ -985,7 +985,6 @@ T * operator-> () const;
 #endif
 
 %ignore stir::NumericVectorWithOffset::xapyb;
-//%ignore stir::NumericVectorWithOffset::axpby;
 %include "stir/NumericVectorWithOffset.h"
 
 #ifdef SWIGPYTHON


### PR DESCRIPTION
@KrisThielemans removing this line might be needed for #765. It was needed before I unset the macro, but I guess now should return full (old) functionality.


