### PR TITLE
Fix822 ffp early stop with open mp

### DIFF
--- a/src/recon_buildblock/find_basic_vs_nums_in_subset.cxx
+++ b/src/recon_buildblock/find_basic_vs_nums_in_subset.cxx
@@ -43,7 +43,7 @@ namespace detail
                                const int subset_num, const int num_subsets)
   {
     std::vector<ViewSegmentNumbers> vs_nums_to_process;
-    for (int segment_num = min_segment_num; segment_num <= max_segment_num; segment_num++)
+    for (int segment_num = min_segment_num; segment_num <= max_segment_num; ++segment_num)
       {
         for (int view = proj_data_info.get_min_view_num() + subset_num; 
              view <= proj_data_info.get_max_view_num(); 


### PR DESCRIPTION
This is a small patch to fix early stop when forward projecting with OpenMP. 
The issue is not 100% reproducible but I have experienced many times. 