### PR TITLE
BinNormalisation fixes

### DIFF
--- a/src/include/stir/recon_buildblock/BinNormalisationFromAttenuationImage.h
+++ b/src/include/stir/recon_buildblock/BinNormalisationFromAttenuationImage.h
@@ -91,32 +91,32 @@ public:
   /*! This test is essentially checking if the forward projector can handle the data 
       by calling ForwardProjectorByBin::set_up().
   */
-  virtual Succeeded set_up(const shared_ptr<const ExamInfo>& exam_info_sptr, const shared_ptr<const ProjDataInfo>& );
+  virtual Succeeded set_up(const shared_ptr<const ExamInfo>& exam_info_sptr, const shared_ptr<const ProjDataInfo>& ) override;
 
   //! Normalise some data
   /*! 
     This means \c multiply with the data in the projdata object 
     passed in the constructor. 
   */
-  virtual void apply(RelatedViewgrams<float>& viewgrams,const double start_time, const double end_time) const;
+  virtual void apply(RelatedViewgrams<float>& viewgrams,const double start_time, const double end_time) const override;
 
   //! Undo the normalisation of some data
   /*! 
     This means \c divide with the data in the projdata object 
     passed in the constructor. 
   */
-  virtual void undo(RelatedViewgrams<float>& viewgrams,const double start_time, const double end_time) const;
+  virtual void undo(RelatedViewgrams<float>& viewgrams,const double start_time, const double end_time) const override;
 
-  virtual float get_bin_efficiency(const Bin& bin,const double start_time, const double end_time) const; 
+  virtual float get_bin_efficiency(const Bin& bin,const double start_time, const double end_time) const override;
 
 private:
   shared_ptr<const DiscretisedDensity<3,float> > attenuation_image_ptr;
   shared_ptr<ForwardProjectorByBin> forward_projector_ptr;
 
   // parsing stuff
-  virtual void set_defaults();
-  virtual void initialise_keymap();
-  virtual bool post_processing();
+  virtual void set_defaults() override;
+  virtual void initialise_keymap() override;
+  virtual bool post_processing() override;
 
   std::string attenuation_image_filename;
 };

--- a/src/include/stir/recon_buildblock/BinNormalisationFromECAT7.h
+++ b/src/include/stir/recon_buildblock/BinNormalisationFromECAT7.h
@@ -96,7 +96,7 @@ public:
   BinNormalisationFromECAT7(const std::string& filename);
 
   virtual Succeeded set_up(const shared_ptr<const ExamInfo> &exam_info_sptr,const shared_ptr<const ProjDataInfo>&);
-  float get_bin_efficiency(const Bin& bin, const double start_time, const double end_time) const;
+  float get_uncalibrated_bin_efficiency(const Bin& bin, const double start_time, const double end_time) const override;
 
   bool use_detector_efficiencies() const;
   bool use_dead_time() const;
@@ -132,9 +132,9 @@ private:
 				  const double start_time, const double end_time) const;
 
   // parsing stuff
-  virtual void set_defaults();
-  virtual void initialise_keymap();
-  virtual bool post_processing();
+  virtual void set_defaults() override;
+  virtual void initialise_keymap() override;
+  virtual bool post_processing() override;
 
   std::string normalisation_ECAT7_filename;
 };

--- a/src/include/stir/recon_buildblock/BinNormalisationFromECAT8.h
+++ b/src/include/stir/recon_buildblock/BinNormalisationFromECAT8.h
@@ -93,8 +93,8 @@ public:
   //! Constructor that reads the projdata from a file
   BinNormalisationFromECAT8(const string& filename);
 
-  virtual Succeeded set_up(const shared_ptr<const ExamInfo>& exam_info_sptr, const shared_ptr<const ProjDataInfo>& );
-  float get_uncalibrated_bin_efficiency(const Bin& bin, const double start_time, const double end_time) const;
+  virtual Succeeded set_up(const shared_ptr<const ExamInfo>& exam_info_sptr, const shared_ptr<const ProjDataInfo>& ) override;
+  float get_uncalibrated_bin_efficiency(const Bin& bin, const double start_time, const double end_time) const override;
 
   bool use_detector_efficiencies() const;
   bool use_dead_time() const;
@@ -132,9 +132,9 @@ private:
 				  const double start_time, const double end_time) const;
 
   // parsing stuff
-  virtual void set_defaults();
-  virtual void initialise_keymap();
-  virtual bool post_processing();
+  virtual void set_defaults() override;
+  virtual void initialise_keymap() override;
+  virtual bool post_processing() override;
 
   string normalisation_ECAT8_filename;
 };

--- a/src/include/stir/recon_buildblock/BinNormalisationFromGEHDF5.h
+++ b/src/include/stir/recon_buildblock/BinNormalisationFromGEHDF5.h
@@ -97,8 +97,8 @@ public:
   //! Constructor that reads the projdata from a file
   BinNormalisationFromGEHDF5(const string& filename);
 
-  virtual Succeeded set_up(const shared_ptr<const ExamInfo> &exam_info_sptr, const shared_ptr<ProjDataInfo>&);
-  float get_uncalibrated_bin_efficiency(const Bin& bin, const double start_time, const double end_time) const;
+  virtual Succeeded set_up(const shared_ptr<const ExamInfo>& exam_info_sptr, const shared_ptr<const ProjDataInfo>&) override;
+  float get_uncalibrated_bin_efficiency(const Bin& bin, const double start_time, const double end_time) const override;
 
   bool use_detector_efficiencies() const;
   bool use_dead_time() const;
@@ -116,9 +116,9 @@ private:
   int num_transaxial_crystals_per_block;
   // TODO move to Scanner
   int num_axial_blocks_per_singles_unit;
-  shared_ptr<ProjDataInfo> proj_data_info_ptr;
+  shared_ptr<const ProjDataInfo> proj_data_info_ptr;
   ProjDataInfoCylindricalNoArcCorr const * proj_data_info_cyl_ptr;
-  shared_ptr<ProjDataInfoCylindricalNoArcCorr> proj_data_info_cyl_uncompressed_ptr;
+  shared_ptr<const ProjDataInfoCylindricalNoArcCorr> proj_data_info_cyl_uncompressed_ptr;
   int span;
   int mash;
   int num_blocks_per_singles_unit;
@@ -134,9 +134,9 @@ private:
   float get_geometric_efficiency_factors  (const DetectionPositionPair<>& detection_position_pair) const;
   float get_efficiency_factors (const DetectionPositionPair<>& detection_position_pair) const;
   // parsing stuff
-  virtual void set_defaults();
-  virtual void initialise_keymap();
-  virtual bool post_processing();
+  virtual void set_defaults() override;
+  virtual void initialise_keymap() override;
+  virtual bool post_processing() override;
 
   string normalisation_GEHDF5_filename;
   shared_ptr<GEHDF5Wrapper> m_input_hdf5_sptr;

--- a/src/include/stir/recon_buildblock/BinNormalisationFromProjData.h
+++ b/src/include/stir/recon_buildblock/BinNormalisationFromProjData.h
@@ -77,36 +77,36 @@ public:
   /*! Checks if all data is equal to 1 (up to a tolerance of 1e-4). To do this, it uses ProjData::get_viewgram()
       and loops over all viewgrams.
   */
-  virtual bool is_trivial() const;
+  virtual bool is_trivial() const override;
 
   //! Checks if we can handle certain projection data.
   /*! Compares the  ProjDataInfo from the ProjData object containing the normalisation factors 
       with the ProjDataInfo supplied. */
-  virtual Succeeded set_up(const shared_ptr<const ExamInfo>& exam_info_sptr, const shared_ptr<const ProjDataInfo>& );
+  virtual Succeeded set_up(const shared_ptr<const ExamInfo>& exam_info_sptr, const shared_ptr<const ProjDataInfo>& ) override;
 
   //! Normalise some data
   /*! 
     This means \c multiply with the data in the projdata object 
     passed in the constructor. 
   */
-  virtual void apply(RelatedViewgrams<float>& viewgrams,const double start_time, const double end_time) const;
+  virtual void apply(RelatedViewgrams<float>& viewgrams,const double start_time, const double end_time) const override;
 
   //! Undo the normalisation of some data
   /*! 
     This means \c divide with the data in the projdata object 
     passed in the constructor. 
   */
-  virtual void undo(RelatedViewgrams<float>& viewgrams,const double start_time, const double end_time) const;
+  virtual void undo(RelatedViewgrams<float>& viewgrams,const double start_time, const double end_time) const override;
 
-  virtual float get_bin_efficiency(const Bin& bin,const double start_time, const double end_time) const;
+  virtual float get_bin_efficiency(const Bin& bin,const double start_time, const double end_time) const override;
     //! Get a shared_ptr to the normalisation proj_data.
   virtual shared_ptr<ProjData> get_norm_proj_data_sptr() const;
  
 private:
   shared_ptr<ProjData> norm_proj_data_ptr;
-  virtual void set_defaults();
-  virtual void initialise_keymap();
-  virtual bool post_processing();
+  virtual void set_defaults() override;
+  virtual void initialise_keymap() override;
+  virtual bool post_processing() override;
 
   std::string normalisation_projdata_filename;
 };

--- a/src/include/stir/recon_buildblock/BinNormalisationSPECT.h
+++ b/src/include/stir/recon_buildblock/BinNormalisationSPECT.h
@@ -43,7 +43,7 @@ public:
   BinNormalisationSPECT(const std::string& filename);
 
   void read_norm_data(const std::string& filename);
-  virtual Succeeded set_up(const shared_ptr<const ExamInfo>& exam_info_sptr, const shared_ptr<const ProjDataInfo>& );
+  virtual Succeeded set_up(const shared_ptr<const ExamInfo>& exam_info_sptr, const shared_ptr<const ProjDataInfo>& ) override;
   void set_num_views(int num_views) const { this->num_views=num_views;}
 
   void set_uniformity(Array<3,float>& uniformity){
@@ -62,11 +62,11 @@ public:
                               const double start_time,
                               const double end_time) const;
 
-  virtual void apply(RelatedViewgrams<float>& viewgrams,const double start_time, const double end_time) const;
+  virtual void apply(RelatedViewgrams<float>& viewgrams,const double start_time, const double end_time) const override;
 
-  virtual void undo(RelatedViewgrams<float>& viewgrams,const double start_time, const double end_time) const;
+  virtual void undo(RelatedViewgrams<float>& viewgrams,const double start_time, const double end_time) const override;
 
-  virtual float get_uncalibrated_bin_efficiency(const Bin& bin,const double start_time, const double end_time) const;
+  virtual float get_uncalibrated_bin_efficiency(const Bin& bin,const double start_time, const double end_time) const override;
 
   void read_linearity_table(Array<3,float>& linearity) const;
   void read_uniformity_table(Array<3,float>& uniformity) const;
@@ -79,9 +79,9 @@ public:
 
 protected:
   // parsing stuff
-  virtual void set_defaults();
-  virtual void initialise_keymap();
-  virtual bool post_processing();
+  virtual void set_defaults() override;
+  virtual void initialise_keymap() override;
+  virtual bool post_processing() override;
 
   int max_tang;
   shared_ptr<ProjData> norm_proj_data_info_ptr;

--- a/src/include/stir/recon_buildblock/BinNormalisationWithCalibration.h
+++ b/src/include/stir/recon_buildblock/BinNormalisationWithCalibration.h
@@ -54,14 +54,14 @@ public:
   // needs to be implemented by derived class
   virtual float get_uncalibrated_bin_efficiency(const Bin&, const double start_time, const double end_time) const  = 0;
  
-  virtual float get_bin_efficiency(const Bin& bin, const double start_time, const double end_time) const
+  virtual float get_bin_efficiency(const Bin& bin, const double start_time, const double end_time) const final
    { return this->get_uncalibrated_bin_efficiency(bin, start_time, end_time)/get_calib_decay_branching_ratio_factor(bin); }
   
  protected:
   // parsing stuff
-  virtual void set_defaults();
-  virtual void initialise_keymap();
-  virtual bool post_processing();
+  virtual void set_defaults() override;
+  virtual void initialise_keymap() override;
+  virtual bool post_processing() override;
 
 
 private:

--- a/src/include/stir/recon_buildblock/ChainedBinNormalisation.h
+++ b/src/include/stir/recon_buildblock/ChainedBinNormalisation.h
@@ -95,17 +95,18 @@ ChainedBinNormalisation(shared_ptr<BinNormalisation> const& apply_first,
 
   //! Checks if we can handle certain projection data.
   /*! Calls set_up for the BinNormalisation members. */
-  virtual Succeeded set_up(const shared_ptr<const ExamInfo>& exam_info_sptr, const shared_ptr<const ProjDataInfo>& );
+  virtual Succeeded set_up(const shared_ptr<const ExamInfo>& exam_info_sptr, const shared_ptr<const ProjDataInfo>& ) override;
 
   //! Normalise some data
   /*! 
     This calls apply() of the 2 BinNormalisation members
   */
-  virtual void apply(RelatedViewgrams<float>& viewgrams,const double start_time, const double end_time) const;
+  virtual void apply(RelatedViewgrams<float>& viewgrams,const double start_time, const double end_time) const override;
+#if 0
+  virtual void apply(ProjData&) const override;
+#endif
 
-  virtual void apply(ProjData&) const;
-
-virtual void apply_only_first(RelatedViewgrams<float>& viewgrams,const double start_time, const double end_time) const;
+  virtual void apply_only_first(RelatedViewgrams<float>& viewgrams,const double start_time, const double end_time) const;
 
 virtual void apply_only_first(ProjData&,const double start_time, const double end_time) const;
 
@@ -117,9 +118,10 @@ virtual void apply_only_second(ProjData&,const double start_time, const double e
   /*! 
     This calls undo() of the 2 BinNormalisation members. 
   */
-  virtual void undo(RelatedViewgrams<float>& viewgrams,const double start_time, const double end_time) const;
-
-  virtual void undo(ProjData&,const double start_time, const double end_time) const;
+  virtual void undo(RelatedViewgrams<float>& viewgrams,const double start_time, const double end_time) const override;
+#if 0
+  virtual void undo(ProjData&,const double start_time, const double end_time) const override;
+#endif
 
 virtual void undo_only_first(RelatedViewgrams<float>& viewgrams,const double start_time, const double end_time) const;
 
@@ -129,7 +131,7 @@ virtual void undo_only_second(RelatedViewgrams<float>& viewgrams,const double st
 
 virtual void undo_only_second(ProjData&,const double start_time, const double end_time) const;
 
-  virtual float get_bin_efficiency(const Bin& bin,const double start_time, const double end_time) const;
+  virtual float get_bin_efficiency(const Bin& bin,const double start_time, const double end_time) const override;
  //! Returns the is_trivial() status of the first normalisation object.
  //! \warning Currently, if the object has not been set the function throws an error.
   virtual bool is_first_trivial() const;
@@ -144,9 +146,9 @@ private:
   shared_ptr<BinNormalisation> apply_first;
   shared_ptr<BinNormalisation> apply_second;
   // parsing stuff
-  virtual void set_defaults();
-  virtual void initialise_keymap();
-  virtual bool post_processing();
+  virtual void set_defaults() override;
+  virtual void initialise_keymap() override;
+  virtual bool post_processing() override;
 };
 
 END_NAMESPACE_STIR

--- a/src/include/stir/recon_buildblock/TrivialBinNormalisation.h
+++ b/src/include/stir/recon_buildblock/TrivialBinNormalisation.h
@@ -46,16 +46,16 @@ public:
   //! Name which will be used when parsing a BinNormalisation object
   static const char * const registered_name; 
 
-  virtual inline void apply(RelatedViewgrams<float>&,const double start_time, const double end_time) const {}
-  virtual inline void undo(RelatedViewgrams<float>&,const double start_time, const double end_time) const {}
+  virtual inline void apply(RelatedViewgrams<float>&,const double start_time, const double end_time) const override {}
+  virtual inline void undo(RelatedViewgrams<float>&,const double start_time, const double end_time) const override {}
   
-  virtual inline float get_bin_efficiency(const Bin& bin,const double start_time, const double end_time) const { return 1;}
+  virtual inline float get_bin_efficiency(const Bin& bin,const double start_time, const double end_time) const override { return 1.F;}
 
-  virtual inline bool is_trivial() const { return true;}  
+  virtual inline bool is_trivial() const override { return true;}  
 
 private:
-  virtual inline void set_defaults() {}
-  virtual inline void initialise_keymap() {}
+  virtual inline void set_defaults() override {}
+  virtual inline void initialise_keymap() override {}
   
 };
 

--- a/src/recon_buildblock/BinNormalisationFromECAT7.cxx
+++ b/src/recon_buildblock/BinNormalisationFromECAT7.cxx
@@ -475,7 +475,7 @@ use_crystal_interference_factors() const
 #if 1
 float 
 BinNormalisationFromECAT7::
-get_bin_efficiency(const Bin& bin, const double start_time, const double end_time) const {
+get_uncalibrated_bin_efficiency(const Bin& bin, const double start_time, const double end_time) const {
 
 
   // TODO disable when not HR+ or HR++

--- a/src/recon_buildblock/BinNormalisationFromGEHDF5.cxx
+++ b/src/recon_buildblock/BinNormalisationFromGEHDF5.cxx
@@ -103,7 +103,7 @@ calc_ring1_plus_ring2(const Bin& bin,
 
 static
 void
-set_detection_tangential_coords(shared_ptr<ProjDataInfoCylindricalNoArcCorr> proj_data_cyl_uncomp,
+set_detection_tangential_coords(shared_ptr<const ProjDataInfoCylindricalNoArcCorr> proj_data_cyl_uncomp,
                                 const Bin& uncomp_bin, 
                                 DetectionPositionPair<>& detection_position_pair) {
   int det1_num=0;
@@ -257,7 +257,7 @@ BinNormalisationFromGEHDF5(const string& filename)
 
 Succeeded
 BinNormalisationFromGEHDF5::
-set_up(const shared_ptr<const ExamInfo> &exam_info_sptr, const shared_ptr<ProjDataInfo>& proj_data_info_ptr_v)
+set_up(const shared_ptr<const ExamInfo> &exam_info_sptr, const shared_ptr<const ProjDataInfo>& proj_data_info_ptr_v)
 {
   BinNormalisation::set_up(exam_info_sptr, proj_data_info_ptr_v);
   proj_data_info_ptr = proj_data_info_ptr_v;
@@ -401,7 +401,7 @@ read_norm_data(const string& filename)
             std::vector<unsigned int> repeat_buffer;
             repeat_buffer.reserve(projInfo->get_num_axial_poss(i_seg)*count[1]-1);
             // repeat the values
-            for (unsigned int i=0; i<projInfo->get_num_axial_poss(i_seg);i++)
+            for (int i=0; i<projInfo->get_num_axial_poss(i_seg);i++)
               repeat_buffer.insert(repeat_buffer.end(),buffer.begin(),buffer.end());
             // copy data back
             // AB TODO: Hardcoded magic number, remove somehow (when magic is discovered)

--- a/src/recon_buildblock/ChainedBinNormalisation.cxx
+++ b/src/recon_buildblock/ChainedBinNormalisation.cxx
@@ -99,7 +99,7 @@ ChainedBinNormalisation::apply(RelatedViewgrams<float>& viewgrams,const double s
   if (!is_null_ptr(apply_second))
     apply_second->apply(viewgrams,start_time,end_time);
 }
-
+#if 0
 void
 ChainedBinNormalisation::apply(ProjData& proj_data) const
 {
@@ -108,7 +108,7 @@ ChainedBinNormalisation::apply(ProjData& proj_data) const
   if (!is_null_ptr(apply_second))
     apply_second->apply(proj_data);
 }
-
+#endif
 void
 ChainedBinNormalisation::apply_only_first(RelatedViewgrams<float>& viewgrams,const double start_time, const double end_time) const
 {
@@ -147,6 +147,7 @@ undo(RelatedViewgrams<float>& viewgrams,const double start_time, const double en
     apply_second->undo(viewgrams,start_time,end_time);
 }
 
+#if 0
 void
 ChainedBinNormalisation::
 undo(ProjData& proj_data,const double start_time, const double end_time) const
@@ -156,6 +157,7 @@ undo(ProjData& proj_data,const double start_time, const double end_time) const
   if (!is_null_ptr(apply_second))
     apply_second->undo(proj_data,start_time,end_time);
 }
+#endif
 
 void
 ChainedBinNormalisation::


### PR DESCRIPTION
- Fixes `*GERDF9`- set_up(), caused by a wrong merge
- Fixes `*ECAT7` (although still untested)
- Remove unused overloads of `apply`/`undo` in `ChainedBinNormalisation`
- Add `override` attribute in the hierarchy to prevent errors like the first one in the future