### PR TITLE
speed-up reading from GEHDF5 list files

### DIFF
--- a/src/include/stir/IO/GEHDF5Wrapper.h
+++ b/src/include/stir/IO/GEHDF5Wrapper.h
@@ -94,12 +94,13 @@ public:
     //! reads coincidence time window from file
     float get_coincidence_time_window() const;
 
-    //! reads a listmode event
-    /* \param output: has to be pre-allocated and of the correct size
-       \param current_offset will be incremented
+    //! reads listmode event(s)
+    /* \param[output] output: has to be pre-allocated and of the correct size
+       \param[in] offset: start in listmode data (in number of bytes)
+       \param[in]: size to read (in number of bytes)
     */
     Succeeded read_list_data(char* output,
-                             std::streampos& current_offset,
+                             const std::streampos offset,
                              const hsize_t size) const;
 
     //! read singles at time slice \c current_id
@@ -180,10 +181,8 @@ private:
 
     H5::DataSpace m_dataspace;
 
-    H5::DataSpace* m_memspace_ptr;
-
     std::uint64_t m_list_size = 0;
-
+    int m_dataset_list_Ndims;
     unsigned int m_num_singles_samples;
 
     bool is_list = false;

--- a/src/include/stir/IO/InputStreamWithRecordsFromHDF5.h
+++ b/src/include/stir/IO/InputStreamWithRecordsFromHDF5.h
@@ -13,8 +13,8 @@
       
 */
 /*
-    Copyright (C) 2016-2018, University College London
-    Copyright (C) 2016-2018, University of Leeds
+    Copyright (C) 2016-2018, 2020-2021 University College London
+    Copyright (C) 2016-2019, University of Leeds
     Copyright (C) 2016-2018, University of Hull
 
     This file is part of STIR.
@@ -142,6 +142,16 @@ private:
   const std::size_t size_of_record_signature;
   const std::size_t max_size_of_record;
 
+  //! read data from buffer
+  void read_data(char* output,const std::streampos offset, const hsize_t size) const;
+  // members for buffering
+
+  boost::shared_array<char> buffer;
+  std::size_t max_buffer_size;
+  //! currently filled size
+  mutable std::size_t buffer_size;
+  mutable std::streampos start_of_buffer_offset;
+  void fill_buffer(const std::streampos offset) const;
 };
 
 } // namespace

--- a/src/include/stir/IO/InputStreamWithRecordsFromHDF5.inl
+++ b/src/include/stir/IO/InputStreamWithRecordsFromHDF5.inl
@@ -6,10 +6,15 @@
     
   \author Kris Thielemans
   \author Ottavia Bertolli
+  \author Nikos Efthimiou
+  \author Palak Wadhwa
 */
 /*
     Copyright (C) 2003-2011, Hammersmith Imanet Ltd
     Copyright (C) 2012-2013, Kris Thielemans
+    Copyright (C) 2018 University of Hull
+    Copyright (C) 2018 University of Leeds
+    Copyright (C) 2020-2021 University College London
     This file is part of STIR.
 
     SPDX-License-Identifier: Apache-2.0
@@ -24,7 +29,7 @@
 #include "stir/shared_ptr.h"
 
 #include <fstream>
-
+#include <string.h>
 START_NAMESPACE_STIR
 
 namespace GE {
@@ -58,8 +63,9 @@ template <class RecordT>
     max_size_of_record(max_size_of_record)
 {
     assert(size_of_record_signature<=max_size_of_record);
-    starting_stream_position = 0;
-    current_offset = 0;
+
+    this->max_buffer_size =10000000;
+    this->buffer.reset(new char[this->max_buffer_size]);
 
     set_up();
 }
@@ -71,11 +77,39 @@ set_up()
 {
     input_sptr.reset(new GEHDF5Wrapper(m_filename));
     data_sptr.reset(new char[this->max_size_of_record]);
+    starting_stream_position = 0;
+    current_offset = 0;
 
     input_sptr->initialise_listmode_data();
     m_list_size = input_sptr->get_dataset_size() - this->size_of_record_signature;
 
+    this->buffer_size = 0;
     return Succeeded::yes;
+}
+
+template <class RecordT>
+void
+InputStreamWithRecordsFromHDF5<RecordT>::
+fill_buffer(const std::streampos offset) const
+{
+  this->buffer_size = std::min(this->max_buffer_size, m_list_size - offset);
+  input_sptr->read_list_data(buffer.get(), offset, hsize_t(this->buffer_size));
+  this->start_of_buffer_offset =  offset;
+}
+
+template <class RecordT>
+void
+InputStreamWithRecordsFromHDF5<RecordT>::
+read_data(char* output,const std::streampos offset, const hsize_t size) const
+{
+  if (this->buffer_size == 0 || offset < this->start_of_buffer_offset || offset >= (this->start_of_buffer_offset + this->buffer_size))
+    this->fill_buffer(offset);
+  const std::size_t offset_in_buffer = offset - this->start_of_buffer_offset;
+  const hsize_t size_in_buffer = std::min(size, static_cast<hsize_t>(this->buffer_size - offset_in_buffer));
+
+  memcpy(output, this->buffer.get() + offset_in_buffer, static_cast<std::size_t>(size_in_buffer));
+  if (size_in_buffer < size)
+    read_data(output + size_in_buffer, offset + size_in_buffer, size - size_in_buffer);
 }
 
 template <class RecordT>
@@ -83,22 +117,29 @@ Succeeded
 InputStreamWithRecordsFromHDF5<RecordT>::
 get_next_record(RecordT& record)
 {
+  try
+    {
+      if (current_offset >= static_cast<std::streampos>(m_list_size))
+        return Succeeded::no;
+      char* data_ptr = data_sptr.get();
+      this->read_data(data_ptr, current_offset, hsize_t(this->size_of_record_signature));
+      const std::size_t size_of_record =
+        record.size_of_record_at_ptr(data_ptr, this->size_of_record_signature, false);
 
-  if (current_offset > static_cast<std::streampos>(m_list_size))
+      assert(size_of_record <= this->max_size_of_record);
+      // read more bytes if necessary
+      auto remainder = size_of_record - this->size_of_record_signature;
+      if (remainder > 0)
+        this->read_data(data_ptr+this->size_of_record_signature,
+                       current_offset+this->size_of_record_signature, hsize_t(remainder));
+      current_offset += size_of_record;
+      return
+        record.init_from_data_ptr(data_ptr, size_of_record,false);
+    }
+  catch (...)
+    {
       return Succeeded::no;
-  char* data_ptr = data_sptr.get();
-  input_sptr->read_list_data(data_ptr, current_offset, hsize_t(this->size_of_record_signature));
-  const std::size_t size_of_record =
-    record.size_of_record_at_ptr(data_ptr, this->size_of_record_signature, false);
-
-  assert(size_of_record <= this->max_size_of_record);
-  // read more bytes if necessary
-  auto remainder = size_of_record - this->size_of_record_signature;
-  if (remainder > 0)
-    input_sptr->read_list_data(data_ptr, current_offset, hsize_t(remainder));
-
-  return
-    record.init_from_data_ptr(data_ptr, size_of_record,false);
+    }
 }
 
 


### PR DESCRIPTION
- use an internal buffer such that we don't have to call h5read for every event. This speeds things up dramatically.
- minor clean-up of GEHDF5Wrapper by removing a member variable (making it local)