### PR TITLE
scripts for GE PETCT RDF9 processing 

### DIFF
--- a/examples/GE-PETCT/GE_HUToMu.par
+++ b/examples/GE-PETCT/GE_HUToMu.par
@@ -1,0 +1,36 @@
+PostFiltering parameters :=
+; an example file using the HUToMu filter (or data processor) to convert
+; a CT image in Hounsfield Units to mu-values, followed by some Gaussian smoothing
+;
+; The HUToMu filter takes a file in JSON format specifying the piecewise-linear curves
+; for various systems, Xray voltages and gamma energies.
+; keywords below select the curve accordingly.
+; A sample file is currently located in the source of STIR
+; (currently available at https://raw.githubusercontent.com/UCL/STIR/85cc1940c297b1749cf44a9fba937d7cefdccd47/src/utilities/share/ct_slopes.json)
+; This file is installed in your <install_prefix>/share folder
+
+Postfilter type := Chained Data Processor
+  Chained Data Processor Parameters:=
+
+  Data Processor to apply first:= HUToMu
+    HUToMu Parameters:=
+      slope filename := ${CT_SLOPES_FILENAME}
+      ; next defaults to GENERIC
+      manufacturer_name := GE
+      ; CT tube voltage (defaults to 120)
+      kilovoltage_peak := ${kV}
+      ; gamma energy (defaults to 511 for PET)
+      ;target_photon_energy :=
+    End HUToMu Parameters:=
+
+  Data Processor to apply second:= Separable Gaussian
+    Separable Gaussian Filter Parameters :=
+      ; TODO These have to be determined based on how much filtering occured in the original CT
+      x-dir filter FWHM (in mm):= 6
+      y-dir filter FWHM (in mm):= 6
+      z-dir filter FWHM (in mm):= 6
+    END Separable Gaussian Filter Parameters :=
+
+  END Chained Data Processor Parameters:=
+
+End PostFiltering Parameters:=

--- a/examples/GE-PETCT/NAC_recon.sh
+++ b/examples/GE-PETCT/NAC_recon.sh
@@ -1,0 +1,50 @@
+#! /bin/sh -e
+# Example script to reconstruct GE-Signa PET/MR data with randoms, norm and scatter.
+# Currently supposes you have randoms estimated already.
+# Default filenames are for output of unlist_and_randoms.sh, and for the NEMA demo files
+# Author: Kris Thielemans
+# Edits: Ander Biguri
+
+# directory with some standard .par files
+: ${pardir:=~/devel/STIR/examples/GE-Signa-PETMR}
+
+# names are from unlist_and_randoms
+: ${sino_input:=sinospan2_f1g1d0b0.hs}
+: ${randoms3d:=randomsspan2.hs}
+
+: ${num_subsets:=14}
+: ${num_subiters:=42}
+
+export sino_input randoms3d # used by scatter_estimation.par
+
+# RDF9 norm file 
+: ${RDFNORM:=norm3d}
+
+# we will put most intermediate files in a separate directory
+# note that the scatter code will also create an `extras` folder in the current directory
+mkdir -p output
+
+# output name (or input if it exists already) for normalisation sinogram
+: ${norm_sino_prefix:=output/fullnormfactorsspan2}
+${pardir}/create_norm_projdata.sh ${norm_sino_prefix} ${RDFNORM} ${sino_input}
+
+# use some more memorable names
+data3d=${sino_input}
+norm3d=${norm_sino_prefix}.hs
+
+echo "Creating additive sinogram for the reconstruction (randoms only here)"
+additive_sino=output/add_sino.hs
+stir_math -s ${additive_sino}  ${randoms3d} ${norm3d}
+
+### do an image reconstruction
+
+# FBP recon (currently commented out, not checked)
+#stir_math -s --mult precorrected_data3d.hs ${data3d} ${norm3d}
+#stir_subtract -s --accumulate  precorrected_data3d.hs ${additive_sino}
+#ZOOM=.4 INPUT=precorrected_data3d.hs OUTPUT=final_activity_image_3d FBP3DRP FBP3DRP.par
+
+echo "Running OSMAPOSL"
+echo "Log will be in NAC_image.log"
+INPUT=${data3d} OUTPUT=NAC_image NORM=${norm3d} ADDSINO=${additive_sino} \
+    SUBSETS=$num_subsets SUBITERS=$num_subiters SAVEITERS=$num_subsets SENS=output/subset_sens_NAC RECOMP_SENS=1 \
+     OSMAPOSL ${pardir}/OSMAPOSLbackground.par 2>&1 | tee NAC_image.log

--- a/examples/GE-PETCT/OSMAPOSLbackground.par
+++ b/examples/GE-PETCT/OSMAPOSLbackground.par
@@ -1,0 +1,41 @@
+OSMAPOSLParameters :=
+
+objective function type:= PoissonLogLikelihoodWithLinearModelForMeanAndProjData
+PoissonLogLikelihoodWithLinearModelForMeanAndProjData Parameters:=
+
+input file := ${INPUT}
+
+; if disabled, defaults to maximum segment number in the file
+;maximum absolute segment number to process := 4
+;zero end planes of segment 0:= 1
+
+Bin Normalisation type:=From ProjData
+Bin Normalisation From ProjData :=
+normalisation projdata filename:= ${NORM}
+End Bin Normalisation From ProjData:=
+
+projector pair type := Matrix
+  Projector Pair Using Matrix Parameters :=
+  Matrix type := Ray Tracing
+  Ray tracing matrix parameters :=
+number of rays in tangential direction to trace for each bin :=5
+do symmetry 90degrees min phi := 0
+
+  End Ray tracing matrix parameters :=
+  End Projector Pair Using Matrix Parameters :=
+
+use subset sensitivities := 1
+subset sensitivity filenames := ${SENS}_${SUBSETS}_%d.hv
+recompute sensitivity:=${RECOMP_SENS}
+
+additive sinogram := ${ADDSINO}
+end PoissonLogLikelihoodWithLinearModelForMeanAndProjData Parameters:=
+
+output filename prefix := ${OUTPUT}
+enforce initial positivity condition:=0
+
+number of subsets:= ${SUBSETS}
+number of subiterations:= ${SUBITERS}
+save estimates at subiteration intervals:= ${SAVEITERS}
+
+END :=

--- a/examples/GE-PETCT/correct_projdata_for_norm.par
+++ b/examples/GE-PETCT/correct_projdata_for_norm.par
@@ -1,0 +1,46 @@
+correct_projdata Parameters := 
+
+  input file := ${INPUT}
+
+  ; Current way of specifying time frames, pending modifications to
+  ; STIR to read time info from the headers
+  ; see class documentation for TimeFrameDefinitions for the format of this file
+  ; time frame definition filename :=  frames.fdef
+
+  ; if a frame definition file is specified, you can say that the input data
+  ; corresponds to a specific time frame
+  ; the number should be between 1 and num_frames and defaults to 1
+  ; this is currently only used to pass the relevant time to the normalisation
+  ; time frame number := 1
+  
+  ; output file
+  ; for future compatibility, do not use an extension in the name of the
+  ; output file. It will be added automatically
+  output filename := ${OUTPUT}
+
+  ; default value for next is -1, meaning 'all segments'
+  ; maximum absolute segment number to process := 
+ 
+
+  ; use data in the input file, or substitute data with all 1's
+  ; (useful to get correction factors only)
+  ; default is '1'
+  use data (1) or set to one (0) := 0
+
+  ; precorrect data, or undo precorrection
+  ; default is '1'
+  ; apply (1) or undo (0) correction := 
+
+  ; parameters specifying correction factors
+  ; if no value is given, the corresponding correction will not be performed
+
+  ; random coincidences estimate, subtracted before anything else is done
+  ;randoms projdata filename := random.hs
+  ; normalisation (or binwise multiplication, so can contain attenuation factors as well)
+  Bin Normalisation type := From GE HDF5
+  Bin Normalisation From GE HDF5 :=
+  normalisation filename:= ${RDFNORM}
+  End Bin Normalisation From GE HDF5:=
+
+
+END:= 

--- a/examples/GE-PETCT/create_norm_projdata.sh
+++ b/examples/GE-PETCT/create_norm_projdata.sh
@@ -1,0 +1,27 @@
+#! /bin/sh -e
+# Example script to reconstruct GE-Signa PET/MR data with randoms, norm and scatter.
+# Currently supposes you have randoms estimated already.
+# Default filenames are for output of unlist_and_randoms.sh, and for the NEMA demo files
+# Author: Kris Thielemans
+
+# directory with some standard .par files
+: ${pardir:=~/devel/STIR/examples/GE-Signa-PETMR}
+
+if [ $# -ne 3 ]; then
+  echo "Usage: `basename $0` output_filename_prefix RDF_norm_filename template_filename"
+  echo "This creates a projdata with the normalisation factors"
+  exit 1
+fi
+
+norm_sino_prefix=$1
+# note: variable name is used in correct_projdata_for_norm.par
+RDFNORM=$2
+export RDFNORM
+template_filename=$3
+
+if [ -r ${norm_sino_prefix}.hs ]; then
+  echo "Reusing existing ${norm_sino_prefix}.hs"
+else
+  echo "Creating ${norm_sino_prefix}.hs"
+  OUTPUT=${norm_sino_prefix} INPUT=${template_filename} correct_projdata ${pardir}/correct_projdata_for_norm.par > ${norm_sino_prefix}.log 2>&1
+fi

--- a/examples/GE-PETCT/process-from-projdata.sh
+++ b/examples/GE-PETCT/process-from-projdata.sh
@@ -1,0 +1,35 @@
+: ${datadir:=`pwd`}
+#~/MyLaptop/University\ College\ London/inm.physics\ -\ Documents/General/phantoms/DMI/dual-phantom-from-GE/exam177_dualPhantom_DMI3R_CT_RAW_RDFv9
+: ${RDF:=${datadir}/raw_HDF5_decompressed/rdf_f1b1.rdf}
+: ${CT:=`ls "${datadir}/CTAC/"*.1.img`}
+
+: ${STIR_install:=~/devel/install/share/doc/stir-5.0}
+: ${pardir:=~/devel/STIR/examples/GE-PETCT/}
+export pardir
+
+for f in "${datadir}/raw_dcm/"*.3.img; do nm_extract -i "$f" -o .; done
+
+randoms=randoms_`basename "${RDF%%.*}"`.hs
+construct_randoms_from_GEsingles "${randoms}" "${RDF}"
+
+# copy prompts to Interfile to get round a limitation of the current
+# RDF reader (it doesn't have get_sinogram(), and is rather slow)
+stir_math -s `basename "${RDF%%.rdf}"`.hs "${RDF}"
+RDF=`basename "${RDF%%.rdf}"`.hs
+
+
+CT_SLOPES_FILENAME=$STIR_install/../../stir/ct_slopes.json
+export CT_SLOPES_FILENAME
+# TODO get kV from the CT dicom header
+kV=120
+export kV
+postfilter ctac.hv  "${CT}"  "${pardir}/GE_HUToMu.par"
+
+RDFNORM=`ls *norm.rdf`
+export RDFNORM
+
+sino_input=${RDF} randoms3d=${randoms} RDFNORM=${RDFNORM} num_subsets=17 num_subiters=42 $pardir/NAC_recon.sh
+
+$pardir/register_GEAC.sh  mu ctac.hv NAC_image_42.hv
+
+sino_input=${RDF} randoms3d=${randoms} RDFNORM=${RDFNORM} atnimg=mu.nii num_subsets=17 num_subiters=140 $pardir/scatter_and_recon.sh

--- a/examples/GE-PETCT/register_GEAC.sh
+++ b/examples/GE-PETCT/register_GEAC.sh
@@ -1,0 +1,32 @@
+#! /bin/sh -e
+# Example script to register MRAC/CTAC files from DICOM to a STIR NAC image, such that it is
+# suitable for attenuation correction.
+# 
+# Relies on reg_aladin from NiftyReg, but you could use other registration algorithms of course
+# Author: Kris Thielemans
+
+# directory with some standard .par files
+: ${pardir:=~/devel/STIR/examples/GE-Signa-PETMR}
+
+if [ $# -ne 3 ]; then
+  echo "Usage: `basename $0` output_filename_prefix GE_AC_filename STIR_NAC_filename"
+  echo 'This creates a Nifti file (called <output_filename_prefix>.nii) with the registered mu-map'
+  exit 1
+fi
+
+output_filename_prefix=$1
+GE_AC_filename=$2
+NAC_filename=$3
+
+# flip GE images to (wrong) output
+invert_axis x ${output_filename_prefix}_prereg.hv ${GE_AC_filename}
+invert_axis z ${output_filename_prefix}_prereg.hv ${output_filename_prefix}_prereg.hv
+
+# convert to Nifti
+stir_math --output-format $pardir/../samples/stir_math_ITK_output_file_format.par ${output_filename_prefix}_prereg.nii ${output_filename_prefix}_prereg.hv
+NAC_filename_nii=${NAC_filename%%.*}_copy.nii
+stir_math --output-format $pardir/../samples/stir_math_ITK_output_file_format.par ${NAC_filename_nii} ${NAC_filename}
+
+# register
+reg_aladin -ref ${NAC_filename_nii} -flo ${output_filename_prefix}_prereg.nii -res ${output_filename_prefix}.nii -rigOnly -speeeeed
+

--- a/examples/GE-PETCT/scanner.py
+++ b/examples/GE-PETCT/scanner.py
@@ -1,0 +1,22 @@
+>>> import stir
+p=stir.ProjData.read_from_file('rdf_f1b1.hs')
+p=stir.ProjData.read_from_file('output/fullefffactorsspan2.hs')
+s=p.get_proj_data_info().get_scanner()
+
+% not for ST
+import math
+import numpy
+s=stir.Scanner.get_scanner_from_name('Discovery MI3')
+#s=stir.Scanner.get_scanner_from_name('GE Signa PET/MR')
+nc=s.get_num_crystals_per_ring()
+nc=s.get_num_detectors_per_ring()
+ncb=s.get_num_transaxial_crystals_per_block()
+nbb=s.get_num_transaxial_blocks_per_bucket()
+R=s.get_effective_ring_radius()
+crystal_size=2*math.pi*R/nc
+print(crystal_size)
+#crystal_size=4.2
+
+
+print(numpy.arctan(ncb*nbb/2*crystal_size / R)*180/math.pi)
+print(s.get_intrinsic_azimuthal_tilt()*180/math.pi)

--- a/examples/GE-PETCT/scatter_and_recon.sh
+++ b/examples/GE-PETCT/scatter_and_recon.sh
@@ -1,0 +1,86 @@
+#! /bin/sh -e
+# Example script to reconstruct GE-Signa PET/MR data with randoms, norm and scatter.
+# Currently supposes you have randoms estimated already.
+# Default filenames are for output of unlist_and_randoms.sh.
+# Author: Kris Thielemans
+# Edits: Ander Biguri
+
+# directory with some standard .par files
+: ${pardir:=~/devel/STIR/examples/GE-Signa-PETMR}
+
+# names are from unlist_and_randoms
+: ${sino_input:=sinospan2_f1g1d0b0.hs}
+: ${randoms3d:=randomsspan2.hs}
+export sino_input randoms3d # used by scatter_estimation.par
+
+: ${num_subsets:=14}
+: ${num_subiters:=42}
+
+# RDF9 norm file 
+# note: variable name is used in correct_projdata.par
+: ${RDFNORM:=norm3d}
+export RDFNORM
+
+: ${atnimg:=att.hv}
+export atnimg # used in scatter_estimation.par
+
+# we will put most intermediate files in a separate directory
+# note that the scatter code will also create an `extras` folder in the current directory
+mkdir -p output
+
+# output name (or input if it exists already) for normalisation sinogram
+: ${norm_sino_prefix:=output/fullnormfactorsspan2}
+${pardir}/create_norm_projdata.sh ${norm_sino_prefix} ${RDFNORM} ${sino_input}
+
+: ${acf3d:=output/acf.hs} # will be created if it doesn't exist yet
+export acf3d  # used in scatter_estimation.par
+
+# image 0 everywhere where activity is zero, 1 elsewhere
+: ${mask_image:=output/mask_image.hv}  # will be created by masking the attenuation image
+
+# use some more memorable names
+data3d=${sino_input}
+norm3d=${norm_sino_prefix}.hs
+
+# compute 3D ACFs
+if [ -r ${acf3d} ]; then
+  echo "Reusing existing ACFs ${acf3d}"
+else
+  echo "Creating ACFs ${acf3d}"
+  calculate_attenuation_coefficients --PMRT  --ACF ${acf3d} ${atnimg} ${data3d} 
+fi
+
+### estimate scatter
+
+echo "Estimating scatter (be patient). Log saved in output/scatter.log"
+
+# filename-prefix for additive sino (i.e. "precorrected" sum of scatter and randoms)
+total_additive_prefix=output/total_additive
+num_scat_iters=3
+scatter_pardir=${pardir}/../samples/scatter_estimation_par_files
+# you might have to change this for a different scanner than the Signa PET/MR
+# (it needs to be a divisor of the number of views)
+scatter_recon_num_subiterations=$num_subsets
+scatter_recon_num_subsets=$num_subsets
+export scatter_pardir
+export num_scat_iters total_additive_prefix
+export scatter_recon_num_subiterations scatter_recon_num_subsets
+NORM=${norm3d} mask_image=${mask_image} mask_projdata_filename=output/mask2d.hs scatter_prefix=output/scatter \
+    estimate_scatter $scatter_pardir/scatter_estimation.par 2>&1 | tee output/scatter.log 
+# output for recon
+additive_sino=${total_additive_prefix}_${num_scat_iters}.hs
+
+### do an image reconstruction
+
+stir_math -s --mult output/mult_factors_3d.hs  ${acf3d} ${norm3d}
+
+# FBP recon (currently commented out, not checked)
+#stir_math -s --mult precorrected_data3d.hs ${data3d} mult_factors_3d.hs
+#stir_subtract -s --accumulate  precorrected_data3d.hs ${additive_sino}
+#ZOOM=.4 INPUT=precorrected_data3d.hs OUTPUT=final_activity_image_3d FBP3DRP FBP3DRP.par
+
+echo "Running OSMAPOSL"
+echo "Log will be in final_activity_image.log"
+INPUT=${data3d} OUTPUT=final_activity_image NORM=output/mult_factors_3d.hs ADDSINO=${additive_sino} \
+     SUBSETS=$num_subsets SUBITERS=$num_subiters SAVEITERS=$num_subsets SENS=output/subset_sens RECOMP_SENS=1 \
+     OSMAPOSL ${pardir}/OSMAPOSLbackground.par 2>&1 | tee final_activity_image.log


### PR DESCRIPTION
I'm putting it here as a start, but it is very preliminary right now. 
- Assumes you want to process sinograms (but the GE-Signa scripts handle listmode, so can be used here)
- Nac_recon.sh also does norm etc, so this needs to be split
- various assumptions along the way
- a copy of a lot of files from the Signa directory
