### PR TITLE
Upper and lower thresholding for arrays

### DIFF
--- a/src/include/stir/Array.h
+++ b/src/include/stir/Array.h
@@ -186,8 +186,10 @@ public:
   //! Fill elements with value n (overrides VectorWithOffset::fill)
   inline void fill(const elemT &n);
 
+  //! Sets elements below value to the value (overrides VectorWithOffset::fill)
   inline void apply_lower_threshold(const elemT &l);
 
+  //! Sets elements above value to the value (overrides VectorWithOffset::fill)
   inline void apply_upper_threshold(const elemT &u);
 
   //! checks if the index range is 'regular'

--- a/src/include/stir/Array.h
+++ b/src/include/stir/Array.h
@@ -186,6 +186,10 @@ public:
   //! Fill elements with value n (overrides VectorWithOffset::fill)
   inline void fill(const elemT &n);
 
+  inline void apply_lower_threshold(const elemT &l);
+
+  inline void apply_upper_threshold(const elemT &u);
+
   //! checks if the index range is 'regular'
   /*! Implementation note: this works by calling get_index_range().is_regular().
       We cannot rely on remembering if it was a regular range at construction (or

--- a/src/include/stir/Array.inl
+++ b/src/include/stir/Array.inl
@@ -252,6 +252,26 @@ Array<num_dimensions, elemT>::fill(const elemT &n)
 }
 
 template <int num_dimensions, typename elemT>
+void
+Array<num_dimensions, elemT>::apply_lower_threshold(const elemT &l)
+{
+  this->check_state();
+  for(int i=this->get_min_index(); i<=this->get_max_index();  i++)
+    this->num[i].apply_lower_threshold(l);
+  this->check_state();
+}
+
+template <int num_dimensions, typename elemT>
+void
+Array<num_dimensions, elemT>::apply_upper_threshold(const elemT &u)
+{
+  this->check_state();
+  for(int i=this->get_min_index(); i<=this->get_max_index();  i++)
+    this->num[i].apply_upper_threshold(u);
+  this->check_state();
+}
+
+template <int num_dimensions, typename elemT>
 bool
 Array<num_dimensions, elemT>::is_regular() const
 {

--- a/src/include/stir/VectorWithOffset.h
+++ b/src/include/stir/VectorWithOffset.h
@@ -266,7 +266,11 @@ public:
   //! fill elements with value \a n
   inline void fill(const T &n);
 
+  //! threshold values to min the value
   inline void apply_lower_threshold(const T &lower);
+
+  //! threshold values to max the value
+  inline void apply_upper_threshold(const T &upper);
 
   //! \name access to the data via a pointer
   //@{

--- a/src/include/stir/VectorWithOffset.h
+++ b/src/include/stir/VectorWithOffset.h
@@ -266,10 +266,10 @@ public:
   //! fill elements with value \a n
   inline void fill(const T &n);
 
-  //! threshold values to min the value
+    //! Sets elements below value to the value
   inline void apply_lower_threshold(const T &lower);
 
-  //! threshold values to max the value
+  //! Sets elements above value to the value
   inline void apply_upper_threshold(const T &upper);
 
   //! \name access to the data via a pointer

--- a/src/include/stir/VectorWithOffset.h
+++ b/src/include/stir/VectorWithOffset.h
@@ -266,6 +266,8 @@ public:
   //! fill elements with value \a n
   inline void fill(const T &n);
 
+  inline void apply_lower_threshold(const T &lower);
+
   //! \name access to the data via a pointer
   //@{
   //! member function for access to the data via a T*

--- a/src/include/stir/VectorWithOffset.inl
+++ b/src/include/stir/VectorWithOffset.inl
@@ -572,6 +572,15 @@ VectorWithOffset<T>::apply_lower_threshold(const T &lower)
   this->check_state();
 }
 
+template <class T>
+inline void
+VectorWithOffset<T>::apply_upper_threshold(const T &upper)
+{
+  this->check_state();
+  threshold_upper(this->begin(), this->end(), upper);
+  this->check_state();
+}
+
 
 
 /*! 

--- a/src/include/stir/VectorWithOffset.inl
+++ b/src/include/stir/VectorWithOffset.inl
@@ -23,6 +23,7 @@
 
 #include <algorithm>
 #include <stdexcept>
+#include "thresholding.h"
 
 START_NAMESPACE_STIR
 
@@ -558,6 +559,16 @@ VectorWithOffset<T>::fill(const T &n)
   //std::fill(begin(), end(), n);
   for(int i=this->get_min_index(); i<=this->get_max_index(); i++)
     num[i] = n;
+  this->check_state();
+}
+
+
+template <class T>
+inline void
+VectorWithOffset<T>::apply_lower_threshold(const T &lower)
+{
+  this->check_state();
+  threshold_lower(this->begin(), this->end(), lower);
   this->check_state();
 }
 


### PR DESCRIPTION
Adds two methods: `apply_lower_threshold(l)` and `apply_upper_threshold(u)` to `Array` and `VectorWithOffset` that allows for thresholding to an lower and upper bound.

This has been tested for `DiscretisedDensity`