### PR TITLE
Adds the ability to exclude_trues when unlisting ROOT files

### DIFF
--- a/documentation/STIR-UsersGuide.tex
+++ b/documentation/STIR-UsersGuide.tex
@@ -799,6 +799,51 @@ in conjunction with the \textit{LMF} library. However, these might be obsolete
 as the OpenGATE project might be distributing files
 to enable STIR to read \textit{LMF} format files.
 
+\subsubsubsection{ROOT exclusion keys configurations}
+The \textit{exclude xxx events := 0} keys can be used to process specific types of events.
+Below is are sets event types that will be processed with an exclusion or combination of exclusions.
+Not not mentioned, the exclusion of event type is false.
+
+\begin{table}[h]
+    \centering
+    \begin{tabular}{ | c | c | }
+        \hline
+        \textbf{Event(s) type} & \textbf{Exclusion Configuration}
+        \\ \hline \hline
+        All events & \textit{None}
+
+        \\ \hline \hline
+        \vtop{\hbox{\strut Scattered from same eventID }
+        \hbox{\strut Unscattered from same eventID}}
+        & \textit{exclude random events := 1}
+        \\ \hline
+        \vtop{\hbox{\strut Unscattered from same eventID }
+        \hbox{\strut Unscattered from different eventIDs}}
+        & \textit{exclude scattered events := 1}
+        \\ \hline
+        \vtop{\hbox{\strut Scattered from different eventIDs }
+        \hbox{\strut Unscattered from different eventIDs}}
+        & \textit{exclude non-random events := 1}
+        \\ \hline
+        \vtop{\hbox{\strut Scattered from same eventID}
+        \hbox{\strut Scattered from different eventIDs}}
+        & \textit{exclude unscattered events := 1}
+
+        \\ \hline \hline
+        Unscattered from same eventID & \vtop{\hbox{\strut \textit{exclude random events := 1} }\hbox{\strut \textit{exclude scattered events := 1}}}
+        \\ \hline
+        Unscattered from different eventIDs &  \vtop{\hbox{\strut \textit{exclude non-random events := 1} }\hbox{\strut \textit{exclude scattered events := 1}}}
+        \\ \hline
+        Scattered from same eventID  & \vtop{\hbox{\strut \textit{exclude random events := 1} }\hbox{\strut \textit{exclude unscattered events := 1}}}
+        \\ \hline
+        Scattered from different eventIDs & \vtop{\hbox{\strut \textit{exclude non-random events := 1} }\hbox{\strut \textit{exclude unscattered events := 1}}}
+        \\ \hline
+    \end{tabular}
+    \caption{A guide on how to process specific types of events from a ROOT file using various exclusion keys and combinations of keys.}
+    \label{tab:ROOT_file_exclusions}
+\end{table}
+
+
 \subsection{Multi header format}
 \label{multi-file-format}
 It is often useful to be able to constract a single dataset from multiply components (e.g. images

--- a/documentation/STIR-UsersGuide.tex
+++ b/documentation/STIR-UsersGuide.tex
@@ -770,8 +770,13 @@ GATE_Cylindrical_PET Parameters :=
   number of crystals_Z := 4
 
   Singles readout depth := 1
+
+  ; exclude different event types
+  exclude non-random events := 0
+  exclude unscattered events := 0
   exclude scattered events := 0
   exclude random events := 0
+
   offset (num of detectors) := 0
 
   low energy window (keV) := 0      ; Default 0

--- a/documentation/STIR-UsersGuide.tex
+++ b/documentation/STIR-UsersGuide.tex
@@ -800,9 +800,9 @@ as the OpenGATE project might be distributing files
 to enable STIR to read \textit{LMF} format files.
 
 \subsubsubsection{ROOT exclusion keys configurations}
-The \textit{exclude xxx events := 0} keys can be used to process specific types of events.
+The \textit{exclude xxx events := 1} keys can be used to process specific types of events.
 Below is are sets event types that will be processed with an exclusion or combination of exclusions.
-Not not mentioned, the exclusion of event type is false.
+The exclusions of an event type is false by default.
 
 \begin{table}[h]
     \centering

--- a/documentation/STIR-UsersGuide.tex
+++ b/documentation/STIR-UsersGuide.tex
@@ -801,7 +801,7 @@ to enable STIR to read \textit{LMF} format files.
 
 \subsubsubsection{ROOT exclusion keys configurations}
 The \textit{exclude xxx events := 1} keys can be used to process specific types of events.
-Below is are sets event types that will be processed with an exclusion or combination of exclusions.
+Below are sets event types that will be processed with an exclusion or combination of exclusions.
 The exclusions of an event type is false by default.
 
 \begin{table}[h]

--- a/documentation/release_5.0.htm
+++ b/documentation/release_5.0.htm
@@ -140,8 +140,9 @@ Backward compatibility for reconstructed images can be achieved by setting the <
   In some cases, there could only be a single time frame (start to end of the study).
   </li>
 <li><tt>apply_patlak_to_images</tt> no longer uses an existing file as a template for the dynamic image but will overwrite it.</li>
-	<li><tt>ROOT</tt> file I/O improvements no longer gets entire entry's tree and instead loads individual branches as needed.
-    ROOT file reading is now up to 4x faster. In addition, there is now an option <tt>check energy window information</tt> (defaulting to on).</li>
+	<li><tt>ROOT</tt> file I/O improvements. An entire entry's tree is no longer loaded by default and instead individual branches are loaded as needed.
+    ROOT file event processing is now up to 4x faster. In addition, there is now an option to <tt>check energy window information</tt> (defaulting to on).
+    Futhermore, added functionality to exclude true and unscattered event types from list mode processing. </li>
 </ul>
 
 

--- a/examples/samples/root_header.hroot
+++ b/examples/samples/root_header.hroot
@@ -37,6 +37,8 @@ number of crystals_Y := 1
 number of crystals_Z := 4
 
 Singles readout depth := 1
+exclude unscattered events := 0
+exclude non-random events := 0
 exclude scattered events := 0
 exclude random events := 0
 check energy window information := 1

--- a/examples/samples/root_headerECAT.hroot
+++ b/examples/samples/root_headerECAT.hroot
@@ -45,6 +45,12 @@ number of crystals Z := 8
 ; per singles unit. 
 Singles readout depth := 1
 
+; If set the unscattered events will be skipped (Default := 0)
+exclude unscattered events := 0
+
+; If set the true events will be skipped (Default := 0)
+exclude non-random events := 0
+
 ; If set the scattered events will be skipped (Default := 0)
 exclude scattered events := 0
 

--- a/src/IO/InputStreamFromROOTFile.cxx
+++ b/src/IO/InputStreamFromROOTFile.cxx
@@ -174,10 +174,10 @@ InputStreamFromROOTFile::set_up(const std::string & header_path)
       // Ensure that two conflicting exclusions are not applied
       if (this->exclude_trues && this->exclude_randoms)
         error("InputStreamFromROOTFile: Both the exclusion of true and random events has been set. Therefore, "
-              "no data will be processes.");
+              "no data will be processed.");
       if (this->exclude_scattered && this->exclude_unscattered)
         error("InputStreamFromROOTFile: Both the exclusion of scattered and unscattered events has been set. Therefore, "
-              "no data will be processes.");
+              "no data will be processed.");
 
       // Show which event types will be unlisted based upon the exclusion criteria
       bool trues = true;

--- a/src/IO/InputStreamFromROOTFile.cxx
+++ b/src/IO/InputStreamFromROOTFile.cxx
@@ -68,7 +68,7 @@ InputStreamFromROOTFile::set_defaults()
 {
     starting_stream_position = 0;
     singles_readout_depth = -1;
-    exclude_trues = false;
+    exclude_nonrandom = false;
     exclude_scattered = false;
     exclude_unscattered = false;
     exclude_randoms = false;
@@ -89,7 +89,7 @@ InputStreamFromROOTFile::initialise_keymap()
     this->parser.add_key("name of data file", &this->filename);
     this->parser.add_key("Singles readout depth", &this->singles_readout_depth);
     this->parser.add_key("name of input TChain", &this->chain_name);
-    this->parser.add_key("exclude true events", &this->exclude_trues);
+    this->parser.add_key("exclude non-random events", &this->exclude_nonrandom);
     this->parser.add_key("exclude scattered events", &this->exclude_scattered);
     this->parser.add_key("exclude unscattered events", &this->exclude_unscattered);
     this->parser.add_key("exclude random events", &this->exclude_randoms);
@@ -172,7 +172,7 @@ InputStreamFromROOTFile::set_up(const std::string & header_path)
 
     {
       // Ensure that two conflicting exclusions are not applied
-      if (this->exclude_trues && this->exclude_randoms)
+      if (this->exclude_nonrandom && this->exclude_randoms)
         error("InputStreamFromROOTFile: Both the exclusion of true and random events has been set. Therefore, "
               "no data will be processed.");
       if (this->exclude_scattered && this->exclude_unscattered)
@@ -184,11 +184,11 @@ InputStreamFromROOTFile::set_up(const std::string & header_path)
       bool randoms = true;
       bool scattered = true;
       bool scattered_randoms = true;
-      if ( this->exclude_trues || this->exclude_unscattered)
+      if (this->exclude_nonrandom || this->exclude_unscattered)
         trues = false;
       if ( this->exclude_randoms || this->exclude_unscattered )
         randoms= false;
-      if ( this->exclude_scattered || this->exclude_trues )
+      if ( this->exclude_scattered || this->exclude_nonrandom )
         scattered = false;
       if ( this->exclude_scattered || this->exclude_randoms )
         scattered_randoms = false;
@@ -223,7 +223,7 @@ InputStreamFromROOTFile::check_brentry_randoms_scatter_energy_conditions(Long64_
   }
 
   // Trues/Random event exclusion condition.
-  if (this->exclude_randoms || this->exclude_trues) {
+  if (this->exclude_randoms || this->exclude_nonrandom) {
     GetEntryCheck(br_eventID1->GetEntry(brentry));
     GetEntryCheck(br_eventID2->GetEntry(brentry));
 
@@ -232,7 +232,7 @@ InputStreamFromROOTFile::check_brentry_randoms_scatter_energy_conditions(Long64_
       return false;
 
     // exclude trues
-    if (this->exclude_trues && this->eventID1 == this->eventID2)
+    if (this->exclude_nonrandom && this->eventID1 == this->eventID2)
       return false;
   }
 

--- a/src/include/stir/IO/InputStreamFromROOTFile.h
+++ b/src/include/stir/IO/InputStreamFromROOTFile.h
@@ -157,6 +157,7 @@ public:
 
     inline void set_chain_name(const std::string&);
 
+    inline void set_exclude_true_events(bool);
     inline void set_exclude_scattered_events(bool);
 
     inline void set_exclude_random_events(bool);
@@ -258,6 +259,8 @@ public:
     int num_virtual_axial_crystals_per_block;
     int num_virtual_transaxial_crystals_per_block;
     //@}
+    //! Skip True events (eventID1 == eventID2). Default is false
+    bool exclude_trues;
     //! Skip scattered events (comptonphantom1 > 0 && comptonphantom2 > 0). Default is false
     bool exclude_scattered;
     //! Skip random events (eventID1 != eventID2). Default is false

--- a/src/include/stir/IO/InputStreamFromROOTFile.h
+++ b/src/include/stir/IO/InputStreamFromROOTFile.h
@@ -10,7 +10,7 @@
 */
 /*
  *  Copyright (C) 2015, 2016 University of Leeds
-    Copyright (C) 2016, 2021, 2020 UCL
+    Copyright (C) 2016, 2021, 2020, 2021 UCL
     Copyright (C) 2018 University of Hull
     This file is part of STIR.
 

--- a/src/include/stir/IO/InputStreamFromROOTFile.h
+++ b/src/include/stir/IO/InputStreamFromROOTFile.h
@@ -158,7 +158,10 @@ public:
     inline void set_chain_name(const std::string&);
 
     inline void set_exclude_true_events(bool);
+
     inline void set_exclude_scattered_events(bool);
+
+    inline void set_exclude_unscattered_events(bool);
 
     inline void set_exclude_random_events(bool);
 
@@ -263,6 +266,8 @@ public:
     bool exclude_trues;
     //! Skip scattered events (comptonphantom1 > 0 && comptonphantom2 > 0). Default is false
     bool exclude_scattered;
+    //! Skip unscattered events (comptonphantom1 == 0 && comptonphantom2 == 0)). Default is false
+    bool exclude_unscattered;
     //! Skip random events (eventID1 != eventID2). Default is false
     bool exclude_randoms;
     //! Check energy window information (low_energy_window < energy <  up_energy_window). Default is true

--- a/src/include/stir/IO/InputStreamFromROOTFile.h
+++ b/src/include/stir/IO/InputStreamFromROOTFile.h
@@ -263,7 +263,7 @@ public:
     int num_virtual_transaxial_crystals_per_block;
     //@}
     //! Skip True events (eventID1 == eventID2). Default is false
-    bool exclude_trues;
+    bool exclude_nonrandom;
     //! Skip scattered events (comptonphantom1 > 0 && comptonphantom2 > 0). Default is false
     bool exclude_scattered;
     //! Skip unscattered events (comptonphantom1 == 0 && comptonphantom2 == 0)). Default is false

--- a/src/include/stir/IO/InputStreamFromROOTFile.inl
+++ b/src/include/stir/IO/InputStreamFromROOTFile.inl
@@ -119,6 +119,12 @@ InputStreamFromROOTFile::set_chain_name(const std::string& val)
 }
 
 void
+InputStreamFromROOTFile::set_exclude_true_events(bool val)
+{
+  exclude_trues = val;
+}
+
+void
 InputStreamFromROOTFile::set_exclude_scattered_events(bool val)
 {
     exclude_scattered = val;

--- a/src/include/stir/IO/InputStreamFromROOTFile.inl
+++ b/src/include/stir/IO/InputStreamFromROOTFile.inl
@@ -1,6 +1,6 @@
 /*
  *  Copyright (C) 2015, 2016 University of Leeds
-    Copyright (C) 2016, UCL
+    Copyright (C) 2016, 2021 UCL
     This file is part of STIR.
 
     This file is free software; you can redistribute it and/or modify
@@ -22,6 +22,7 @@
 
   \author Nikos Efthimiou
   \author Harry Tsoumpas
+  \author Robert Twyman
 */
 
 #include "stir/IO/InputStreamFromROOTFile.h"

--- a/src/include/stir/IO/InputStreamFromROOTFile.inl
+++ b/src/include/stir/IO/InputStreamFromROOTFile.inl
@@ -131,6 +131,12 @@ InputStreamFromROOTFile::set_exclude_scattered_events(bool val)
 }
 
 void
+InputStreamFromROOTFile::set_exclude_unscattered_events(bool val)
+{
+  exclude_unscattered = val;
+}
+
+void
 InputStreamFromROOTFile::set_exclude_random_events(bool val)
 {
     exclude_randoms = val;

--- a/src/include/stir/IO/InputStreamFromROOTFile.inl
+++ b/src/include/stir/IO/InputStreamFromROOTFile.inl
@@ -121,7 +121,7 @@ InputStreamFromROOTFile::set_chain_name(const std::string& val)
 void
 InputStreamFromROOTFile::set_exclude_true_events(bool val)
 {
-  exclude_trues = val;
+  exclude_nonrandom = val;
 }
 
 void


### PR DESCRIPTION
There are two debugging variables used in unlisting ROOT files, i.e. `exclude_randoms` and `exclude_scattered`. Therefore True (`trues`) events are always unlisted making the unlisting of only scattered and random events difficult, requiring 2 unlistings and `stir_math`. 

The current unlisting combination, always include `trues` results in the following combination
 x | **Exclude Randoms=1** | **Exclude Randoms=0**
--- | --- | ---
**Exclude Scattered=1** | `T` | `T` + `R`
**Exclude Scattered=0** | `T` + `S` | `T` + `R` + `S` + `RS`

where `T` = True and unscattered event, `R` = Random and unscattered event, `S` = True but Scattered event, and `RS` is a Random and Scattered event.

____
**`exclude_trues=1`**


This PR addes the ability to `exclude_trues=1`, resulting in the following possible combinations
 x | **Exclude Randoms=1** | **Exclude Random=0**
--- | --- | ---
**Exclude Scattered=1** | None | `R`
**Exclude Scattered=0** | None | `R` + `RS`

which allows the unlisting of Random and Random scattered event.

____
**`exclude_unscattered=1`**

It also adds the ability to `exclude_unscattered=1`, resulting in the following possible combinations
 x | **Exclude Randoms=1** | **Exclude Randoms=0**
--- | --- | ---
**Exclude Scattered=1** | None | None
**Exclude Scattered=0** | `S` | `S` + `RS`


--------
 Additionally, in the `set_up`, if all events will be excluded then an error will be thrown, i.e. 
```exclude_unscattered=1 && exclude_scattered=1```
 AND 
```exclude_trues=1 && exclude_randoms=1```

TODO (pending general approval):

- [ ] Add documentation regarding usage
- [ ] Update the example `*.hroot` files
- [ ] Add to usersguide regarding the possible combinations detailed here.
- [ ] Add to release notes