### PR TITLE
BinNormSPECT actually apply calibration factor from interfile

### DIFF
--- a/src/include/stir/recon_buildblock/BinNormalisation.h
+++ b/src/include/stir/recon_buildblock/BinNormalisation.h
@@ -133,6 +133,7 @@ public:
             shared_ptr<DataSymmetriesForViewSegmentNumbers> = shared_ptr<DataSymmetriesForViewSegmentNumbers>()) const; 
   
   void set_exam_info_sptr(const shared_ptr<const ExamInfo> _exam_info_sptr);
+  shared_ptr<const ExamInfo> get_exam_info_sptr() const ;
 
  protected:
   //! check if the argument is the same as what was used for set_up()

--- a/src/recon_buildblock/BinNormalisation.cxx
+++ b/src/recon_buildblock/BinNormalisation.cxx
@@ -56,6 +56,11 @@ set_exam_info_sptr(const shared_ptr<const ExamInfo> _exam_info_sptr)
     this->exam_info_sptr=_exam_info_sptr;
 }
 
+shared_ptr<const ExamInfo> BinNormalisation::
+get_exam_info_sptr() const 
+{
+    return this->exam_info_sptr;
+}
 
 Succeeded
 BinNormalisation::

--- a/src/recon_buildblock/BinNormalisationSPECT.cxx
+++ b/src/recon_buildblock/BinNormalisationSPECT.cxx
@@ -109,6 +109,8 @@ post_processing()
 //  allow to set your own calibration factor
   if(measured_calibration_factor>0) 
       set_calibration_factor(measured_calibration_factor);
+  else 
+      set_calibration_factor(get_exam_info_sptr()->get_calibration_factor());
   
 //  read_norm_data(normalisation_spect_filename);
   return false;


### PR DESCRIPTION
It seems I had forgot to actually set calibration factor when using normalisation