### PR TITLE
Fix issue with find_ML_singles_from_delayed when delayed sinogram is out of cwd

### DIFF
--- a/src/utilities/find_ML_singles_from_delayed.cxx
+++ b/src/utilities/find_ML_singles_from_delayed.cxx
@@ -103,16 +103,7 @@ int main(int argc, char **argv)
       // write fan sums to file
       {
         std::string fan_sum_name = "fansums_for_";
-        {
-          // extract filename
-          char sep = '/';
-#ifdef _WIN32
-          sep = '\\';
-#endif
-          std::string fname = argv[2];
-          size_t i = fname.rfind(sep, fname.length());
-          fan_sum_name += fname.substr(i+1, fname.length() - i);
-        }
+        fan_sum_name += get_filename(argv[2]);
 	fan_sum_name.erase(fan_sum_name.begin() + fan_sum_name.rfind('.'), 
 			   fan_sum_name.end());
 	fan_sum_name += ".dat"; 

--- a/src/utilities/find_ML_singles_from_delayed.cxx
+++ b/src/utilities/find_ML_singles_from_delayed.cxx
@@ -103,7 +103,16 @@ int main(int argc, char **argv)
       // write fan sums to file
       {
         std::string fan_sum_name = "fansums_for_";
-	fan_sum_name += argv[2];
+        {
+          // extract filename
+          char sep = '/';
+#ifdef _WIN32
+          sep = '\\';
+#endif
+          std::string fname = argv[2];
+          size_t i = fname.rfind(sep, fname.length());
+          fan_sum_name += fname.substr(i+1, fname.length() - i);
+        }
 	fan_sum_name.erase(fan_sum_name.begin() + fan_sum_name.rfind('.'), 
 			   fan_sum_name.end());
 	fan_sum_name += ".dat"; 


### PR DESCRIPTION
Fixes #848
If the delayed data sinogram was a path, saving/loading the fan_sum data would error because the path would be `fansums_for_${FullPath}.dat` 

This fix extracts the filename from a path and so it will save the fansums as `fansums_for_${filename}.dat`