### PR TITLE
Faster root IO

### DIFF
--- a/documentation/release_5.0.htm
+++ b/documentation/release_5.0.htm
@@ -120,6 +120,8 @@ improvements to the documentation.
   In some cases, there could only be a single time frame (start to end of the study).
   </li>
 <li><tt>apply_patlak_to_images</tt> no longer uses an existing file as a template for the dynamic image but will overwrite it.</li>
+    <li><tt>root file I/O improvements</tt> no longer gets entire entry's tree and instead loads individual branches as needed.
+    Root file reading is now up to 4x faster.</li>
 </ul>
 
 

--- a/documentation/release_5.0.htm
+++ b/documentation/release_5.0.htm
@@ -120,8 +120,8 @@ improvements to the documentation.
   In some cases, there could only be a single time frame (start to end of the study).
   </li>
 <li><tt>apply_patlak_to_images</tt> no longer uses an existing file as a template for the dynamic image but will overwrite it.</li>
-    <li><tt>root file I/O improvements</tt> no longer gets entire entry's tree and instead loads individual branches as needed.
-    Root file reading is now up to 4x faster.</li>
+	<li><tt>ROOT</tt> file I/O improvements no longer gets entire entry's tree and instead loads individual branches as needed.
+    ROOT file reading is now up to 4x faster. In addition, there is now an option <tt>check energy window information</tt> (defaulting to on).</li>
 </ul>
 
 

--- a/examples/samples/root_header.hroot
+++ b/examples/samples/root_header.hroot
@@ -38,7 +38,8 @@ number of crystals_Z := 4
 
 Singles readout depth := 1
 exclude scattered events := 0
-exclude random events := 0 
+exclude random events := 0
+check energy window information := 1
 offset (num of detectors) := 0 
 
 low energy window (keV) := 0  		; Default 0

--- a/examples/samples/root_headerECAT.hroot
+++ b/examples/samples/root_headerECAT.hroot
@@ -45,13 +45,14 @@ number of crystals Z := 8
 ; per singles unit. 
 Singles readout depth := 1
 
-;
-; If set the scattered events will be skipped
+; If set the scattered events will be skipped (Default := 0)
 exclude scattered events := 0
 
-;
-; If set the random events will be skipped
+; If set the random events will be skipped (Default := 0)
 exclude random events := 0 
+
+; If check events are within the specified energy window (Default := 1)
+check energy window information := 1
 
 ; 
 ; STIR will try to align the data. 

--- a/recon_test_pack/root_header.hroot
+++ b/recon_test_pack/root_header.hroot
@@ -35,6 +35,7 @@ number of crystals_Z := 4
 Singles readout depth := 1
 exclude scattered events := ${EXCLUDE_SCATTERED}
 exclude random events := ${EXCLUDE_RANDOM}
+check energy window information := 1  ; Default 1
 offset (num of detectors) := 0 
 
 low energy window (keV) := 0  		; Default 0

--- a/src/IO/InputStreamFromROOTFile.cxx
+++ b/src/IO/InputStreamFromROOTFile.cxx
@@ -127,15 +127,16 @@ InputStreamFromROOTFile::set_up(const std::string & header_path)
     stream_ptr->Add(fullfilename.c_str());
     // Turn off all branches
     stream_ptr->SetBranchStatus("*",0);
+
     // Branches are turned back on by SetBranchAddress()
-    stream_ptr->SetBranchAddress("time1", &time1);
-    stream_ptr->SetBranchAddress("time2", &time2);
-    stream_ptr->SetBranchAddress("eventID1",&eventID1);
-    stream_ptr->SetBranchAddress("eventID2",&eventID2);
-    stream_ptr->SetBranchAddress("energy1", &energy1);
-    stream_ptr->SetBranchAddress("energy2", &energy2);
-    stream_ptr->SetBranchAddress("comptonPhantom1", &comptonphantom1);
-    stream_ptr->SetBranchAddress("comptonPhantom2", &comptonphantom2);
+    stream_ptr->SetBranchAddress("time1", &time1, &br_time1);
+    stream_ptr->SetBranchAddress("time2", &time2, &br_time2);
+    stream_ptr->SetBranchAddress("eventID1",&eventID1, &br_eventID1);
+    stream_ptr->SetBranchAddress("eventID2",&eventID2, &br_eventID2);
+    stream_ptr->SetBranchAddress("energy1", &energy1, &br_energy1);
+    stream_ptr->SetBranchAddress("energy2", &energy2, &br_energy2);
+    stream_ptr->SetBranchAddress("comptonPhantom1", &comptonphantom1, &br_comptonPhantom1);
+    stream_ptr->SetBranchAddress("comptonPhantom2", &comptonphantom2, &br_comptonPhantom2);
 
     if (read_optional_root_fields)
     {

--- a/src/IO/InputStreamFromROOTFile.cxx
+++ b/src/IO/InputStreamFromROOTFile.cxx
@@ -69,6 +69,7 @@ InputStreamFromROOTFile::set_defaults()
     singles_readout_depth = -1;
     exclude_scattered = false;
     exclude_randoms = false;
+    check_energy_window_information = true;
     low_energy_window = 0.f;
     up_energy_window = 1000.f;
     read_optional_root_fields=false;
@@ -87,6 +88,7 @@ InputStreamFromROOTFile::initialise_keymap()
     this->parser.add_key("name of input TChain", &this->chain_name);
     this->parser.add_key("exclude scattered events", &this->exclude_scattered);
     this->parser.add_key("exclude random events", &this->exclude_randoms);
+    this->parser.add_key("check energy window information", &this->check_energy_window_information);
     this->parser.add_key("offset (num of detectors)", &this->offset_dets);
     this->parser.add_key("low energy window (keV)", &this->low_energy_window);
     this->parser.add_key("upper energy window (keV)", &this->up_energy_window);
@@ -194,17 +196,19 @@ InputStreamFromROOTFile::check_brentry_randoms_scatter_energy_conditions(Long64_
   }
 
   // Energy condition.
-  if (br_energy1->GetEntry(brentry) == 0)
-    return false;
-  if (br_energy2->GetEntry(brentry) == 0)
-    return false;
-  // Check both energy values are within window
-  if (this->get_energy1_in_keV() < this->low_energy_window ||
-      this->get_energy1_in_keV() > this->up_energy_window ||
-      this->get_energy2_in_keV() < this->low_energy_window ||
-      this->get_energy2_in_keV() > this->up_energy_window)
-  {
-    return false;
+  if (this->check_energy_window_information){
+    if (br_energy1->GetEntry(brentry) == 0)
+      return false;
+    if (br_energy2->GetEntry(brentry) == 0)
+      return false;
+    // Check both energy values are within window
+    if (this->get_energy1_in_keV() < this->low_energy_window ||
+        this->get_energy1_in_keV() > this->up_energy_window ||
+        this->get_energy2_in_keV() < this->low_energy_window ||
+        this->get_energy2_in_keV() > this->up_energy_window)
+    {
+      return false;
+    }
   }
   return true;
 }

--- a/src/IO/InputStreamFromROOTFile.cxx
+++ b/src/IO/InputStreamFromROOTFile.cxx
@@ -175,10 +175,9 @@ InputStreamFromROOTFile::check_brentry_randoms_scatter_energy_conditions(Long64_
 
   // Scatter event condition.
   if (this->exclude_scattered) {
-    if (br_comptonPhantom1->GetEntry(brentry) == 0)
-      return false;
-    if (br_comptonPhantom2->GetEntry(brentry) == 0)
-      return false;
+    GetEntryCheck(br_comptonPhantom1->GetEntry(brentry));
+    GetEntryCheck(br_comptonPhantom2->GetEntry(brentry));
+
     // Check if either event has been Compton scattered
     if (this->comptonphantom1 > 0 || this->comptonphantom2 > 0)
       return false;
@@ -186,10 +185,9 @@ InputStreamFromROOTFile::check_brentry_randoms_scatter_energy_conditions(Long64_
 
   // Random event condition.
   if (this->exclude_randoms) {
-    if (br_eventID1->GetEntry(brentry) == 0)
-      return false;
-    if (br_eventID2->GetEntry(brentry) == 0)
-      return false;
+    GetEntryCheck(br_eventID1->GetEntry(brentry));
+    GetEntryCheck(br_eventID2->GetEntry(brentry));
+
     // Check for the same event
     if ((this->eventID1 != this->eventID2))
       return false;
@@ -197,10 +195,9 @@ InputStreamFromROOTFile::check_brentry_randoms_scatter_energy_conditions(Long64_
 
   // Energy condition.
   if (this->check_energy_window_information){
-    if (br_energy1->GetEntry(brentry) == 0)
-      return false;
-    if (br_energy2->GetEntry(brentry) == 0)
-      return false;
+    GetEntryCheck(br_energy1->GetEntry(brentry));
+    GetEntryCheck(br_energy2->GetEntry(brentry));
+
     // Check both energy values are within window
     if (this->get_energy1_in_keV() < this->low_energy_window ||
         this->get_energy1_in_keV() > this->up_energy_window ||

--- a/src/IO/InputStreamFromROOTFile.cxx
+++ b/src/IO/InputStreamFromROOTFile.cxx
@@ -164,6 +164,51 @@ InputStreamFromROOTFile::set_up(const std::string & header_path)
     return Succeeded::yes;
 }
 
+bool
+InputStreamFromROOTFile::check_brentry_randoms_scatter_energy_conditions(Long64_t brentry)
+{
+  if (brentry < 0)
+    return false;
+
+  // Scatter event condition.
+  if (this->exclude_scattered) {
+    if (br_comptonPhantom1->GetEntry(brentry) == 0)
+      return false;
+    if (br_comptonPhantom2->GetEntry(brentry) == 0)
+      return false;
+    // Check if either event has been Compton scattered
+    if (this->comptonphantom1 > 0 || this->comptonphantom2 > 0)
+      return false;
+  }
+
+  // Random event condition.
+  if (this->exclude_randoms) {
+    if (br_eventID1->GetEntry(brentry) == 0)
+      return false;
+    if (br_eventID2->GetEntry(brentry) == 0)
+      return false;
+    // Check for the same event
+    if ((this->eventID1 != this->eventID2))
+      return false;
+  }
+
+  // Energy condition.
+  if (br_energy1->GetEntry(brentry) == 0)
+    return false;
+  if (br_energy2->GetEntry(brentry) == 0)
+    return false;
+  // Check both energy values are within window
+  if (this->get_energy1_in_keV() < this->low_energy_window ||
+      this->get_energy1_in_keV() > this->up_energy_window ||
+      this->get_energy2_in_keV() < this->low_energy_window ||
+      this->get_energy2_in_keV() > this->up_energy_window)
+  {
+    return false;
+  }
+  return true;
+}
+
+
 void
 InputStreamFromROOTFile::set_crystal_repeater_x(int val)
 {

--- a/src/IO/InputStreamFromROOTFile.cxx
+++ b/src/IO/InputStreamFromROOTFile.cxx
@@ -5,10 +5,11 @@
 
   \author Nikos Efthimiou
   \author Kris Thielemans
+  \author Robert Twyman
 */
 /*
  *  Copyright (C) 2015, 2016 University of Leeds
-    Copyright (C) 2016, 2020 UCL
+    Copyright (C) 2016, 2020, 2021 UCL
     Copyright (C) 2018 University of Hull
     This file is part of STIR.
 

--- a/src/IO/InputStreamFromROOTFile.cxx
+++ b/src/IO/InputStreamFromROOTFile.cxx
@@ -140,25 +140,25 @@ InputStreamFromROOTFile::set_up(const std::string & header_path)
 
     if (read_optional_root_fields)
     {
-        stream_ptr->SetBranchAddress("axialPos",&axialPos);
-        stream_ptr->SetBranchAddress("globalPosX1",&globalPosX1);
-        stream_ptr->SetBranchAddress("globalPosX2",&globalPosX2);
-        stream_ptr->SetBranchAddress("globalPosY1",&globalPosY1);
-        stream_ptr->SetBranchAddress("globalPosY2",&globalPosY2);
-        stream_ptr->SetBranchAddress("globalPosZ1",&globalPosZ1);
-        stream_ptr->SetBranchAddress("globalPosZ2",&globalPosZ2);
-        stream_ptr->SetBranchAddress("rotationAngle",&rotation_angle);
-        stream_ptr->SetBranchAddress("runID",&runID);
-        stream_ptr->SetBranchAddress("sinogramS",&sinogramS);
-        stream_ptr->SetBranchAddress("sinogramTheta",&sinogramTheta);
-        stream_ptr->SetBranchAddress("sourceID1",&sourceID1);
-        stream_ptr->SetBranchAddress("sourceID2",&sourceID2);
-        stream_ptr->SetBranchAddress("sourcePosX1",&sourcePosX1);
-        stream_ptr->SetBranchAddress("sourcePosX2",&sourcePosX2);
-        stream_ptr->SetBranchAddress("sourcePosY1",&sourcePosY1);
-        stream_ptr->SetBranchAddress("sourcePosY2",&sourcePosY2);
-        stream_ptr->SetBranchAddress("sourcePosZ1",&sourcePosZ1);
-        stream_ptr->SetBranchAddress("sourcePosZ2",&sourcePosZ2);
+        stream_ptr->SetBranchAddress("axialPos",&axialPos, &br_axialPos);
+        stream_ptr->SetBranchAddress("globalPosX1",&globalPosX1, &br_globalPosX1);
+        stream_ptr->SetBranchAddress("globalPosX2",&globalPosX2, &br_globalPosX2);
+        stream_ptr->SetBranchAddress("globalPosY1",&globalPosY1, &br_globalPosY1);
+        stream_ptr->SetBranchAddress("globalPosY2",&globalPosY2, &br_globalPosY2);
+        stream_ptr->SetBranchAddress("globalPosZ1",&globalPosZ1, &br_globalPosZ1);
+        stream_ptr->SetBranchAddress("globalPosZ2",&globalPosZ2, &br_globalPosZ2);
+        stream_ptr->SetBranchAddress("rotationAngle",&rotation_angle, &br_rotation_angle);
+        stream_ptr->SetBranchAddress("runID",&runID, &br_runID);
+        stream_ptr->SetBranchAddress("sinogramS",&sinogramS, &br_sinogramS);
+        stream_ptr->SetBranchAddress("sinogramTheta",&sinogramTheta, &br_sinogramTheta);
+        stream_ptr->SetBranchAddress("sourceID1",&sourceID1, &br_sourceID1);
+        stream_ptr->SetBranchAddress("sourceID2",&sourceID2, &br_sourceID2);
+        stream_ptr->SetBranchAddress("sourcePosX1",&sourcePosX1, &br_sourcePosX1);
+        stream_ptr->SetBranchAddress("sourcePosX2",&sourcePosX2, &br_sourcePosX2);
+        stream_ptr->SetBranchAddress("sourcePosY1",&sourcePosY1, &br_sourcePosY1);
+        stream_ptr->SetBranchAddress("sourcePosY2",&sourcePosY2, &br_sourcePosY2);
+        stream_ptr->SetBranchAddress("sourcePosZ1",&sourcePosZ1, &br_sourcePosZ1);
+        stream_ptr->SetBranchAddress("sourcePosZ2",&sourcePosZ2, &br_sourcePosZ2);
     }
 
     return Succeeded::yes;

--- a/src/IO/InputStreamFromROOTFileForCylindricalPET.cxx
+++ b/src/IO/InputStreamFromROOTFileForCylindricalPET.cxx
@@ -73,42 +73,11 @@ get_next_record(CListRecordROOT& record)
       if (current_position == nentries)
           return Succeeded::no;
 
-      auto brentry = stream_ptr->LoadTree(static_cast<Long64_t>(current_position));
+      Long64_t brentry = stream_ptr->LoadTree(static_cast<Long64_t>(current_position));
       current_position ++ ;
 
-      if (brentry < 0)
-        return Succeeded::no;
-
-      if (this->exclude_scattered) {
-        // Ensure events are no scattered
-        if (br_comptonPhantom1->GetEntry(brentry) == 0)
-          return Succeeded::no;
-        if (br_comptonPhantom2->GetEntry(brentry) == 0)
-          return Succeeded::no;
-        if (this->comptonphantom1 > 0 || this->comptonphantom2 > 0)
-          continue;
-      }
-
-      if (this->exclude_randoms) {
-        // Ensure events are from same eventID
-        if (br_eventID1->GetEntry(brentry) == 0)
-          return Succeeded::no;
-        if (br_eventID2->GetEntry(brentry) == 0)
-          return Succeeded::no;
-        if ((this->eventID1 != this->eventID2))
-          continue;
-      }
-
-      // Check energy information
-      if (br_energy1->GetEntry(brentry) == 0)
-        return Succeeded::no;
-      if (br_energy2->GetEntry(brentry) == 0)
-        return Succeeded::no;
-      if (this->get_energy1_in_keV() < this->low_energy_window ||
-              this->get_energy1_in_keV() > this->up_energy_window ||
-              this->get_energy2_in_keV() < this->low_energy_window ||
-              this->get_energy2_in_keV() > this->up_energy_window)
-          continue;
+      if (!this->check_brentry_randoms_scatter_energy_conditions(brentry))
+        continue;
 
       if (br_time1->GetEntry(brentry) == 0)
         return Succeeded::no;

--- a/src/IO/InputStreamFromROOTFileForCylindricalPET.cxx
+++ b/src/IO/InputStreamFromROOTFileForCylindricalPET.cxx
@@ -111,6 +111,11 @@ get_next_record(CListRecordROOT& record)
               this->get_energy2_in_keV() > this->up_energy_window)
           continue;
 
+      if (br_time1->GetEntry(brentry) == 0)
+        return Succeeded::no;
+      if (br_time2->GetEntry(brentry) == 0)
+        return Succeeded::no;
+
       // Get positional ID information
       if (br_crystalID1->GetEntry(brentry) == 0)
         return Succeeded::no;
@@ -161,11 +166,6 @@ get_next_record(CListRecordROOT& record)
     // Add offset
     crystal1 += offset_dets;
     crystal2 += offset_dets;
-
-    if (br_time1->GetEntry(brentry) == 0)
-      return Succeeded::no;
-    if (br_time2->GetEntry(brentry) == 0)
-      return Succeeded::no;
 
     return
             record.init_from_data(ring1, ring2,

--- a/src/IO/InputStreamFromROOTFileForCylindricalPET.cxx
+++ b/src/IO/InputStreamFromROOTFileForCylindricalPET.cxx
@@ -74,9 +74,55 @@ get_next_record(CListRecordROOT& record)
         if (current_position == nentries)
             return Succeeded::no;
 
+      auto brentry = stream_ptr->LoadTree(static_cast<Long64_t>(current_position));
+      if (brentry < 0)
+        return Succeeded::no;
 
-        if (stream_ptr->GetEntry(static_cast<Long64_t>(current_position)) == 0 )
-            return Succeeded::no;
+      // InputStreamFromROOTFile
+      if (br_time1->GetEntry(brentry) == 0)
+        return Succeeded::no;
+      if (br_time2->GetEntry(brentry) == 0)
+        return Succeeded::no;
+
+      if (br_eventID1->GetEntry(brentry) == 0)
+        return Succeeded::no;
+      if (br_eventID2->GetEntry(brentry) == 0)
+        return Succeeded::no;
+
+      if (br_energy1->GetEntry(brentry) == 0)
+        return Succeeded::no;
+      if (br_energy2->GetEntry(brentry) == 0)
+        return Succeeded::no;
+
+      if (br_comptonPhantom1->GetEntry(brentry) == 0)
+        return Succeeded::no;
+      if (br_comptonPhantom2->GetEntry(brentry) == 0)
+        return Succeeded::no;
+
+      // Cylindrical PET
+      if (br_crystalID1->GetEntry(brentry) == 0)
+        return Succeeded::no;
+      if (br_crystalID2->GetEntry(brentry) == 0)
+        return Succeeded::no;
+
+      if (br_submoduleID1->GetEntry(brentry) == 0)
+        return Succeeded::no;
+      if (br_submoduleID2->GetEntry(brentry) == 0)
+        return Succeeded::no;
+
+      if (br_moduleID1->GetEntry(brentry) == 0)
+        return Succeeded::no;
+      if (br_moduleID2->GetEntry(brentry) == 0)
+        return Succeeded::no;
+
+      if (br_rsectorID1->GetEntry(brentry) == 0)
+        return Succeeded::no;
+      if (br_rsectorID2->GetEntry(brentry) == 0)
+        return Succeeded::no;
+
+
+//        if (stream_ptr->GetEntry(static_cast<Long64_t>(current_position)) == 0 )
+//            return Succeeded::no;
 
         current_position ++ ;
 
@@ -188,14 +234,14 @@ set_up(const std::string & header_path)
         return Succeeded::no;
     }
 
-    stream_ptr->SetBranchAddress("crystalID1",&crystalID1);
-    stream_ptr->SetBranchAddress("crystalID2",&crystalID2);
-    stream_ptr->SetBranchAddress("submoduleID1",&submoduleID1);
-    stream_ptr->SetBranchAddress("submoduleID2",&submoduleID2);
-    stream_ptr->SetBranchAddress("moduleID1",&moduleID1);
-    stream_ptr->SetBranchAddress("moduleID2",&moduleID2);
-    stream_ptr->SetBranchAddress("rsectorID1",&rsectorID1);
-    stream_ptr->SetBranchAddress("rsectorID2",&rsectorID2);
+    stream_ptr->SetBranchAddress("crystalID1",&crystalID1, &br_crystalID1);
+    stream_ptr->SetBranchAddress("crystalID2",&crystalID2, &br_crystalID2);
+    stream_ptr->SetBranchAddress("submoduleID1",&submoduleID1, &br_submoduleID1);
+    stream_ptr->SetBranchAddress("submoduleID2",&submoduleID2, &br_submoduleID2);
+    stream_ptr->SetBranchAddress("moduleID1",&moduleID1, &br_moduleID1);
+    stream_ptr->SetBranchAddress("moduleID2",&moduleID2, &br_moduleID2);
+    stream_ptr->SetBranchAddress("rsectorID1",&rsectorID1, &br_rsectorID1);
+    stream_ptr->SetBranchAddress("rsectorID2",&rsectorID2, &br_rsectorID2);
 
     nentries = static_cast<unsigned long int>(stream_ptr->GetEntries());
     if (nentries == 0)

--- a/src/IO/InputStreamFromROOTFileForCylindricalPET.cxx
+++ b/src/IO/InputStreamFromROOTFileForCylindricalPET.cxx
@@ -68,13 +68,12 @@ Succeeded
 InputStreamFromROOTFileForCylindricalPET::
 get_next_record(CListRecordROOT& record)
 {
-    auto brentry = stream_ptr->LoadTree(static_cast<Long64_t>(current_position));
     while(true)
     {
       if (current_position == nentries)
           return Succeeded::no;
 
-      brentry = stream_ptr->LoadTree(static_cast<Long64_t>(current_position));
+      auto brentry = stream_ptr->LoadTree(static_cast<Long64_t>(current_position));
       current_position ++ ;
 
       if (brentry < 0)

--- a/src/IO/InputStreamFromROOTFileForCylindricalPET.cxx
+++ b/src/IO/InputStreamFromROOTFileForCylindricalPET.cxx
@@ -79,31 +79,23 @@ get_next_record(CListRecordROOT& record)
       if (!this->check_brentry_randoms_scatter_energy_conditions(brentry))
         continue;
 
-      if (br_time1->GetEntry(brentry) == 0)
-        return Succeeded::no;
-      if (br_time2->GetEntry(brentry) == 0)
-        return Succeeded::no;
+
+      // Get time information
+      GetEntryCheck(br_time1->GetEntry(brentry));
+      GetEntryCheck(br_time2->GetEntry(brentry));
 
       // Get positional ID information
-      if (br_crystalID1->GetEntry(brentry) == 0)
-        return Succeeded::no;
-      if (br_crystalID2->GetEntry(brentry) == 0)
-        return Succeeded::no;
+      GetEntryCheck(br_crystalID1->GetEntry(brentry));
+      GetEntryCheck(br_crystalID2->GetEntry(brentry));
 
-      if (br_submoduleID1->GetEntry(brentry) == 0)
-        return Succeeded::no;
-      if (br_submoduleID2->GetEntry(brentry) == 0)
-        return Succeeded::no;
+      GetEntryCheck(br_submoduleID1->GetEntry(brentry));
+      GetEntryCheck(br_submoduleID2->GetEntry(brentry));
 
-      if (br_moduleID1->GetEntry(brentry) == 0)
-        return Succeeded::no;
-      if (br_moduleID2->GetEntry(brentry) == 0)
-        return Succeeded::no;
+      GetEntryCheck(br_moduleID1->GetEntry(brentry));
+      GetEntryCheck(br_moduleID2->GetEntry(brentry));
 
-      if (br_rsectorID1->GetEntry(brentry) == 0)
-        return Succeeded::no;
-      if (br_rsectorID2->GetEntry(brentry) == 0)
-        return Succeeded::no;
+      GetEntryCheck(br_rsectorID1->GetEntry(brentry));
+      GetEntryCheck(br_rsectorID2->GetEntry(brentry));
 
       break;
     }

--- a/src/IO/InputStreamFromROOTFileForCylindricalPET.cxx
+++ b/src/IO/InputStreamFromROOTFileForCylindricalPET.cxx
@@ -68,38 +68,50 @@ Succeeded
 InputStreamFromROOTFileForCylindricalPET::
 get_next_record(CListRecordROOT& record)
 {
-
+    auto brentry = stream_ptr->LoadTree(static_cast<Long64_t>(current_position));
     while(true)
     {
-        if (current_position == nentries)
-            return Succeeded::no;
+      if (current_position == nentries)
+          return Succeeded::no;
 
-      auto brentry = stream_ptr->LoadTree(static_cast<Long64_t>(current_position));
+      brentry = stream_ptr->LoadTree(static_cast<Long64_t>(current_position));
+      current_position ++ ;
+
       if (brentry < 0)
         return Succeeded::no;
 
-      // InputStreamFromROOTFile
-      if (br_time1->GetEntry(brentry) == 0)
-        return Succeeded::no;
-      if (br_time2->GetEntry(brentry) == 0)
-        return Succeeded::no;
+      if (this->exclude_scattered) {
+        // Ensure events are no scattered
+        if (br_comptonPhantom1->GetEntry(brentry) == 0)
+          return Succeeded::no;
+        if (br_comptonPhantom2->GetEntry(brentry) == 0)
+          return Succeeded::no;
+        if (this->comptonphantom1 > 0 || this->comptonphantom2 > 0)
+          continue;
+      }
 
-      if (br_eventID1->GetEntry(brentry) == 0)
-        return Succeeded::no;
-      if (br_eventID2->GetEntry(brentry) == 0)
-        return Succeeded::no;
+      if (this->exclude_randoms) {
+        // Ensure events are from same eventID
+        if (br_eventID1->GetEntry(brentry) == 0)
+          return Succeeded::no;
+        if (br_eventID2->GetEntry(brentry) == 0)
+          return Succeeded::no;
+        if ((this->eventID1 != this->eventID2))
+          continue;
+      }
 
+      // Check energy information
       if (br_energy1->GetEntry(brentry) == 0)
         return Succeeded::no;
       if (br_energy2->GetEntry(brentry) == 0)
         return Succeeded::no;
+      if (this->get_energy1_in_keV() < this->low_energy_window ||
+              this->get_energy1_in_keV() > this->up_energy_window ||
+              this->get_energy2_in_keV() < this->low_energy_window ||
+              this->get_energy2_in_keV() > this->up_energy_window)
+          continue;
 
-      if (br_comptonPhantom1->GetEntry(brentry) == 0)
-        return Succeeded::no;
-      if (br_comptonPhantom2->GetEntry(brentry) == 0)
-        return Succeeded::no;
-
-      // Cylindrical PET
+      // Get positional ID information
       if (br_crystalID1->GetEntry(brentry) == 0)
         return Succeeded::no;
       if (br_crystalID2->GetEntry(brentry) == 0)
@@ -120,24 +132,7 @@ get_next_record(CListRecordROOT& record)
       if (br_rsectorID2->GetEntry(brentry) == 0)
         return Succeeded::no;
 
-
-//        if (stream_ptr->GetEntry(static_cast<Long64_t>(current_position)) == 0 )
-//            return Succeeded::no;
-
-        current_position ++ ;
-
-        if ( (this->comptonphantom1 > 0 || this->comptonphantom2 > 0) && this->exclude_scattered )
-            continue;
-        if ( (this->eventID1 != this->eventID2) && this->exclude_randoms)
-            continue;
-      //multiply here by 1000 to convert the list mode energy from MeV to keV
-        if (this->get_energy1_in_keV() < this->low_energy_window ||
-                this->get_energy1_in_keV() > this->up_energy_window ||
-                this->get_energy2_in_keV() < this->low_energy_window ||
-                this->get_energy2_in_keV() > this->up_energy_window)
-            continue;
-
-        break;
+      break;
     }
 
     int ring1 = static_cast<int>(crystalID1/crystal_repeater_y)
@@ -166,6 +161,11 @@ get_next_record(CListRecordROOT& record)
     // Add offset
     crystal1 += offset_dets;
     crystal2 += offset_dets;
+
+    if (br_time1->GetEntry(brentry) == 0)
+      return Succeeded::no;
+    if (br_time2->GetEntry(brentry) == 0)
+      return Succeeded::no;
 
     return
             record.init_from_data(ring1, ring2,

--- a/src/IO/InputStreamFromROOTFileForCylindricalPET.cxx
+++ b/src/IO/InputStreamFromROOTFileForCylindricalPET.cxx
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2016, UCL
+    Copyright (C) 2016, 2021 UCL
     Copyright (C) 2018, University of Hull
     This file is part of STIR.
 

--- a/src/IO/InputStreamFromROOTFileForECATPET.cxx
+++ b/src/IO/InputStreamFromROOTFileForECATPET.cxx
@@ -77,21 +77,15 @@ get_next_record(CListRecordROOT& record)
     if (!this->check_brentry_randoms_scatter_energy_conditions(brentry))
       continue;
 
-    if (br_time1->GetEntry(brentry) == 0)
-      return Succeeded::no;
-    if (br_time2->GetEntry(brentry) == 0)
-      return Succeeded::no;
+    GetEntryCheck(br_time1->GetEntry(brentry));
+    GetEntryCheck(br_time2->GetEntry(brentry));
 
     // Get positional ID information
-    if (br_crystalID1->GetEntry(brentry) == 0)
-      return Succeeded::no;
-    if (br_crystalID2->GetEntry(brentry) == 0)
-      return Succeeded::no;
+    GetEntryCheck(br_crystalID1->GetEntry(brentry));
+    GetEntryCheck(br_crystalID2->GetEntry(brentry));
 
-    if (br_blockID1->GetEntry(brentry) == 0)
-      return Succeeded::no;
-    if (br_blockID2->GetEntry(brentry) == 0)
-      return Succeeded::no;
+    GetEntryCheck(br_blockID1->GetEntry(brentry));
+    GetEntryCheck(br_blockID2->GetEntry(brentry));
 
     break;
   }

--- a/src/IO/InputStreamFromROOTFileForECATPET.cxx
+++ b/src/IO/InputStreamFromROOTFileForECATPET.cxx
@@ -71,41 +71,10 @@ get_next_record(CListRecordROOT& record)
     if (current_position == nentries)
       return Succeeded::no;
 
-    auto brentry = stream_ptr->LoadTree(static_cast<Long64_t>(current_position));
+    Long64_t brentry = stream_ptr->LoadTree(static_cast<Long64_t>(current_position));
     current_position ++ ;
 
-    if (brentry < 0)
-      return Succeeded::no;
-
-    if (this->exclude_scattered) {
-      // Ensure events are no scattered
-      if (br_comptonPhantom1->GetEntry(brentry) == 0)
-        return Succeeded::no;
-      if (br_comptonPhantom2->GetEntry(brentry) == 0)
-        return Succeeded::no;
-      if (this->comptonphantom1 > 0 || this->comptonphantom2 > 0)
-        continue;
-    }
-
-    if (this->exclude_randoms) {
-      // Ensure events are from same eventID
-      if (br_eventID1->GetEntry(brentry) == 0)
-        return Succeeded::no;
-      if (br_eventID2->GetEntry(brentry) == 0)
-        return Succeeded::no;
-      if ((this->eventID1 != this->eventID2))
-        continue;
-    }
-
-    // Check energy information
-    if (br_energy1->GetEntry(brentry) == 0)
-      return Succeeded::no;
-    if (br_energy2->GetEntry(brentry) == 0)
-      return Succeeded::no;
-    if (this->get_energy1_in_keV() < this->low_energy_window ||
-        this->get_energy1_in_keV() > this->up_energy_window ||
-        this->get_energy2_in_keV() < this->low_energy_window ||
-        this->get_energy2_in_keV() > this->up_energy_window)
+    if (!this->check_brentry_randoms_scatter_energy_conditions(brentry))
       continue;
 
     if (br_time1->GetEntry(brentry) == 0)

--- a/src/IO/InputStreamFromROOTFileForECATPET.cxx
+++ b/src/IO/InputStreamFromROOTFileForECATPET.cxx
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2016, UCL
+    Copyright (C) 2016, 2021, UCL
     Copyright (C) 2018, University of Hull
     This file is part of STIR.
 

--- a/src/IO/InputStreamFromROOTFileForECATPET.cxx
+++ b/src/IO/InputStreamFromROOTFileForECATPET.cxx
@@ -66,13 +66,12 @@ Succeeded
 InputStreamFromROOTFileForECATPET::
 get_next_record(CListRecordROOT& record)
 {
-  auto brentry = stream_ptr->LoadTree(static_cast<Long64_t>(current_position));
   while(true)
   {
     if (current_position == nentries)
       return Succeeded::no;
 
-    brentry = stream_ptr->LoadTree(static_cast<Long64_t>(current_position));
+    auto brentry = stream_ptr->LoadTree(static_cast<Long64_t>(current_position));
     current_position ++ ;
 
     if (brentry < 0)

--- a/src/include/stir/IO/InputStreamFromROOTFile.h
+++ b/src/include/stir/IO/InputStreamFromROOTFile.h
@@ -220,7 +220,7 @@ public:
     float sourcePosX1, sourcePosX2, sourcePosY1, sourcePosY2, sourcePosZ1, sourcePosZ2;
      //@}
 
-    //! ROOT Branch address variables.
+    //! \name ROOT Branch address variables.
     //@{
     TBranch *br_time1 = nullptr;
     TBranch *br_time2 = nullptr;
@@ -278,7 +278,7 @@ public:
     float get_energy2_in_keV() const
     { return energy2 * 1e3; };
 
-    //! Checks brentry information. True if all conditions are satisfied.
+    //! Checks brentry satisfies the randoms, scatter and energy conditions.
     bool check_brentry_randoms_scatter_energy_conditions(long long int brentry);
 };
 

--- a/src/include/stir/IO/InputStreamFromROOTFile.h
+++ b/src/include/stir/IO/InputStreamFromROOTFile.h
@@ -283,6 +283,10 @@ public:
 
     //! Checks brentry satisfies the randoms, scatter and energy conditions.
     bool check_brentry_randoms_scatter_energy_conditions(long long int brentry);
+
+    //! Checks the return of branch->GetEntry(brentry) and errors if return <= 0
+    void GetEntryCheck(const int ret)
+    { if (ret > 0) return; error(ret == 0 ? "Entry is null." : "ROOT I/O error."); };
 };
 
 END_NAMESPACE_STIR

--- a/src/include/stir/IO/InputStreamFromROOTFile.h
+++ b/src/include/stir/IO/InputStreamFromROOTFile.h
@@ -36,6 +36,7 @@
 
 // forward declaration of ROOT's TChain
 class TChain;
+class TBranch;
 
 START_NAMESPACE_STIR
 
@@ -218,6 +219,15 @@ public:
     float globalPosX1, globalPosX2, globalPosY1, globalPosY2, globalPosZ1, globalPosZ2;
     float sourcePosX1, sourcePosX2, sourcePosY1, sourcePosY2, sourcePosZ1, sourcePosZ2;
      //@}
+
+    TBranch *br_time1 = nullptr;
+    TBranch *br_time2 = nullptr;
+    TBranch *br_eventID1 = nullptr;
+    TBranch *br_eventID2 = nullptr;
+    TBranch *br_energy1 = nullptr;
+    TBranch *br_energy2 = nullptr;
+    TBranch *br_comptonPhantom1 = nullptr;
+    TBranch *br_comptonPhantom2 = nullptr;
 
     //! \name number of "fake" crystals per block, inserted by the scanner
     //@{!

--- a/src/include/stir/IO/InputStreamFromROOTFile.h
+++ b/src/include/stir/IO/InputStreamFromROOTFile.h
@@ -205,7 +205,7 @@ public:
     int crystal_repeater_z;
     //}
 
-    //! \name ROOT Variables, e.g. to hold data from each entry.
+    //! \name ROOT Variables, i.e. to hold data from each entry.
     //@{
     TChain *stream_ptr;
     // note: should be ROOT's Int_t, Double_t and Float_t types, but those

--- a/src/include/stir/IO/InputStreamFromROOTFile.h
+++ b/src/include/stir/IO/InputStreamFromROOTFile.h
@@ -262,6 +262,8 @@ public:
     bool exclude_scattered;
     //! Skip random events (eventID1 != eventID2)
     bool exclude_randoms;
+    //! Check energy window information (low_energy_window < energy <  up_energy_window)
+    bool check_energy_window_information;
     //! Lower energy threshold
     float low_energy_window;
     //! Upper energy threshold

--- a/src/include/stir/IO/InputStreamFromROOTFile.h
+++ b/src/include/stir/IO/InputStreamFromROOTFile.h
@@ -254,6 +254,9 @@ public:
     { return energy1 * 1e3; };
     float get_energy2_in_keV() const
     { return energy2 * 1e3; };
+
+    //! Checks brentry information. True if all conditions are satisfied.
+    bool check_brentry_randoms_scatter_energy_conditions(long long int brentry);
 };
 
 END_NAMESPACE_STIR

--- a/src/include/stir/IO/InputStreamFromROOTFile.h
+++ b/src/include/stir/IO/InputStreamFromROOTFile.h
@@ -220,6 +220,8 @@ public:
     float sourcePosX1, sourcePosX2, sourcePosY1, sourcePosY2, sourcePosZ1, sourcePosZ2;
      //@}
 
+    //! ROOT Branch address variables.
+    //@{
     TBranch *br_time1 = nullptr;
     TBranch *br_time2 = nullptr;
     TBranch *br_eventID1 = nullptr;
@@ -228,6 +230,27 @@ public:
     TBranch *br_energy2 = nullptr;
     TBranch *br_comptonPhantom1 = nullptr;
     TBranch *br_comptonPhantom2 = nullptr;
+    //Optional Branch variables. To be used if read_optional_root_fields is true.
+    TBranch *br_axialPos = nullptr;
+    TBranch *br_globalPosX1 = nullptr;
+    TBranch *br_globalPosX2 = nullptr;
+    TBranch *br_globalPosY1 = nullptr;
+    TBranch *br_globalPosY2 = nullptr;
+    TBranch *br_globalPosZ1 = nullptr;
+    TBranch *br_globalPosZ2 = nullptr;
+    TBranch *br_rotation_angle = nullptr;
+    TBranch *br_runID = nullptr;
+    TBranch *br_sinogramS = nullptr;
+    TBranch *br_sinogramTheta = nullptr;
+    TBranch *br_sourceID1 = nullptr;
+    TBranch *br_sourceID2 = nullptr;
+    TBranch *br_sourcePosX1 = nullptr;
+    TBranch *br_sourcePosX2 = nullptr;
+    TBranch *br_sourcePosY1 = nullptr;
+    TBranch *br_sourcePosY2 = nullptr;
+    TBranch *br_sourcePosZ1 = nullptr;
+    TBranch *br_sourcePosZ2 = nullptr;
+    //@}
 
     //! \name number of "fake" crystals per block, inserted by the scanner
     //@{!

--- a/src/include/stir/IO/InputStreamFromROOTFile.h
+++ b/src/include/stir/IO/InputStreamFromROOTFile.h
@@ -6,10 +6,11 @@
   \author Nikos Efthimiou
   \author Harry Tsoumpas
   \author Kris Thielemans
+  \author Robert Twyman
 */
 /*
  *  Copyright (C) 2015, 2016 University of Leeds
-    Copyright (C) 2016, 2020 UCL
+    Copyright (C) 2016, 2021, 2020 UCL
     Copyright (C) 2018 University of Hull
     This file is part of STIR.
 

--- a/src/include/stir/IO/InputStreamFromROOTFile.h
+++ b/src/include/stir/IO/InputStreamFromROOTFile.h
@@ -258,15 +258,15 @@ public:
     int num_virtual_axial_crystals_per_block;
     int num_virtual_transaxial_crystals_per_block;
     //@}
-    //! Skip scattered events (comptonphantom1 > 0 && comptonphantom2 > 0)
+    //! Skip scattered events (comptonphantom1 > 0 && comptonphantom2 > 0). Default is false
     bool exclude_scattered;
-    //! Skip random events (eventID1 != eventID2)
+    //! Skip random events (eventID1 != eventID2). Default is false
     bool exclude_randoms;
-    //! Check energy window information (low_energy_window < energy <  up_energy_window)
+    //! Check energy window information (low_energy_window < energy <  up_energy_window). Default is true
     bool check_energy_window_information;
-    //! Lower energy threshold
+    //! Lower energy threshold. Default is 1000 (keV)
     float low_energy_window;
-    //! Upper energy threshold
+    //! Upper energy threshold. Default is 0 (keV)
     float up_energy_window;
     //! This value will apply a rotation on the detectors' id in the same ring.
     int offset_dets;

--- a/src/include/stir/IO/InputStreamFromROOTFileForCylindricalPET.h
+++ b/src/include/stir/IO/InputStreamFromROOTFileForCylindricalPET.h
@@ -143,7 +143,8 @@ protected:
     virtual void initialise_keymap();
     virtual bool post_processing();
 
-    // TBranches
+    //! \name TBranches for Cylindrical PET
+    //@{
     TBranch *br_crystalID1 = nullptr;
     TBranch *br_crystalID2 = nullptr;
     TBranch *br_submoduleID1 = nullptr;
@@ -152,11 +153,15 @@ protected:
     TBranch *br_moduleID2 = nullptr;
     TBranch *br_rsectorID1 = nullptr;
     TBranch *br_rsectorID2 = nullptr;
+    //@}
 
+    //! \name ROOT Variables, e.g. to hold data from each entry.
+    //@{
     std::int32_t crystalID1, crystalID2;
     std::int32_t submoduleID1, submoduleID2;
     std::int32_t moduleID1, moduleID2;
     std::int32_t rsectorID1, rsectorID2;
+    //@}
 
     int submodule_repeater_x;
     int submodule_repeater_y;

--- a/src/include/stir/IO/InputStreamFromROOTFileForCylindricalPET.h
+++ b/src/include/stir/IO/InputStreamFromROOTFileForCylindricalPET.h
@@ -139,6 +139,16 @@ public:
 
 protected:
 
+    // TBranches
+    TBranch *br_crystalID1 = nullptr;
+    TBranch *br_crystalID2 = nullptr;
+    TBranch *br_submoduleID1 = nullptr;
+    TBranch *br_submoduleID2 = nullptr;
+    TBranch *br_moduleID1 = nullptr;
+    TBranch *br_moduleID2 = nullptr;
+    TBranch *br_rsectorID1 = nullptr;
+    TBranch *br_rsectorID2 = nullptr;
+
     virtual void set_defaults();
     virtual void initialise_keymap();
     virtual bool post_processing();

--- a/src/include/stir/IO/InputStreamFromROOTFileForCylindricalPET.h
+++ b/src/include/stir/IO/InputStreamFromROOTFileForCylindricalPET.h
@@ -139,6 +139,10 @@ public:
 
 protected:
 
+    virtual void set_defaults();
+    virtual void initialise_keymap();
+    virtual bool post_processing();
+
     // TBranches
     TBranch *br_crystalID1 = nullptr;
     TBranch *br_crystalID2 = nullptr;
@@ -148,10 +152,6 @@ protected:
     TBranch *br_moduleID2 = nullptr;
     TBranch *br_rsectorID1 = nullptr;
     TBranch *br_rsectorID2 = nullptr;
-
-    virtual void set_defaults();
-    virtual void initialise_keymap();
-    virtual bool post_processing();
 
     std::int32_t crystalID1, crystalID2;
     std::int32_t submoduleID1, submoduleID2;

--- a/src/include/stir/IO/InputStreamFromROOTFileForCylindricalPET.h
+++ b/src/include/stir/IO/InputStreamFromROOTFileForCylindricalPET.h
@@ -156,7 +156,7 @@ protected:
     TBranch *br_rsectorID2 = nullptr;
     //@}
 
-    //! \name ROOT Variables, e.g. to hold data from each entry.
+    //! \name ROOT Variables, i.e. to hold data from each entry.
     //@{
     std::int32_t crystalID1, crystalID2;
     std::int32_t submoduleID1, submoduleID2;

--- a/src/include/stir/IO/InputStreamFromROOTFileForCylindricalPET.h
+++ b/src/include/stir/IO/InputStreamFromROOTFileForCylindricalPET.h
@@ -4,9 +4,10 @@
 \brief Declaration of class stir::InputStreamFromROOTFileForCylindricalPET
 
 \author Nikos Efthimiou
+\author Robert Twyman
 */
 /*
-    Copyright (C) 2016, UCL
+    Copyright (C) 2016, 2021, UCL
     Copyright (C) 2018 University of Hull
     This file is part of STIR.
 

--- a/src/include/stir/IO/InputStreamFromROOTFileForECATPET.h
+++ b/src/include/stir/IO/InputStreamFromROOTFileForECATPET.h
@@ -133,14 +133,19 @@ protected:
     virtual void initialise_keymap();
     virtual bool post_processing();
 
-    // TBranches
+    //! \name TBranches for ECAT PET
+    //@{
     TBranch *br_crystalID1 = nullptr;
     TBranch *br_crystalID2 = nullptr;
     TBranch *br_blockID1 = nullptr;
     TBranch *br_blockID2 = nullptr;
+    //@}
 
+    //! \name ROOT Variables, e.g. to hold data from each entry.
+    //@{
     std::int32_t blockID1, blockID2;
     std::int32_t crystalID1, crystalID2;
+    //@}
 
     int block_repeater_y;
     int block_repeater_z;

--- a/src/include/stir/IO/InputStreamFromROOTFileForECATPET.h
+++ b/src/include/stir/IO/InputStreamFromROOTFileForECATPET.h
@@ -142,7 +142,7 @@ protected:
     TBranch *br_blockID2 = nullptr;
     //@}
 
-    //! \name ROOT Variables, e.g. to hold data from each entry.
+    //! \name ROOT Variables, i.e. to hold data from each entry.
     //@{
     std::int32_t blockID1, blockID2;
     std::int32_t crystalID1, crystalID2;

--- a/src/include/stir/IO/InputStreamFromROOTFileForECATPET.h
+++ b/src/include/stir/IO/InputStreamFromROOTFileForECATPET.h
@@ -133,6 +133,12 @@ protected:
     virtual void initialise_keymap();
     virtual bool post_processing();
 
+    // TBranches
+    TBranch *br_crystalID1 = nullptr;
+    TBranch *br_crystalID2 = nullptr;
+    TBranch *br_blockID1 = nullptr;
+    TBranch *br_blockID2 = nullptr;
+
     std::int32_t blockID1, blockID2;
     std::int32_t crystalID1, crystalID2;
 

--- a/src/include/stir/IO/InputStreamFromROOTFileForECATPET.h
+++ b/src/include/stir/IO/InputStreamFromROOTFileForECATPET.h
@@ -4,9 +4,10 @@
 \brief Declaration of class stir::InputStreamFromROOTFileForECATPET
 
 \author Nikos Efthimiou
+\author Robert Twyman
 */
 /*
-    Copyright (C) 2016, UCL
+    Copyright (C) 2016, 2021, UCL
     Copyright (C) 2018 University of Hull
     This file is part of STIR.
 


### PR DESCRIPTION
Uses GetEntry() on individual branches as the checks are performed. These changes are suggestions provided by a [discussion on the ROOT forums](https://root-forum.cern.ch/t/tchain-get-entry-acceleration/43468/5).

This is an extention on #813, which allowed unlisting of 10.53M events in `21.78s CPU time`. This PR improves the unlisting to `11.97s CPU time` (when unlisting with no-exclusions). The sinograms, created by unlisting a ROOT file with STIR master and this PR are identical. 

@KrisThielemans https://github.com/UCL/STIR/pull/813#issuecomment-774195119 I found another one. 