### PR TITLE
Axpby fix2

### DIFF
--- a/src/buildblock/ProjData.cxx
+++ b/src/buildblock/ProjData.cxx
@@ -439,6 +439,14 @@ write_to_file(const string& output_filename) const
 
 void
 ProjData::
+axpby( const float a, const ProjData& x,
+       const float b, const ProjData& y)
+{
+  xapyb(x,a,y,b);
+}
+
+void
+ProjData::
 xapyb(const ProjData& x, const float a,
       const ProjData& y, const float b)
 {

--- a/src/buildblock/ProjData.cxx
+++ b/src/buildblock/ProjData.cxx
@@ -494,6 +494,21 @@ xapyb(const ProjData& x, const ProjData& a,
     }
 }
 
+void
+ProjData::
+sapyb(const float a, const ProjData& y, const float b)
+{
+  this->xapyb(*this,a,y,b);
+}
+
+void
+ProjData::
+sapyb(const ProjData& a, const ProjData& y,const ProjData& b)
+{
+  this->xapyb(*this,a,y,b);
+}
+
+
 std::vector<int>
 ProjData::
 standard_segment_sequence(const ProjDataInfo& pdi)

--- a/src/buildblock/ProjData.cxx
+++ b/src/buildblock/ProjData.cxx
@@ -467,6 +467,33 @@ xapyb(const ProjData& x, const float a,
     }
 }
 
+void
+ProjData::
+xapyb(const ProjData& x, const ProjData& a,
+      const ProjData& y, const ProjData& b)
+{
+    if (*get_proj_data_info_sptr() != *x.get_proj_data_info_sptr() ||
+        *get_proj_data_info_sptr() != *y.get_proj_data_info_sptr() ||
+        *get_proj_data_info_sptr() != *a.get_proj_data_info_sptr() ||
+        *get_proj_data_info_sptr() != *b.get_proj_data_info_sptr())
+        error("ProjData::xapyb: ProjDataInfo don't match");
+
+    const int n_min = get_min_segment_num();
+    const int n_max = get_max_segment_num();
+
+    for (int s=n_min; s<=n_max; ++s)
+    {
+        SegmentBySinogram<float> seg = get_empty_segment_by_sinogram(s);
+        const SegmentBySinogram<float> sx = x.get_segment_by_sinogram(s);
+        const SegmentBySinogram<float> sy = y.get_segment_by_sinogram(s);
+        const SegmentBySinogram<float> sa = a.get_segment_by_sinogram(s);
+        const SegmentBySinogram<float> sb = b.get_segment_by_sinogram(s);
+
+        seg.xapyb(sx, sa, sy, sb);
+        set_segment(seg);
+    }
+}
+
 std::vector<int>
 ProjData::
 standard_segment_sequence(const ProjDataInfo& pdi)

--- a/src/buildblock/ProjDataInMemory.cxx
+++ b/src/buildblock/ProjDataInMemory.cxx
@@ -202,5 +202,51 @@ xapyb(const ProjData& x, const float a,
     this->buffer.xapyb(x_pdm->buffer, a, y_pdm->buffer, b);
 #endif
 }
+      
+void
+ProjDataInMemory::
+xapyb(const ProjData& x, const ProjData& a,
+      const ProjData& y, const ProjData& b)
+{
+    // To use this method, we require that all three proj data be ProjDataInMemory
+    // So cast them. If any null pointers, fall back to default functionality
+    const ProjDataInMemory *x_pdm = dynamic_cast<const ProjDataInMemory*>(&x);
+    const ProjDataInMemory *y_pdm = dynamic_cast<const ProjDataInMemory*>(&y);
+    const ProjDataInMemory *a_pdm = dynamic_cast<const ProjDataInMemory*>(&a);
+    const ProjDataInMemory *b_pdm = dynamic_cast<const ProjDataInMemory*>(&b);
+
+
+    // At least one is not ProjDataInMemory, fall back to default
+    if (is_null_ptr(x_pdm) || is_null_ptr(y_pdm) ||
+        is_null_ptr(a_pdm) || is_null_ptr(b_pdm)) {
+        ProjData::xapyb(x,a,y,b);
+        return;
+    }
+
+    // Else, all are ProjDataInMemory
+
+    // First check that info match
+    if (*get_proj_data_info_sptr() != *x.get_proj_data_info_sptr() ||
+        *get_proj_data_info_sptr() != *y.get_proj_data_info_sptr() ||
+        *get_proj_data_info_sptr() != *a.get_proj_data_info_sptr() ||
+        *get_proj_data_info_sptr() != *b.get_proj_data_info_sptr())
+        error("ProjDataInMemory::xapyb: ProjDataInfo don't match");
+
+#if 0
+    // Get number of elements
+    const std::size_t numel = size_all();
+
+    float *buffer = this->buffer.get();
+    const float *x_buffer = x_pdm->buffer.get();
+    const float *y_buffer = y_pdm->buffer.get();
+    const float *a_buffer = a_pdm->buffer.get();
+    const float *b_buffer = b_pdm->buffer.get();
+
+    for (unsigned i=0; i<numel; ++i)
+        buffer[i] = a_buffer[i]*x_buffer[i] + b_buffer[i]*y_buffer[i];
+#else
+    this->buffer.xapyb(x_pdm->buffer, a_pdm->buffer, y_pdm->buffer, b_pdm->buffer);
+#endif
+}
 
 END_NAMESPACE_STIR

--- a/src/buildblock/ProjDataInMemory.cxx
+++ b/src/buildblock/ProjDataInMemory.cxx
@@ -160,6 +160,14 @@ ProjDataInMemory::get_bin_value(Bin& bin)
 
 void
 ProjDataInMemory::
+axpby( const float a, const ProjData& x,
+       const float b, const ProjData& y)
+{
+  xapyb(x,a,y,b);
+}
+
+void
+ProjDataInMemory::
 xapyb(const ProjData& x, const float a,
       const ProjData& y, const float b)
 {

--- a/src/buildblock/ProjDataInMemory.cxx
+++ b/src/buildblock/ProjDataInMemory.cxx
@@ -249,4 +249,18 @@ xapyb(const ProjData& x, const ProjData& a,
 #endif
 }
 
+void
+ProjDataInMemory::
+sapyb(const float a, const ProjData& y, const float b)
+{
+  this->xapyb(*this,a,y,b);
+}
+
+void
+ProjDataInMemory::
+sapyb(const ProjData& a, const ProjData& y,const ProjData& b)
+{
+  this->xapyb(*this,a,y,b);
+}
+
 END_NAMESPACE_STIR

--- a/src/include/stir/Array.inl
+++ b/src/include/stir/Array.inl
@@ -387,7 +387,7 @@ void Array<num_dimensions, elemT>::
     sapyb(const T &a,
           const Array &y, const T &b)
 {
-  this->xapyb(((const Array)*this), a, y, b);
+  this->xapyb(*this, a, y, b);
 }
 
 /**********************************************

--- a/src/include/stir/NumericVectorWithOffset.inl
+++ b/src/include/stir/NumericVectorWithOffset.inl
@@ -345,7 +345,7 @@ NumericVectorWithOffset<T, NUMBER>::
 sapyb(const T2& a,
       const NumericVectorWithOffset& y, const T2& b)
 {  
-  this->xapyb(((const NumericVectorWithOffset)*this),a,y,b);
+  this->xapyb(*this,a,y,b);
 }
 
 END_NAMESPACE_STIR

--- a/src/include/stir/ProjData.h
+++ b/src/include/stir/ProjData.h
@@ -323,6 +323,9 @@ public:
   virtual void xapyb(const ProjData& x, const float a,
                      const ProjData& y, const float b);
 
+  //! set values of the array to x*a+y*b, where a, b, x and y are ProjData
+  virtual void xapyb(const ProjData& x, const ProjData& a,
+                     const ProjData& y, const ProjData& b);
 
 protected:
 

--- a/src/include/stir/ProjData.h
+++ b/src/include/stir/ProjData.h
@@ -315,9 +315,14 @@ public:
   //! writes data to a file in Interfile format
   Succeeded write_to_file(const std::string& filename) const;
 
+  //! \deprecated a*x+b*y (\see xapyb)
+  STIR_DEPRECATED virtual void axpby(const float a, const ProjData& x,
+                                     const float b, const ProjData& y);
+
   //! set values of the array to x*a+y*b, where a and b are scalar, and x and y are ProjData
   virtual void xapyb(const ProjData& x, const float a,
                      const ProjData& y, const float b);
+
 
 protected:
 

--- a/src/include/stir/ProjData.h
+++ b/src/include/stir/ProjData.h
@@ -327,6 +327,12 @@ public:
   virtual void xapyb(const ProjData& x, const ProjData& a,
                      const ProjData& y, const ProjData& b);
 
+  //! set values of the array to self*a+y*b where a and b are scalar, y is ProjData
+  virtual void sapyb(const float a, const ProjData& y, const float b);
+
+  //! set values of the array to self*a+y*b where a, b and y are ProjData
+  virtual void sapyb(const ProjData& a, const ProjData& y, const ProjData& b);
+
 protected:
 
    shared_ptr<ProjDataInfo> proj_data_info_ptr; // TODO fix name to _sptr

--- a/src/include/stir/ProjDataInMemory.h
+++ b/src/include/stir/ProjDataInMemory.h
@@ -96,6 +96,12 @@ public:
   virtual void xapyb(const ProjData& x, const float a,
                      const ProjData& y, const float b);
 
+  //! set values of the array to x*a+y*b, where a, b, x and y are ProjData.
+  /// This implementation requires that a, b, x and y are ProjDataInMemory
+  /// (else falls back on general method)
+  virtual void xapyb(const ProjData& x, const ProjData& a,
+                     const ProjData& y, const ProjData& b);
+
   /** @name iterator typedefs
    *  iterator typedefs
    */

--- a/src/include/stir/ProjDataInMemory.h
+++ b/src/include/stir/ProjDataInMemory.h
@@ -102,6 +102,16 @@ public:
   virtual void xapyb(const ProjData& x, const ProjData& a,
                      const ProjData& y, const ProjData& b);
 
+  //! set values of the array to self*a+y*b where a and b are scalar, y is ProjData
+  /// This implementation requires that a, b and y are ProjDataInMemory
+  /// (else falls back on general method)  
+  virtual void sapyb(const float a, const ProjData& y, const float b);
+
+  //! set values of the array to self*a+y*b where a, b and y are ProjData
+   /// This implementation requires that a, b and y are ProjDataInMemory
+  /// (else falls back on general method)   
+  virtual void sapyb(const ProjData& a, const ProjData& y, const ProjData& b);
+
   /** @name iterator typedefs
    *  iterator typedefs
    */

--- a/src/include/stir/ProjDataInMemory.h
+++ b/src/include/stir/ProjDataInMemory.h
@@ -86,6 +86,10 @@ public:
   //! Returns a  value of a bin
   float get_bin_value(Bin& bin);
     
+  //! \deprecated a*x+b*y (\see xapyb)
+  STIR_DEPRECATED virtual void axpby(const float a, const ProjData& x,
+                                     const float b, const ProjData& y);
+
   //! set values of the array to x*a+y*b, where a and b are scalar, and x and y are ProjData.
   /// This implementation requires that x and y are ProjDataInMemory
   /// (else falls back on general method)

--- a/src/test/test_proj_data_maths.cxx
+++ b/src/test/test_proj_data_maths.cxx
@@ -117,14 +117,23 @@ run_tests()
     ProjDataInMemory y1(pd1);
     fill(y1,1000.f);
     ProjDataInMemory y2(y1);
+  
 
     // Check xapby with general and ProjDataInMemory methods
     const float a = 2.f;
     const float b = 3.f;
     pd1.xapyb(x1,a,y1,b);
     pd2.ProjData::xapyb(x2,a,y2,b);
-
     check_proj_data_are_equal_and_non_zero(pd1,pd2);
+
+    // Check sapby with general and ProjDataInMemory methods
+    ProjDataInMemory out1(x1);
+    out1.sapyb(a, y1, b);
+    check_proj_data_are_equal_and_non_zero(pd1,out1);
+    
+    ProjDataInMemory out2(x1);
+    out2.ProjData::sapyb(a, y1, b);
+    check_proj_data_are_equal_and_non_zero(pd1,out2);
 
     // Check using iterators
     ProjDataInMemory pd3(pd1);


### PR DESCRIPTION
 - Added `axpby` back in to `ProjData` and `ProjDataInMemory` and marked as deprecated
 - Added array method `xapyb(const ProjData& x, const ProjData& a,
                     const ProjData& y, const ProjData& b)` in to `ProjData` and `ProjDataInMemory`
 - Added `sapby` scalar and vector methods in to `ProjData` and `ProjDataInMemory`