### PR TITLE
[CMake] explicitly add .cxx extensions

### DIFF
--- a/src/IO/CMakeLists.txt
+++ b/src/IO/CMakeLists.txt
@@ -24,56 +24,56 @@ set(dir IO)
 set (dir_LIB_SOURCES ${dir}_LIB_SOURCES)
 
 set(${dir_LIB_SOURCES}
-  OutputFileFormat 
-  OutputFileFormat_default 
-  InterfileOutputFileFormat
-  interfile InterfileHeader InterfilePDFSHeaderSPECT
-  InterfileHeaderSiemens
-  InputFileFormatRegistry 
-  InterfileDynamicDiscretisedDensityOutputFileFormat 
-  InterfileParametricDiscretisedDensityOutputFileFormat
-  MultiDynamicDiscretisedDensityOutputFileFormat
+  OutputFileFormat.cxx
+  OutputFileFormat_default.cxx
+  InterfileOutputFileFormat.cxx
+  interfile InterfileHeader InterfilePDFSHeaderSPECT.cxx
+  InterfileHeaderSiemens.cxx
+  InputFileFormatRegistry.cxx
+  InterfileDynamicDiscretisedDensityOutputFileFormat.cxx
+  InterfileParametricDiscretisedDensityOutputFileFormat.cxx
+  MultiDynamicDiscretisedDensityOutputFileFormat.cxx
 
-  GIPL_ImageFormat
-  stir_ecat_common 
+  GIPL_ImageFormat.cxx
+  stir_ecat_common.cxx
 ) 
 
 # we can use IO from the itk library
 if (ITK_FOUND)
   list(APPEND ${dir_LIB_SOURCES}
-    ITKOutputFileFormat
-    ITKImageInputFileFormat  
+    ITKOutputFileFormat.cxx
+    ITKImageInputFileFormat.cxx
  )
 endif()
 
 if (LLN_FOUND)
  list(APPEND ${dir_LIB_SOURCES}
-    ECAT7OutputFileFormat stir_ecat7 
-    ECAT6OutputFileFormat 
-    ECAT7ParametricDensityOutputFileFormat 
-    ECAT7DynamicDiscretisedDensityOutputFileFormat 
-    ECAT7DynamicDiscretisedDensityInputFileFormat
-    stir_ecat6 ecat6_utils
+    ECAT7OutputFileFormat.cxx stir_ecat7.cxx
+    ECAT6OutputFileFormat.cxx
+    ECAT7ParametricDensityOutputFileFormat.cxx
+    ECAT7DynamicDiscretisedDensityOutputFileFormat.cxx
+    ECAT7DynamicDiscretisedDensityInputFileFormat.cxx
+    stir_ecat6.cxx ecat6_utils.cxx
  )
 endif()
 
 if (CERN_ROOT_FOUND)
  list(APPEND ${dir_LIB_SOURCES}
-    InputStreamFromROOTFile
-    InputStreamFromROOTFileForCylindricalPET
-    InputStreamFromROOTFileForECATPET
+    InputStreamFromROOTFile.cxx
+    InputStreamFromROOTFileForCylindricalPET.cxx
+    InputStreamFromROOTFileForECATPET.cxx
  )
 endif()
 
 if (HDF5_FOUND)
  list(APPEND ${dir_LIB_SOURCES}
-    GEHDF5Wrapper
+    GEHDF5Wrapper.cxx
  )
 endif()
 
 if(AVW_FOUND)
   list(APPEND ${dir_LIB_SOURCES}
-    stir_AVW
+    stir_AVW.cxx
   )
 endif()
 

--- a/src/Shape_buildblock/CMakeLists.txt
+++ b/src/Shape_buildblock/CMakeLists.txt
@@ -5,12 +5,12 @@ set(dir Shape_buildblock)
 set (dir_LIB_SOURCES ${dir}_LIB_SOURCES)
 
 set(${dir_LIB_SOURCES}
-  Shape3D 
-  DiscretisedShape3D 
-  Shape3DWithOrientation 
-  Ellipsoid 
-  EllipsoidalCylinder 
-  Box3D
+  Shape3D.cxx
+  DiscretisedShape3D.cxx
+  Shape3DWithOrientation.cxx
+  Ellipsoid.cxx
+  EllipsoidalCylinder.cxx
+  Box3D.cxx
 )
 
 #$(dir)_REGISTRY_SOURCES:= $(dir)_registries

--- a/src/SimSET/CMakeLists.txt
+++ b/src/SimSET/CMakeLists.txt
@@ -24,8 +24,8 @@ set(dir_EXE_SOURCES ${dir}_EXE_SOURCES)
 
 # routines that need linking with the STIR library
 set(${dir_EXE_SOURCES}
-	conv_SimSET_projdata_to_STIR
-	conv_to_SimSET_att_image
+	conv_SimSET_projdata_to_STIR.cxx
+	conv_to_SimSET_att_image.cxx
 )
 
 include(stir_exe_targets)

--- a/src/analytic/FBP2D/CMakeLists.txt
+++ b/src/analytic/FBP2D/CMakeLists.txt
@@ -6,8 +6,8 @@ set(dir analytic_FBP2D)
 set (dir_LIB_SOURCES ${dir}_LIB_SOURCES)
 
 set(${dir_LIB_SOURCES}
-	RampFilter 
-	FBP2DReconstruction
+	RampFilter.cxx
+	FBP2DReconstruction.cxx
 )
 
 #$(dir)_REGISTRY_SOURCES:= 
@@ -18,7 +18,7 @@ target_link_libraries(analytic_FBP2D recon_buildblock IO )
 set (dir_EXE_SOURCES ${dir}_EXE_SOURCES)
 
 set(${dir_EXE_SOURCES}
-	FBP2D
+	FBP2D.cxx
 )
 
 include(stir_exe_targets)

--- a/src/analytic/FBP3DRP/CMakeLists.txt
+++ b/src/analytic/FBP3DRP/CMakeLists.txt
@@ -6,8 +6,8 @@ set(dir analytic_FBP3DRP)
 set (dir_LIB_SOURCES ${dir}_LIB_SOURCES)
 
 set(${dir_LIB_SOURCES}
-	ColsherFilter 
-	FBP3DRPReconstruction
+	ColsherFilter.cxx
+	FBP3DRPReconstruction.cxx
 )
 
 #$(dir)_REGISTRY_SOURCES:= 
@@ -18,7 +18,7 @@ target_link_libraries(analytic_FBP3DRP analytic_FBP2D recon_buildblock  )
 set (dir_EXE_SOURCES ${dir}_EXE_SOURCES)
 
 set(${dir_EXE_SOURCES}
-	FBP3DRP
+	FBP3DRP.cxx
 )
 
 include(stir_exe_targets)

--- a/src/buildblock/CMakeLists.txt
+++ b/src/buildblock/CMakeLists.txt
@@ -3,95 +3,95 @@ set(dir buildblock)
 set (dir_LIB_SOURCES ${dir}_LIB_SOURCES)
 
 set(${dir_LIB_SOURCES}
-  Array  
-  IndexRange 
-  PatientPosition
-  ExamInfo
-  ExamData
-  ProjData 
-  ProjDataInfo 
-  ProjDataInfoCylindrical 
-  ProjDataInfoCylindricalArcCorr 
-  ProjDataInfoCylindricalNoArcCorr 
-  ArcCorrection 
-  ProjDataFromStream  
-  ProjDataGEAdvance
-  ProjDataInMemory 
-  ProjDataInterfile 
-  Scanner 
-  SegmentBySinogram 
-  Segment 
-  SegmentByView 
-  Viewgram
-  Verbosity
-  Sinogram 
-  RelatedViewgrams 
-  scale_sinograms 
-  interpolate_projdata 
-  extend_projdata
-  multiply_crystal_factors
-  DiscretisedDensity 
-  VoxelsOnCartesianGrid 
-  ParseDiscretisedDensityParameters
-  utilities 
-  interfile_keyword_functions 
-  zoom 
-  NumericType ByteOrder 
-  KeyParser  
-  recon_array_functions 
-  linear_regression overlap_interpolate 
-  error warning
-  TextWriter
-  DataSymmetriesForViewSegmentNumbers 
-  TimeFrameDefinitions 
-  ParsingObject 
-	ArrayFilter1DUsingConvolutionSymmetricKernel 
-	ArrayFilterUsingRealDFTWithPadding 
-	SeparableArrayFunctionObject 
-	SeparableMetzArrayFilter 
-        SeparableGaussianImageFilter
-        SeparableGaussianArrayFilter
-	MedianArrayFilter3D 
-	MedianImageFilter3D 
-	MinimalArrayFilter3D 
-	MinimalImageFilter3D 
-	SeparableCartesianMetzImageFilter 
-	TruncateToCylindricalFOVImageProcessor 
-	ThresholdMinToSmallPositiveValueDataProcessor 
-	ChainedDataProcessor 
-	ArrayFilter1DUsingConvolution 
-	SeparableConvolutionImageFilter 
-	NonseparableConvolutionUsingRealDFTImageFilter 
-	SSRB 
-	inverse_SSRB 
-	centre_of_gravity 
-	DynamicDiscretisedDensity 
-	DynamicProjData 
-	MultipleProjData 
-  MultipleDataSetHeader
-	GatedProjData 
-	ArrayFilter2DUsingConvolution 
-	ArrayFilter3DUsingConvolution 
-	find_fwhm_in_image
-        GatedDiscretisedDensity
-        MaximalArrayFilter3D
-        MaximalImageFilter3D
-        TimeGateDefinitions
-	ML_norm
-        num_threads
-        GeneralisedPoissonNoiseGenerator
-        FilePath
-        date_time_functions
+  Array.cxx
+  IndexRange.cxx
+  PatientPosition.cxx
+  ExamInfo.cxx
+  ExamData.cxx
+  ProjData.cxx
+  ProjDataInfo.cxx
+  ProjDataInfoCylindrical.cxx
+  ProjDataInfoCylindricalArcCorr.cxx
+  ProjDataInfoCylindricalNoArcCorr.cxx
+  ArcCorrection.cxx
+  ProjDataFromStream.cxx
+  ProjDataGEAdvance.cxx
+  ProjDataInMemory.cxx
+  ProjDataInterfile.cxx
+  Scanner.cxx
+  SegmentBySinogram.cxx
+  Segment.cxx
+  SegmentByView.cxx
+  Viewgram.cxx
+  Verbosity.cxx
+  Sinogram.cxx
+  RelatedViewgrams.cxx
+  scale_sinograms.cxx
+  interpolate_projdata.cxx
+  extend_projdata.cxx
+  multiply_crystal_factors.cxx
+  DiscretisedDensity.cxx
+  VoxelsOnCartesianGrid.cxx
+  ParseDiscretisedDensityParameters.cxx
+  utilities.cxx
+  interfile_keyword_functions.cxx
+  zoom.cxx
+  NumericType ByteOrder.cxx
+  KeyParser.cxx
+  recon_array_functions.cxx
+  linear_regression overlap_interpolate.cxx
+  error warning.cxx
+  TextWriter.cxx
+  DataSymmetriesForViewSegmentNumbers.cxx
+  TimeFrameDefinitions.cxx
+  ParsingObject.cxx
+	ArrayFilter1DUsingConvolutionSymmetricKernel.cxx
+	ArrayFilterUsingRealDFTWithPadding.cxx
+	SeparableArrayFunctionObject.cxx
+	SeparableMetzArrayFilter.cxx
+        SeparableGaussianImageFilter.cxx
+        SeparableGaussianArrayFilter.cxx
+	MedianArrayFilter3D.cxx
+	MedianImageFilter3D.cxx
+	MinimalArrayFilter3D.cxx
+	MinimalImageFilter3D.cxx
+	SeparableCartesianMetzImageFilter.cxx
+	TruncateToCylindricalFOVImageProcessor.cxx
+	ThresholdMinToSmallPositiveValueDataProcessor.cxx
+	ChainedDataProcessor.cxx
+	ArrayFilter1DUsingConvolution.cxx
+	SeparableConvolutionImageFilter.cxx
+	NonseparableConvolutionUsingRealDFTImageFilter.cxx
+	SSRB.cxx
+	inverse_SSRB.cxx
+	centre_of_gravity.cxx
+	DynamicDiscretisedDensity.cxx
+	DynamicProjData.cxx
+	MultipleProjData.cxx
+  MultipleDataSetHeader.cxx
+	GatedProjData.cxx
+	ArrayFilter2DUsingConvolution.cxx
+	ArrayFilter3DUsingConvolution.cxx
+	find_fwhm_in_image.cxx
+        GatedDiscretisedDensity.cxx
+        MaximalArrayFilter3D.cxx
+        MaximalImageFilter3D.cxx
+        TimeGateDefinitions.cxx
+	ML_norm.cxx
+        num_threads.cxx
+        GeneralisedPoissonNoiseGenerator.cxx
+        FilePath.cxx
+        date_time_functions.cxx
 )
 if (HAVE_HDF5)
  list(APPEND ${dir_LIB_SOURCES}
-    ProjDataGEHDF5
+    ProjDataGEHDF5.cxx
     )
 endif()
 
 if (NOT HAVE_SYSTEM_GETOPT)
   # add our own version of getopt to buildblock
-  list(APPEND ${dir_LIB_SOURCES} getopt)
+  list(APPEND ${dir_LIB_SOURCES} getopt.c)
 endif()
 
 include(stir_lib_target)

--- a/src/cmake/stir_exe_targets.cmake
+++ b/src/cmake/stir_exe_targets.cmake
@@ -2,7 +2,7 @@
 #
 # Copyright 2011-01-01 - 2011-06-30 Hammersmith Imanet Ltd
 # Copyright 2011-07-01 - 2013 Kris Thielemans
-# Copyright 2016 University College London
+# Copyright 2016,2021 University College London
 
 # This file is part of STIR.
 #
@@ -26,15 +26,13 @@
 # NIKOS EFTHIMIOU
 # Added dependency on ALL_HEADERS and ALL_INLINES in order
 # to display .h and .inl files in Qt-Creator
-foreach(executable ${${dir_EXE_SOURCES}})
- if(BUILD_EXECUTABLES)
-   add_executable(${executable} ${ALL_HEADERS} ${ALL_INLINES}  ${ALL_TXXS} ${executable} ${STIR_REGISTRIES})
+foreach(source ${${dir_EXE_SOURCES}})
+  if(BUILD_EXECUTABLES)
+   get_filename_component(executable ${source} NAME_WE)
+   add_executable(${executable} ${ALL_HEADERS} ${ALL_INLINES}  ${ALL_TXXS} ${source} ${STIR_REGISTRIES})
    target_link_libraries(${executable} ${STIR_LIBRARIES})
    SET_PROPERTY(TARGET ${executable} PROPERTY FOLDER "Executables")
    target_include_directories(${executable} PUBLIC ${Boost_INCLUDE_DIR})
+   install(TARGETS ${executable} DESTINATION bin)
   endif()
 endforeach()
-
-if(BUILD_EXECUTABLES)
- install(TARGETS ${${dir_EXE_SOURCES}} DESTINATION bin)
-endif()

--- a/src/data_buildblock/CMakeLists.txt
+++ b/src/data_buildblock/CMakeLists.txt
@@ -24,19 +24,19 @@ set(dir  data_buildblock)
 set (dir_LIB_SOURCES ${dir}_LIB_SOURCES)
 
 set(${dir_LIB_SOURCES}
-	SinglesRates 
-	SinglesRatesForTimeFrames
-        randoms_from_singles
+	SinglesRates.cxx
+	SinglesRatesForTimeFrames.cxx
+        randoms_from_singles.cxx
 )
 if (HAVE_ECAT)
   list(APPEND  ${dir_LIB_SOURCES}
-	SinglesRatesFromSglFile 
-	SinglesRatesFromECAT7  
+	SinglesRatesFromSglFile.cxx
+	SinglesRatesFromECAT7.cxx
   )
 endif()
 if (HAVE_HDF5)
     list (APPEND  ${dir_LIB_SOURCES}
-        SinglesFromGEHDF5
+        SinglesFromGEHDF5.cxx
   )
 endif()
 

--- a/src/display/CMakeLists.txt
+++ b/src/display/CMakeLists.txt
@@ -5,7 +5,7 @@ set(dir display)
 
 set (dir_LIB_SOURCES ${dir}_LIB_SOURCES)
 set(${dir}_LIB_SOURCES 
-	  display_array
+	  display_array.cxx
 )
 
 find_package(X11)
@@ -23,7 +23,7 @@ set(GRAPHICS ${default_GRAPHICS}
 if( "${GRAPHICS}" STREQUAL "X")
 	set(${dir}_LIB_SOURCES 
 	  ${${dir}_LIB_SOURCES}
-	  gen screengen screen
+	  gen.c screengen.c screen.c
 	)
 	ADD_DEFINITIONS(-DSTIR_SIMPLE_BITMAPS -DSC_XWINDOWS)
 

--- a/src/experimental/motion_utilities/CMakeLists.txt
+++ b/src/experimental/motion_utilities/CMakeLists.txt
@@ -22,9 +22,9 @@ set(dir local_motion_utilities)
 set(dir_EXE_SOURCES ${dir}_EXE_SOURCES)
 
 set(${dir_EXE_SOURCES}
-  rigid_object_transform_projdata
-  rigid_object_transform_image
-  non_rigid_transform
+  rigid_object_transform_projdata.cxx
+  rigid_object_transform_image.cxx
+  non_rigid_transform.cxx
 )
 
 #include(stir_exe_targets)

--- a/src/experimental/recon_buildblock/CMakeLists.txt
+++ b/src/experimental/recon_buildblock/CMakeLists.txt
@@ -24,7 +24,7 @@ set(dir local_recon_buildblock)
 set (dir_LIB_SOURCES ${dir}_LIB_SOURCES)
 
 set(${dir_LIB_SOURCES}
- PostsmoothingForwardProjectorByBin
+ PostsmoothingForwardProjectorByBin.cxx
 )
 
 include(stir_lib_target)

--- a/src/experimental/utilities/CMakeLists.txt
+++ b/src/experimental/utilities/CMakeLists.txt
@@ -18,8 +18,8 @@ set(dir local_utilities)
 set(dir_EXE_SOURCES ${dir}_EXE_SOURCES)
 
 set(${dir_EXE_SOURCES}
-create_normfactors3D
-create_normfactors
+create_normfactors3D.cxx
+create_normfactors.cxx
 )
 
 

--- a/src/iterative/KOSMAPOSL/CMakeLists.txt
+++ b/src/iterative/KOSMAPOSL/CMakeLists.txt
@@ -4,7 +4,7 @@ set(dir iterative_KOSMAPOSL)
 set (dir_LIB_SOURCES ${dir}_LIB_SOURCES)
 
 set(${dir_LIB_SOURCES}
-	KOSMAPOSLReconstruction
+	KOSMAPOSLReconstruction.cxx
 )
 
 #$(dir)_REGISTRY_SOURCES:= 
@@ -14,7 +14,7 @@ include(stir_lib_target)
 set (dir_EXE_SOURCES ${dir}_EXE_SOURCES)
 
 set(${dir_EXE_SOURCES}
-	KOSMAPOSL
+	KOSMAPOSL.cxx
 )
 
 include(stir_exe_targets)

--- a/src/iterative/OSMAPOSL/CMakeLists.txt
+++ b/src/iterative/OSMAPOSL/CMakeLists.txt
@@ -4,7 +4,7 @@ set(dir iterative_OSMAPOSL)
 set (dir_LIB_SOURCES ${dir}_LIB_SOURCES)
 
 set(${dir_LIB_SOURCES}
-	OSMAPOSLReconstruction
+	OSMAPOSLReconstruction.cxx
 )
 
 #$(dir)_REGISTRY_SOURCES:= 
@@ -14,7 +14,7 @@ include(stir_lib_target)
 set (dir_EXE_SOURCES ${dir}_EXE_SOURCES)
 
 set(${dir_EXE_SOURCES}
-	OSMAPOSL
+	OSMAPOSL.cxx
 )
 
 include(stir_exe_targets)

--- a/src/iterative/OSSPS/CMakeLists.txt
+++ b/src/iterative/OSSPS/CMakeLists.txt
@@ -4,7 +4,7 @@ set(dir iterative_OSSPS)
 set (dir_LIB_SOURCES ${dir}_LIB_SOURCES)
 
 set(${dir_LIB_SOURCES}
-	OSSPSReconstruction
+	OSSPSReconstruction.cxx
 )
 
 #$(dir)_REGISTRY_SOURCES:= 
@@ -14,7 +14,7 @@ include(stir_lib_target)
 set (dir_EXE_SOURCES ${dir}_EXE_SOURCES)
 
 set(${dir_EXE_SOURCES}
-	OSSPS
+	OSSPS.cxx
 )
 
 

--- a/src/iterative/POSMAPOSL/CMakeLists.txt
+++ b/src/iterative/POSMAPOSL/CMakeLists.txt
@@ -23,7 +23,7 @@ set(dir iterative_POSMAPOSL)
 set(dir_EXE_SOURCES ${dir}_EXE_SOURCES)
 
 set(${dir_EXE_SOURCES}
-   POSMAPOSL
+   POSMAPOSL.cxx
 )
 
 include(stir_exe_targets)

--- a/src/iterative/POSSPS/CMakeLists.txt
+++ b/src/iterative/POSSPS/CMakeLists.txt
@@ -23,7 +23,7 @@ set(dir iterative_POSSPS)
 set(dir_EXE_SOURCES ${dir}_EXE_SOURCES)
 
 set(${dir_EXE_SOURCES}
-   POSSPS
+   POSSPS.cxx
 )
 
 include(stir_exe_targets)

--- a/src/listmode_buildblock/CMakeLists.txt
+++ b/src/listmode_buildblock/CMakeLists.txt
@@ -5,44 +5,44 @@ set(dir listmode_buildblock)
 set (dir_LIB_SOURCES ${dir}_LIB_SOURCES)
 
 set(${dir_LIB_SOURCES}
-        ListModeData
-        ListEvent
-        CListEvent
-        LmToProjDataAbstract
-	LmToProjData 
-        LmToProjDataBootstrap
-	LmToProjDataWithRandomRejection
-        CListModeDataECAT8_32bit
-        CListRecordECAT8_32bit
-	CListModeDataSAFIR
-	DetectorCoordinateMapFromFile
+        ListModeData.cxx
+        ListEvent.cxx
+        CListEvent.cxx
+        LmToProjDataAbstract.cxx
+	LmToProjData.cxx
+        LmToProjDataBootstrap.cxx
+	LmToProjDataWithRandomRejection.cxx
+        CListModeDataECAT8_32bit.cxx
+        CListRecordECAT8_32bit.cxx
+	CListModeDataSAFIR.cxx
+	DetectorCoordinateMapFromFile.cxx
 )
 
 if (HAVE_HDF5)
 list(APPEND ${dir_LIB_SOURCES}
-        CListModeDataGEHDF5
-        # CListRecordGEHDF5
+        CListModeDataGEHDF5.cxx
+        # CListRecordGEHDF5.cxx
 )
 endif()
 
 if (HAVE_ECAT)
   list(APPEND ${dir_LIB_SOURCES}
-	CListModeDataECAT 
-	CListRecordECAT962 
-	CListRecordECAT966 
+	CListModeDataECAT.cxx
+	CListRecordECAT962.cxx
+	CListRecordECAT966.cxx
   )
 endif()
 
 if (HAVE_CERN_ROOT)
 	list(APPEND ${dir_LIB_SOURCES}
-		CListModeDataROOT
-		CListRecordROOT
+		CListModeDataROOT.cxx
+		CListRecordROOT.cxx
 	)
 endif()
 
 if (STIR_WITH_NiftyPET_PROJECTOR)
   list(APPEND ${dir_LIB_SOURCES}
-    NiftyPET_listmode/LmToProjDataNiftyPET
+    NiftyPET_listmode/LmToProjDataNiftyPET.cxx
   )
 endif()
 

--- a/src/listmode_utilities/CMakeLists.txt
+++ b/src/listmode_utilities/CMakeLists.txt
@@ -23,22 +23,22 @@ set(dir listmode_utilities)
 set(dir_EXE_SOURCES ${dir}_EXE_SOURCES)
 
 set(${dir_EXE_SOURCES}
-  lm_to_projdata
-  lm_to_projdata_bootstrap
-  lm_to_projdata_with_random_rejection
-  lm_fansums
-  list_lm_info
-  list_lm_events
-  list_lm_countrates
-)
+  lm_to_projdata.cxx
+  lm_to_projdata_bootstrap.cxx
+  lm_to_projdata_with_random_rejection.cxx
+  lm_fansums.cxx
+  list_lm_info.cxx
+  list_lm_events.cxx
+  list_lm_countrates.cxx
+  )
 
 if (HAVE_ECAT)
   # yes, the LLN files seem to be there, so we can compile more
   list(APPEND ${dir_EXE_SOURCES}
-	scan_sgl_file
-	print_sgl_values
-	rebin_sgl_file
-	add_ecat7_header_to_sgl
+	scan_sgl_file.cxx
+	print_sgl_values.cxx
+	rebin_sgl_file.cxx
+	add_ecat7_header_to_sgl.cxx
   )
 endif()
 

--- a/src/modelling_buildblock/CMakeLists.txt
+++ b/src/modelling_buildblock/CMakeLists.txt
@@ -6,9 +6,9 @@ set(dir modelling_buildblock)
 set (dir_LIB_SOURCES ${dir}_LIB_SOURCES)
 
 set(${dir_LIB_SOURCES}
-	KineticModel 
-	PatlakPlot 
-	ParametricDiscretisedDensity
+	KineticModel.cxx
+	PatlakPlot.cxx
+	ParametricDiscretisedDensity.cxx
 )
 
 #$(dir)_REGISTRY_SOURCES:= modelling_registries

--- a/src/modelling_utilities/CMakeLists.txt
+++ b/src/modelling_utilities/CMakeLists.txt
@@ -23,13 +23,13 @@ set(dir modelling_utilities)
 set(dir_EXE_SOURCES ${dir}_EXE_SOURCES)
 
 set(${dir_EXE_SOURCES}
-	apply_patlak_to_images
-	get_dynamic_images_from_parametric_images
-	make_parametric_image_from_components
-	extract_single_images_from_dynamic_image
-	mult_model_with_dyn_images
-	write_patlak_matrix
-	mult_image_parameters
+	apply_patlak_to_images.cxx
+	get_dynamic_images_from_parametric_images.cxx
+	make_parametric_image_from_components.cxx
+	extract_single_images_from_dynamic_image.cxx
+	mult_model_with_dyn_images.cxx
+	write_patlak_matrix.cxx
+	mult_image_parameters.cxx
 )
 
 include(stir_exe_targets)

--- a/src/numerics_buildblock/CMakeLists.txt
+++ b/src/numerics_buildblock/CMakeLists.txt
@@ -5,8 +5,8 @@ set(dir numerics_buildblock)
 set (dir_LIB_SOURCES ${dir}_LIB_SOURCES)
 
 set(${dir_LIB_SOURCES}
-  fourier
-  determinant
+  fourier.cxx
+  determinant.cxx
 )
 
 #$(dir)_REGISTRY_SOURCES:= $(dir)_registries.cxx

--- a/src/recon_buildblock/CMakeLists.txt
+++ b/src/recon_buildblock/CMakeLists.txt
@@ -22,98 +22,98 @@ set(dir recon_buildblock)
 set (dir_LIB_SOURCES ${dir}_LIB_SOURCES)
 
 set(${dir_LIB_SOURCES}
- ForwardProjectorByBin 
-	ForwardProjectorByBinUsingRayTracing 
-	ForwardProjectorByBinUsingRayTracing_Siddon 
-	PresmoothingForwardProjectorByBin
-	BackProjectorByBin 
-	BackProjectorByBinUsingInterpolation 
-	BackProjectorByBinUsingInterpolation_linear 
-	BackProjectorByBinUsingInterpolation_piecewise_linear 
-	PostsmoothingBackProjectorByBin
-	Reconstruction 
-	AnalyticReconstruction 
-	IterativeReconstruction 
-	distributable 
-	DataSymmetriesForBins 
-	DataSymmetriesForDensels 
-	TrivialDataSymmetriesForBins 
-	DataSymmetriesForBins_PET_CartesianGrid 
-	SymmetryOperation 
-	SymmetryOperations_PET_CartesianGrid 
-        find_basic_vs_nums_in_subset
-	ProjMatrixElemsForOneBin 
-	ProjMatrixElemsForOneDensel 
-	ProjMatrixByBin 
-	ProjMatrixByBinUsingRayTracing 
-	ProjMatrixByBinUsingInterpolation 
-	ProjMatrixByBinFromFile
-	ProjMatrixByBinSPECTUB
-	SPECTUB_Tools
-	SPECTUB_Weight3d
-	ForwardProjectorByBinUsingProjMatrixByBin 
-	BackProjectorByBinUsingProjMatrixByBin 
-	BackProjectorByBinUsingSquareProjMatrixByBin
-	RayTraceVoxelsOnCartesianGrid 
-	ProjectorByBinPair 
-	ProjectorByBinPairUsingProjMatrixByBin 
-	ProjectorByBinPairUsingSeparateProjectors 
-	BinNormalisation 
-	ChainedBinNormalisation 
-	BinNormalisationFromProjData 
-	TrivialBinNormalisation 
-	BinNormalisationFromAttenuationImage 
-	BinNormalisationSPECT
-	GeneralisedPrior 
-	ProjDataRebinning 
-	FourierRebinning
-	PLSPrior
-        QuadraticPrior
-        RelativeDifferencePrior
-	FilterRootPrior 
-	GeneralisedObjectiveFunction 
-	PoissonLogLikelihoodWithLinearModelForMean 
-	PoissonLogLikelihoodWithLinearModelForMeanAndProjData 
-	PoissonLogLikelihoodWithLinearModelForMeanAndListModeData 
-	PoissonLogLikelihoodWithLinearModelForMeanAndListModeDataWithProjMatrixByBin 
-        PoissonLogLikelihoodWithLinearKineticModelAndDynamicProjectionData	
-        PoissonLogLikelihoodWithLinearModelForMeanAndGatedProjDataWithMotion
+ ForwardProjectorByBin.cxx
+	ForwardProjectorByBinUsingRayTracing.cxx
+	ForwardProjectorByBinUsingRayTracing_Siddon.cxx
+	PresmoothingForwardProjectorByBin.cxx
+	BackProjectorByBin.cxx
+	BackProjectorByBinUsingInterpolation.cxx
+	BackProjectorByBinUsingInterpolation_linear.cxx
+	BackProjectorByBinUsingInterpolation_piecewise_linear.cxx
+	PostsmoothingBackProjectorByBin.cxx
+	Reconstruction.cxx
+	AnalyticReconstruction.cxx
+	IterativeReconstruction.cxx
+	distributable.cxx
+	DataSymmetriesForBins.cxx
+	DataSymmetriesForDensels.cxx
+	TrivialDataSymmetriesForBins.cxx
+	DataSymmetriesForBins_PET_CartesianGrid.cxx
+	SymmetryOperation.cxx
+	SymmetryOperations_PET_CartesianGrid.cxx
+        find_basic_vs_nums_in_subset.cxx
+	ProjMatrixElemsForOneBin.cxx
+	ProjMatrixElemsForOneDensel.cxx
+	ProjMatrixByBin.cxx
+	ProjMatrixByBinUsingRayTracing.cxx
+	ProjMatrixByBinUsingInterpolation.cxx
+	ProjMatrixByBinFromFile.cxx
+	ProjMatrixByBinSPECTUB.cxx
+	SPECTUB_Tools.cxx
+	SPECTUB_Weight3d.cxx
+	ForwardProjectorByBinUsingProjMatrixByBin.cxx
+	BackProjectorByBinUsingProjMatrixByBin.cxx
+	BackProjectorByBinUsingSquareProjMatrixByBin.cxx
+	RayTraceVoxelsOnCartesianGrid.cxx
+	ProjectorByBinPair.cxx
+	ProjectorByBinPairUsingProjMatrixByBin.cxx
+	ProjectorByBinPairUsingSeparateProjectors.cxx
+	BinNormalisation.cxx
+	ChainedBinNormalisation.cxx
+	BinNormalisationFromProjData.cxx
+	TrivialBinNormalisation.cxx
+	BinNormalisationFromAttenuationImage.cxx
+	BinNormalisationSPECT.cxx
+	GeneralisedPrior.cxx
+	ProjDataRebinning.cxx
+	FourierRebinning.cxx
+	PLSPrior.cxx
+        QuadraticPrior.cxx
+        RelativeDifferencePrior.cxx
+	FilterRootPrior.cxx
+	GeneralisedObjectiveFunction.cxx
+	PoissonLogLikelihoodWithLinearModelForMean.cxx
+	PoissonLogLikelihoodWithLinearModelForMeanAndProjData.cxx
+	PoissonLogLikelihoodWithLinearModelForMeanAndListModeData.cxx
+	PoissonLogLikelihoodWithLinearModelForMeanAndListModeDataWithProjMatrixByBin.cxx
+        PoissonLogLikelihoodWithLinearKineticModelAndDynamicProjectionData.cxx
+        PoissonLogLikelihoodWithLinearModelForMeanAndGatedProjDataWithMotion.cxx
 )
 
 if (HAVE_ECAT)
  list(APPEND ${dir_LIB_SOURCES}
-	BinNormalisationFromECAT7
+	BinNormalisationFromECAT7.cxx
  )
 endif()
 
 # ECAT8 doesn't need the LLN matrix library
 list(APPEND ${dir_LIB_SOURCES}
-	BinNormalisationFromECAT8
+	BinNormalisationFromECAT8.cxx
 )
 
 if (HAVE_HDF5)
 list(APPEND ${dir_LIB_SOURCES}
-         BinNormalisationFromGEHDF5
+         BinNormalisationFromGEHDF5.cxx
  )
 endif()
 
 if(STIR_MPI)
 set(${dir_LIB_SOURCES}
      ${${dir_LIB_SOURCES}}
-	distributableMPICacheEnabled 
-	distributed_functions 
-	DistributedWorker 
-	DistributedCachingInformation 
-	distributed_test_functions
+	distributableMPICacheEnabled.cxx
+	distributed_functions.cxx
+	DistributedWorker.cxx
+	DistributedCachingInformation.cxx
+	distributed_test_functions.cxx
 )
 endif()
 
 if (STIR_WITH_NiftyPET_PROJECTOR)
   list(APPEND ${dir_LIB_SOURCES}
-    NiftyPET_projector/NiftyPETHelper
-    NiftyPET_projector/ForwardProjectorByBinNiftyPET
-    NiftyPET_projector/BackProjectorByBinNiftyPET
-    NiftyPET_projector/ProjectorByBinPairUsingNiftyPET
+    NiftyPET_projector/NiftyPETHelper.cxx
+    NiftyPET_projector/ForwardProjectorByBinNiftyPET.cxx
+    NiftyPET_projector/BackProjectorByBinNiftyPET.cxx
+    NiftyPET_projector/ProjectorByBinPairUsingNiftyPET.cxx
   )
 endif()
 

--- a/src/scatter_buildblock/CMakeLists.txt
+++ b/src/scatter_buildblock/CMakeLists.txt
@@ -6,17 +6,17 @@ set(dir scatter_buildblock)
 
 set (dir_LIB_SOURCES ${dir}_LIB_SOURCES)
 set(${dir_LIB_SOURCES}
-	sample_scatter_points 
-	single_scatter_estimate 
-	single_scatter_integrals 
-	scatter_detection_modelling 
-        cached_single_scatter_integrals 
-	scatter_estimate_for_one_scatter_point 
-	upsample_and_fit_scatter_estimate 
-	ScatterEstimation
-	CreateTailMaskFromACFs 
-	ScatterSimulation
-	SingleScatterSimulation
+	sample_scatter_points.cxx
+	single_scatter_estimate.cxx
+	single_scatter_integrals.cxx
+	scatter_detection_modelling.cxx
+        cached_single_scatter_integrals.cxx
+	scatter_estimate_for_one_scatter_point.cxx
+	upsample_and_fit_scatter_estimate.cxx
+	ScatterEstimation.cxx
+	CreateTailMaskFromACFs.cxx
+	ScatterSimulation.cxx
+	SingleScatterSimulation.cxx
 )
 #$(dir)_REGISTRY_SOURCES:= scatter_buildblock_registries
 

--- a/src/scatter_utilities/CMakeLists.txt
+++ b/src/scatter_utilities/CMakeLists.txt
@@ -22,10 +22,10 @@ set(dir scatter_utilities)
 set(dir_EXE_SOURCES ${dir}_EXE_SOURCES)
 
 set(${dir_EXE_SOURCES}
-	estimate_scatter
-	create_tail_mask_from_ACFs
-	upsample_and_fit_single_scatter
-	simulate_scatter
+	estimate_scatter.cxx
+	create_tail_mask_from_ACFs.cxx
+	upsample_and_fit_single_scatter.cxx
+	simulate_scatter.cxx
 )
 
 include(stir_exe_targets)

--- a/src/spatial_transformation_buildblock/CMakeLists.txt
+++ b/src/spatial_transformation_buildblock/CMakeLists.txt
@@ -23,10 +23,10 @@ set(dir spatial_transformation_buildblock)
 set (dir_LIB_SOURCES ${dir}_LIB_SOURCES)
 
 set(${dir_LIB_SOURCES}
-   SpatialTransformation
-   GatedSpatialTransformation
-   warp_image
-   InvertAxis
+   SpatialTransformation.cxx
+   GatedSpatialTransformation.cxx
+   warp_image.cxx
+   InvertAxis.cxx
 ) 
 
 include(stir_lib_target)

--- a/src/utilities/CMakeLists.txt
+++ b/src/utilities/CMakeLists.txt
@@ -23,68 +23,68 @@ set(dir utilities)
 set(dir_EXE_SOURCES ${dir}_EXE_SOURCES)
 
 set(${dir_EXE_SOURCES}
-  manip_image 
-  stir_write_pgm
-	manip_projdata 
-	display_projdata 
-	do_linear_regression 
-	postfilter 
-	compare_projdata 
-	compare_image 
-	extract_segments 
-        estimate_triple_energy_window_scatter_sinogram
-	correct_projdata 
-	stir_math 
-	list_projdata_info 
-	list_image_info 
-	list_image_values 
-        list_detector_and_bin_info
-	find_maxima_in_image 
-	create_projdata_template 
-	SSRB 
-        invert_axis
-	poisson_noise 
-	get_time_frame_info 
-	generate_image 
-	list_ROI_values 
-	zoom_image 
-	find_fwhm_in_image 
-	abs_image 
-        convert_to_binary_image 
-	rebin_projdata 
-	write_proj_matrix_by_bin 
-        forward_project
-        back_project
-	calculate_attenuation_coefficients 
-	attenuation_coefficients_to_projections 
-        conv_GATE_raw_ECAT_projdata_to_interfile
-        conv_gipl_to_interfile
-        conv_interfile_to_gipl
-        shift_image
-        shift_image_origin
-        warp_and_accumulate_gated_images
-        warp_image
-        zeropad_planes
-	apply_normfactors3D
-	apply_normfactors
-	construct_randoms_from_singles
-	find_ML_normfactors3D
-	find_ML_normfactors
-	find_ML_singles_from_delayed
+  manip_image.cxx
+  stir_write_pgm.cxx
+	manip_projdata.cxx
+	display_projdata.cxx
+	do_linear_regression.cxx
+	postfilter.cxx
+	compare_projdata.cxx
+	compare_image.cxx
+	extract_segments.cxx
+        estimate_triple_energy_window_scatter_sinogram.cxx
+	correct_projdata.cxx
+	stir_math.cxx
+	list_projdata_info.cxx
+	list_image_info.cxx
+	list_image_values.cxx
+        list_detector_and_bin_info.cxx
+	find_maxima_in_image.cxx
+	create_projdata_template.cxx
+	SSRB.cxx
+        invert_axis.cxx
+	poisson_noise.cxx
+	get_time_frame_info.cxx
+	generate_image.cxx
+	list_ROI_values.cxx
+	zoom_image.cxx
+	find_fwhm_in_image.cxx
+	abs_image.cxx
+        convert_to_binary_image.cxx
+	rebin_projdata.cxx
+	write_proj_matrix_by_bin.cxx
+        forward_project.cxx
+        back_project.cxx
+	calculate_attenuation_coefficients.cxx
+	attenuation_coefficients_to_projections.cxx
+        conv_GATE_raw_ECAT_projdata_to_interfile.cxx
+        conv_gipl_to_interfile.cxx
+        conv_interfile_to_gipl.cxx
+        shift_image.cxx
+        shift_image_origin.cxx
+        warp_and_accumulate_gated_images.cxx
+        warp_image.cxx
+        zeropad_planes.cxx
+	apply_normfactors3D.cxx
+	apply_normfactors.cxx
+	construct_randoms_from_singles.cxx
+	find_ML_normfactors3D.cxx
+	find_ML_normfactors.cxx
+	find_ML_singles_from_delayed.cxx
 )
 
 if (AVW_FOUND)
-  list(APPEND ${dir_EXE_SOURCES}  conv_AVW)
+  list(APPEND ${dir_EXE_SOURCES}  conv_AVW.cxx)
 endif()
 
 if (HDF5_FOUND)
  list(APPEND ${dir_EXE_SOURCES}
-    construct_randoms_from_GEsingles
+    construct_randoms_from_GEsingles.cxx
  )
 endif()
 
 if (nlohmann_json_FOUND)
-  list(APPEND ${dir_EXE_SOURCES}  ctac_to_mu_values)
+  list(APPEND ${dir_EXE_SOURCES}  ctac_to_mu_values.cxx)
 
   install(DIRECTORY share/ DESTINATION ${STIR_DATA_DIR}
 		  FILES_MATCHING PATTERN "*.json")

--- a/src/utilities/ecat/CMakeLists.txt
+++ b/src/utilities/ecat/CMakeLists.txt
@@ -5,11 +5,13 @@ set(dir utilities/ecat)
 set(dir_EXE_SOURCES ${dir}_EXE_SOURCES)
 
 set(${dir_EXE_SOURCES}
-   is_ecat7_file copy_ecat7_header 
-	ifheaders_for_ecat7 conv_to_ecat7 print_ecat_singles_values 
-	convecat6_if 
-        conv_to_ecat6 
-	ecat_swap_corners 
+  is_ecat7_file.cxx
+  copy_ecat7_header.cxx
+  ifheaders_for_ecat7.cxx
+  conv_to_ecat7 print_ecat_singles_values.cxx
+  convecat6_if.cxx
+  conv_to_ecat6.cxx
+  ecat_swap_corners.cxx
 )
 
 


### PR DESCRIPTION
CMake 3.19 warns when not specifying extensions, so we add them.

Fixes #852