### PR TITLE
add LmToProjData::set_up()

### DIFF
--- a/documentation/release_4.1.htm
+++ b/documentation/release_4.1.htm
@@ -65,6 +65,10 @@
     but allows us to subtract time-fields.</li>
   <li>Added a utility <tt>list_lm_info</tt>.</li>
   <li>Implementation of <tt>a*x+b*y</tt> methods <code>xapyb</code> and <code>sapyb</code> where <tt>a</tt> and <tt>b</tt> can be scalar or vector types.</li>
+  <li>The <code>LmToProjData</code> hierarchy has a new member function <code>set_up()</code>, and more <code>set_*</code>
+    functions, such that it can be used without parsing. Note that it will be automatically called when parsing
+    (which might change in the future).
+    </li>
 </ul>
 
 

--- a/src/experimental/listmode/LmToProjDataWithMC.cxx
+++ b/src/experimental/listmode/LmToProjDataWithMC.cxx
@@ -7,6 +7,7 @@
 */
 /*
     Copyright (C) 2003- 2012, Hammersmith Imanet Ltd
+    Copyright (C) 2021, University College London
     See STIR/LICENSE.txt for details
 */
 #include "stir_experimental/listmode/LmToProjDataWithMC.h"
@@ -57,21 +58,21 @@ bool
 LmToProjDataWithMC::
 post_processing()
 {
-  if (LmToProjData::post_processing())
-    return true;
-   
+  return LmToProjData::post_processing();
+}
+
+Succeeded LmToProjDataWithMC::set_up()
+{
   if (is_null_ptr(ro3d_ptr))
   {
-    warning("Invalid Rigid Object 3D Motion object\n");
-    return true;
+    error("Invalid Rigid Object 3D Motion object");
   }
 
   if (reference_position_is_average_position_in_frame)
     {
       if (!is_null_ptr(_reference_abs_time_sptr))
 	{
-	  warning("time interval for reference position is set, but you asked for average over each frame");
-	  return true;
+	  error("time interval for reference position is set, but you asked for average over each frame");
 	}
     }
   else
@@ -79,8 +80,7 @@ post_processing()
       // set transformation_to_reference_position
       if (is_null_ptr(_reference_abs_time_sptr))
 	{
-	  warning("time interval for reference position is not set");
-	  return true;
+	  error("time interval for reference position is not set");
 	}
       {
 	const RigidObject3DTransformation av_motion = 

--- a/src/include/stir/listmode/LmToProjData.h
+++ b/src/include/stir/listmode/LmToProjData.h
@@ -16,7 +16,7 @@
 /*
     Copyright (C) 2000- 2009, Hammersmith Imanet Ltd
     Copyright (C) 2019, National Physical Laboratory
-    Copyright (C) 2019, University College of London
+    Copyright (C) 2019, 2021, University College of London
     This file is part of STIR.
 
     This file is free software; you can redistribute it and/or modify
@@ -177,9 +177,13 @@ public:
   /*! \warning leaves parameters ill-defined. Set them by parsing. */
   LmToProjData();
 
+  //! Perform various checks
+  /*! Note: this is currently called by post_processing(). This will change in version 5.0 */
+  virtual Succeeded set_up();
+
   //! This function does the actual work
   virtual void process_data();
-  
+
 protected:
 
   
@@ -268,6 +272,8 @@ protected:
   //! A variable that will be set to 1,0 or -1, according to store_prompts and store_delayeds
   int delayed_increment;
 
+  //! an internal bool variable to check if the object has been set-up or not
+  bool _already_setup;
 };
 
 END_NAMESPACE_STIR

--- a/src/include/stir/listmode/LmToProjDataBootstrap.h
+++ b/src/include/stir/listmode/LmToProjDataBootstrap.h
@@ -85,6 +85,7 @@ public:
   /*! The \a seed argument will override any value found in the par file */
   LmToProjDataBootstrap(const char * const par_filename, const unsigned int seed);
 
+  virtual Succeeded set_up();
 protected:
   //! will be called when a new time frame starts
   /*! Initialises a vector with the number of times each event has to be replicated */

--- a/src/include/stir/listmode/LmToProjDataWithRandomRejection.h
+++ b/src/include/stir/listmode/LmToProjDataWithRandomRejection.h
@@ -6,13 +6,14 @@
   \ingroup listmode
   \brief Class for binning list mode files with the bootstrap method
     
-  \author Kris Thielemans\author Daniel Deidda
+  \author Kris Thielemans
+  \author Daniel Deidda
 
 */
 /*
     Copyright (C) 2003- 2012, Hammersmith Imanet Ltd
     Copyright (C) 2019, National Physical Laboratory
-    Copyright (C) 2019, University College London
+    Copyright (C) 2019, 2021, University College London
     This file is part of STIR.
 
     This file is free software; you can redistribute it and/or modify
@@ -88,6 +89,7 @@ public:
   //void set_seed(const unsigned int seed);
   float set_reject_if_above(const float);
 
+  virtual Succeeded set_up();
 protected:
   //! will be called when a new time frame starts
   /*! Initialises a vector with the number of times each event has to be replicated */

--- a/src/include/stir_experimental/listmode/LmToProjDataWithMC.h
+++ b/src/include/stir_experimental/listmode/LmToProjDataWithMC.h
@@ -40,7 +40,8 @@ public:
 
   virtual void get_bin_from_event(Bin& bin, const CListEvent&) const;
   virtual void process_new_time_event(const ListTime& time_event);
-
+  virtual Succeeded set_up();
+  
 protected: 
   //! motion information
   shared_ptr<RigidObject3DMotion> ro3d_ptr;

--- a/src/listmode_buildblock/LmToProjData.cxx
+++ b/src/listmode_buildblock/LmToProjData.cxx
@@ -9,7 +9,8 @@
 */
 /*
     Copyright (C) 2000 - 2011-12-31, Hammersmith Imanet Ltd
-    Copyright (C) 2013, University College London
+    Copyright (C) 2013, 2021 University College London
+    Copright (C) 2019, National Physical Laboratory
     This file is part of STIR.
 
     This file is free software; you can redistribute it and/or modify
@@ -200,12 +201,6 @@ post_processing()
       return true;
     }
 
-  if (!interactive && output_filename_prefix.size()==0)
-    {
-      warning("You have to specify an output_filename_prefix\n");
-      return true;
-    }
-
   lm_data_ptr = stir::read_from_file<ListModeData>(input_filename);
 
   if (template_proj_data_name.size()==0)
@@ -218,11 +213,39 @@ post_processing()
 
   template_proj_data_info_ptr.reset(template_proj_data_ptr->get_proj_data_info_ptr()->clone());
 
-  // propagate relevant metadata
-  template_proj_data_info_ptr->set_bed_position_horizontal
-    (lm_data_ptr->get_proj_data_info_sptr()->get_bed_position_horizontal());
-  template_proj_data_info_ptr->set_bed_position_vertical
-    (lm_data_ptr->get_proj_data_info_sptr()->get_bed_position_vertical());
+  // set up normalisation objects
+
+  if (is_null_ptr(normalisation_ptr))
+    {
+      warning("Invalid pre-normalisation object\n");
+      return true;
+    }
+  if (is_null_ptr(post_normalisation_ptr))
+    {
+      warning("Invalid post-normalisation object\n");
+      return true;
+    }
+
+  if (set_up() == Succeeded::no)
+    return true;
+
+#ifdef FRAME_BASED_DT_CORR
+  cerr << "LmToProjData Using FRAME_BASED_DT_CORR\n";
+#else
+  cerr << "LmToProjData NOT Using FRAME_BASED_DT_CORR\n";
+#endif
+
+  return false;
+}
+
+Succeeded LmToProjData::set_up()
+{
+  _already_setup = true;
+
+  if (!interactive && output_filename_prefix.size()==0)
+    {
+      error("You have to specify an output_filename_prefix");
+    }
 
   // initialise segment_num related variables
 
@@ -247,36 +270,10 @@ post_processing()
       min(num_segments_in_memory, num_segments);
   if (num_segments == 0)
     {
-      warning("LmToProjData: num_segments_in_memory cannot be 0");
-      return true;
+      error("LmToProjData: num_segments_in_memory cannot be 0");
     }
-  
 
-
-  Scanner const * const scanner_ptr = 
-    template_proj_data_info_ptr->get_scanner_ptr();
-
-  if (*scanner_ptr != *lm_data_ptr->get_scanner_ptr())
-    {
-      warning("LmToProjData:\nScanner from list mode data (%s) is different from\n"
-	      "scanner from template projdata (%s).\n"
-	      "Full definition of scanner from list mode data:\n%s\n"
-	      "Full definition of scanner from template:\n%s\n",
-	      lm_data_ptr->get_scanner_ptr()->get_name().c_str(),
-	      scanner_ptr->get_name().c_str(),
-	      lm_data_ptr->get_scanner_ptr()->parameter_info().c_str(),
-	      scanner_ptr->parameter_info().c_str());
-      return true;
-    }
-  
   // handle store_prompts and store_delayeds
-
-  if (lm_data_ptr->has_delayeds()==false && store_delayeds==true)
-    {
-      warning("This list mode data does not seem to have delayed events.\n"
-	      "Setting store_delayeds to false.");
-      store_delayeds=true;
-    }
   
   if (store_prompts)
     {
@@ -291,34 +288,20 @@ post_processing()
 	delayed_increment = 1;
       else
 	{
-	  warning("At least one of store_prompts or store_delayeds should be true");
-	  return true;
+	  error("At least one of store_prompts or store_delayeds should be true");
 	}
-    }
-
-  // set up normalisation objects
-
-  if (is_null_ptr(normalisation_ptr))
-    {
-      warning("Invalid pre-normalisation object\n");
-      return true;
-    }
-  if (is_null_ptr(post_normalisation_ptr))
-    {
-      warning("Invalid post-normalisation object\n");
-      return true;
     }
 
   if (do_pre_normalisation)
     {
-      shared_ptr<Scanner> scanner_sptr(new Scanner(*scanner_ptr));
+      shared_ptr<Scanner> scanner_sptr(new Scanner(*template_proj_data_info_ptr->get_scanner_sptr()));
       // TODO this won't work for the HiDAC or so
       proj_data_info_cyl_uncompressed_ptr.
 	reset(dynamic_cast<ProjDataInfoCylindricalNoArcCorr *>(
 							       ProjDataInfo::ProjDataInfoCTI(scanner_sptr, 
-											     1, scanner_ptr->get_num_rings()-1,
-											     scanner_ptr->get_num_detectors_per_ring()/2,
-											     scanner_ptr->get_default_num_arccorrected_bins(), 
+											     1, scanner_sptr->get_num_rings()-1,
+											     scanner_sptr->get_num_detectors_per_ring()/2,
+											     scanner_sptr->get_default_num_arccorrected_bins(), 
 											     false)));
       
       if ( normalisation_ptr->set_up(proj_data_info_cyl_uncompressed_ptr)
@@ -349,13 +332,7 @@ post_processing()
       frame_defs = TimeFrameDefinitions(frame_times);
     }
 
-#ifdef FRAME_BASED_DT_CORR
-  cerr << "LmToProjData Using FRAME_BASED_DT_CORR\n";
-#else
-  cerr << "LmToProjData NOT Using FRAME_BASED_DT_CORR\n";
-#endif
-
-  return false;
+  return Succeeded::yes;
 }
 
 /**************************************************************
@@ -519,10 +496,43 @@ start_new_time_frame(const unsigned int)
 void
 LmToProjData::
 process_data()
-{ 
+{
+  if (!_already_setup)
+    error("LmToProjData: you need to call set_up() first");
+
   CPUTimer timer;
   timer.start();
 
+  // propagate relevant metadata
+  template_proj_data_info_ptr->set_bed_position_horizontal
+    (lm_data_ptr->get_proj_data_info_sptr()->get_bed_position_horizontal());
+  template_proj_data_info_ptr->set_bed_position_vertical
+    (lm_data_ptr->get_proj_data_info_sptr()->get_bed_position_vertical());
+
+  // a few more checks, now that we have the lm_data_ptr
+  {
+    Scanner const * const scanner_ptr = 
+      template_proj_data_info_ptr->get_scanner_ptr();
+
+    if (*scanner_ptr != *lm_data_ptr->get_scanner_ptr())
+      {
+        error("LmToProjData:\nScanner from list mode data (%s) is different from\n"
+                "scanner from template projdata (%s).\n"
+                "Full definition of scanner from list mode data:\n%s\n"
+                "Full definition of scanner from template:\n%s\n",
+                lm_data_ptr->get_scanner_ptr()->get_name().c_str(),
+                scanner_ptr->get_name().c_str(),
+                lm_data_ptr->get_scanner_ptr()->parameter_info().c_str(),
+                scanner_ptr->parameter_info().c_str());
+      }
+
+    if (lm_data_ptr->has_delayeds()==false && store_delayeds==true)
+      {
+        warning("This list mode data does not seem to have delayed events.\n"
+                "Setting store_delayeds to false.");
+        store_delayeds=true;
+      }
+  }
   // assume list mode data starts at time 0
   // we have to do this because the first time tag might occur only after a
   // few coincidence events (as happens with ECAT scanners)
@@ -540,7 +550,7 @@ process_data()
   ListRecord& record = *record_sptr;
 
   if (!record.event().is_valid_template(*template_proj_data_info_ptr))
-	  error("The scanner template is not valid for LmToProjData. This might be because of unsupported arc correction.");
+    error("The scanner template is not valid for LmToProjData. This might be because of unsupported arc correction.");
 
 
   /* Here starts the main loop which will store the listmode data. */

--- a/src/listmode_buildblock/LmToProjDataBootstrap.cxx
+++ b/src/listmode_buildblock/LmToProjDataBootstrap.cxx
@@ -105,16 +105,21 @@ bool
 LmToProjDataBootstrap<LmToProjDataT>::
 post_processing()
 {
-  if (LmToProjData::post_processing())
-    return true;
-
-  if (seed == 0)
-    return true;
-
-  return false;
+  return LmToProjDataT::post_processing();
 }
 
+template <typename LmToProjDataT>
+Succeeded LmToProjDataBootstrap<LmToProjDataT>::set_up()
+{
+  if (LmToProjDataT::set_up() == Succeeded::no)    
+    return Succeeded::no;
 
+  if (this->seed == 0)
+    {
+      error("Seed needs to be non-zero");
+    }
+  return Succeeded::yes;
+}
 
 template <typename LmToProjDataT> 
 void 

--- a/src/listmode_buildblock/LmToProjDataWithRandomRejection.cxx
+++ b/src/listmode_buildblock/LmToProjDataWithRandomRejection.cxx
@@ -13,7 +13,7 @@
 /*
     Copyright (C) 2003- 2012, Hammersmith Imanet Ltd
     Copyright (C) 2019, National Physical Laboratory
-    Copyright (C) 2019, University College London
+    Copyright (C) 2019, 2021, University College London
     This file is part of STIR.
 
     This file is free software; you can redistribute it and/or modify
@@ -97,20 +97,27 @@ bool
 LmToProjDataWithRandomRejection<LmToProjDataT>::
 post_processing()
 {
-  if (LmToProjData::post_processing())
-    return true;
+  return LmToProjDataT::post_processing();
+}
+
+template <typename LmToProjDataT>
+Succeeded LmToProjDataWithRandomRejection<LmToProjDataT>::set_up()
+{
+  if (LmToProjDataT::set_up() == Succeeded::no)    
+    return Succeeded::no;
 
   if (this->seed == 0)
     {
-      warning("Seed needs to be non-zero"); return true;
+      error("Seed needs to be non-zero"); return Succeeded::no;
     }
 
   if (this->reject_if_above<0.F || this->reject_if_above>1.F)
     {
-      warning("reject_if_above needs to be between 0 and 1"); return true;
+      error("reject_if_above needs to be between 0 and 1"); return Succeeded::no;
     }
 
-  return false;
+  return Succeeded::yes;
+
 }
 
 template <typename LmToProjDataT> 


### PR DESCRIPTION
Like other STIR hierarchies, this adds a `set_up()` function. Many checks have been moved from `post_processing()` to `set_up().` This allows using `LmToProjData` without parsing.

For backwards compatibility, `LmToProjData::post_processing()` still calls `set_up()`.