### PR TITLE
fix GEHDF5Wrapper for Visual Studio

### DIFF
--- a/src/include/stir/IO/GEHDF5Wrapper.h
+++ b/src/include/stir/IO/GEHDF5Wrapper.h
@@ -214,7 +214,7 @@ private:
     hsize_t m_NY_SUB = 0;
     hsize_t m_NZ_SUB = 0;
 
-    const int m_max_dataset_dims =5;
+    static const int m_max_dataset_dims =5;
 #if 0
     // AB: todo these are never used. 
     hsize_t m_NX = 0;        // output buffer dimensions


### PR DESCRIPTION
need to make a `const int` member also `static` to be able to use it in array declaration