### PR TITLE
Speed up ROOT file OI by turning off all unneeded branches

### DIFF
--- a/src/IO/InputStreamFromROOTFile.cxx
+++ b/src/IO/InputStreamFromROOTFile.cxx
@@ -125,6 +125,9 @@ InputStreamFromROOTFile::set_up(const std::string & header_path)
 
     stream_ptr = new TChain(this->chain_name.c_str());
     stream_ptr->Add(fullfilename.c_str());
+    // Turn off all branches
+    stream_ptr->SetBranchStatus("*",0);
+    // Branches are turned back on by SetBranchAddress()
     stream_ptr->SetBranchAddress("time1", &time1);
     stream_ptr->SetBranchAddress("time2", &time2);
     stream_ptr->SetBranchAddress("eventID1",&eventID1);


### PR DESCRIPTION
A 1 line addition that turns off all branches for reading. When calling `stream_ptr->SetBranchAddress("time1", &time1);` etc., this turns the specific branch back on.

To test this, I unlisted a root file containing True 10.53M coincidence events (I have an SSD). There are no differences between the output sinograms.

 - STIR master: CPU time = 49.4s
 - FasterRootIO: CPU time = 21.7s

@NikEfth Do you have any comment on this? I don't probably dont understand ROOT to the same degree.