### PR TITLE
Logcosh function and approximation when value >30

### DIFF
--- a/src/include/stir/recon_buildblock/LogcoshPrior.h
+++ b/src/include/stir/recon_buildblock/LogcoshPrior.h
@@ -204,16 +204,16 @@ private:
     static inline float logcosh(const float d)
     {
       const float x = fabs(d);
-      if ( x < 30 ){
+      if ( x < 30.f ){
         return log(cosh(x));
       } else {
-        return x + log(0.5);
+        return x + log(0.5f);
       }
     }
 
     //! The surrogate of the logcosh function is tanh(x)/x
     /*!
-     * @param d is should be the difference between the ith and jth voxel.
+     * @param d should be the difference between the ith and jth voxel.
      However, it will use the taylor expansion if the x is too small (to prevent division by 0).
      * @param scalar is the logcosh scalar value controlling the priors transition between the quadratic and linear behaviour
      * @return the surrogate of the log-cosh function

--- a/src/include/stir/recon_buildblock/LogcoshPrior.h
+++ b/src/include/stir/recon_buildblock/LogcoshPrior.h
@@ -196,9 +196,24 @@ private:
     //! Spatially variant penalty penalty image ptr
     shared_ptr<DiscretisedDensity<3,elemT> > kappa_ptr;
 
+    //! The Log(cosh()) function and its approximation
+    /*!
+     Cosh(x) = 0.5(e^x + e^-x) is an exponential function.
+     Makes the approximation that when |x| > 30, e^-|x| << e^|x| and therefore log(cosh(x)) ~= |x| + log(0.5)
+    */
+    static inline float logcosh(const float d)
+    {
+      const float x = fabs(d);
+      if ( x < 30 ){
+        return log(cosh(x));
+      } else {
+        return x + log(0.5);
+      }
+    }
+
     //! The surrogate of the logcosh function is tanh(x)/x
     /*!
-     * @param d is should be the difference between the ith and jth voxel. The scalar factor may be included.
+     * @param d is should be the difference between the ith and jth voxel.
      However, it will use the taylor expansion if the x is too small (to prevent division by 0).
      * @param scalar is the logcosh scalar value controlling the priors transition between the quadratic and linear behaviour
      * @return the surrogate of the log-cosh function

--- a/src/include/stir/recon_buildblock/LogcoshPrior.h
+++ b/src/include/stir/recon_buildblock/LogcoshPrior.h
@@ -198,8 +198,9 @@ private:
 
     //! The Log(cosh()) function and its approximation
     /*!
-     Cosh(x) = 0.5(e^x + e^-x) is an exponential function.
-     Makes the approximation that when |x| > 30, e^-|x| << e^|x| and therefore log(cosh(x)) ~= |x| + log(0.5)
+     Cosh(x) = 0.5(e^x + e^-x) is an exponential function and hence cannot be evaluated for large x.
+     Make the approximation:
+     log(Cosh(x)) = log(0.5) + |x| + log(1 + e^(-2|x|)) = log(0.5) + |x| + O(10^(-27)), for |x|>30
     */
     static inline float logcosh(const float d)
     {

--- a/src/recon_buildblock/LogcoshPrior.cxx
+++ b/src/recon_buildblock/LogcoshPrior.cxx
@@ -291,9 +291,7 @@ compute_value(const DiscretisedDensity<3,elemT> &current_image_estimate)
             {
               // 1/scalar^2 * log(cosh(x * scalar))
               elemT voxel_diff= current_image_estimate[z][y][x] - current_image_estimate[z+dz][y+dy][x+dx];
-              elemT current = weights[dz][dy][dx] *
-                      (1/(this->scalar*this->scalar))*log(cosh(this->scalar*voxel_diff));
-
+              elemT current = weights[dz][dy][dx] * 1/(this->scalar*this->scalar) * logcosh(this->scalar*voxel_diff);
               if (do_kappa)
                 current *= (*kappa_ptr)[z][y][x] * (*kappa_ptr)[z+dz][y+dy][x+dx];
               result += static_cast<double>(current);


### PR DESCRIPTION
Fixes #768

At the threshold of 30 the `log(cosh(x)) = x - log(2)` within numerical precision.