### PR TITLE
fix RUN_DOXYSWIG for parallel builds

### DIFF
--- a/src/swig/CMakeLists.txt
+++ b/src/swig/CMakeLists.txt
@@ -25,9 +25,11 @@ if(BUILD_SWIG_PYTHON OR BUILD_SWIG_OCTAVE OR BUILD_SWIG_MATLAB)
     # We use doxy2swig to convert the doxygen-generated xml to a swig file
     # Note the "standard" CMake trick of first adding a custom command that generates a file, and then
     # a custom target that depends on the file.
+    # Note that we need to depend on the doxygen.stamp as well as otherwise parallel builds can fail
+    # See the last section of https://samthursfield.wordpress.com/2015/11/21/cmake-dependencies-between-targets-and-files-and-custom-commands/
     add_custom_command(
       OUTPUT STIR_DOXY2SWIG.i
-      DEPENDS RUN_DOXYGEN
+      DEPENDS RUN_DOXYGEN ../doxygen.stamp
       COMMAND ${PYTHON_EXECUTABLE}
           ${CMAKE_SOURCE_DIR}/external_helpers/doxy2swig/doxy2swig.py -c
           ${CMAKE_BINARY_DIR}/xml/index.xml


### PR DESCRIPTION
doxyswig could be started before doxygen had finished, resulting in using out-dated files.

Solution comes from Section 5 on https://samthursfield.wordpress.com/2015/11/21/cmake-dependencies-between-targets-and-files-and-custom-commands/

Fixes #877