### PR TITLE
Demo5 - gradient line search

### DIFF
--- a/examples/C++/src/CMakeLists.txt
+++ b/examples/C++/src/CMakeLists.txt
@@ -5,7 +5,7 @@ set(dir examples)
 set(dir_EXE_SOURCES ${dir}_EXE_SOURCES)
 
 set(${dir_EXE_SOURCES}
-	demo1 demo2 demo3 demo4_obj_fun
+	demo1 demo2 demo3 demo4_obj_fun demo5_line_search
 )
 
 

--- a/examples/C++/src/README.txt
+++ b/examples/C++/src/README.txt
@@ -155,6 +155,7 @@ EXE_LOC=/whereever/you/built/STIR/src/examples/src
 	# Feel free to alter the objective function, image filename, and the step size configuration in the parameter file.
 	# Try plotting the output `alphas.dat` and `Phis.dat` and visualise how the step size can impact the
 	  objective function value
+	# Now try `use exponential alphas := 1`?
 
 What now ?
 ----------

--- a/examples/C++/src/README.txt
+++ b/examples/C++/src/README.txt
@@ -109,7 +109,7 @@ ccmake .
 # alternative 2: set STIR_LOCAL to this directory
 cd your-build-dir
 # reconfigure your project
-ccmake -DSTIR_LOCAL=/where/ever/the/STIR/source/is/STIR/examples/src  .
+ccmake -DSTIR_LOCAL=/where/ever/the/STIR/source/is/STIR/examples/C++/src  .
 
 # make the examples
 make demo1 demo2 demo3 demo4_obj_fun demo5_line_search
@@ -127,7 +127,7 @@ First you need to create some data.
       forward_project sino.hs image.hv  small.hs
 
 # Run the demos.
-EXE_LOC=/whereever/you/built/STIR/src/examples/src
+EXE_LOC=/whereever/you/built/STIR/src/examples/C++
 	
 # demo1
 	$EXE_LOC/demo1

--- a/examples/C++/src/README.txt
+++ b/examples/C++/src/README.txt
@@ -45,6 +45,14 @@ demo4_obj_fun.cxx
 		- how to compute the objective function (log-likelihood) value of an image
 	    - how to compute the objective function (log-likelihood) gradient
 	    - how a basic iterative optimisation works (or may not, if parameters are altered)
+
+demo5_line_search.cxx
+	Deviating from the previous demos, this demo performs a line search from a provided image
+	in the direction of the gradient for various step sizes.
+	  It illustrates
+		- how to initialise and setup an objective function object
+		- how to compute the objective function (log-likelihood) value and gradient
+	    - Demonstrates how important step sizes for each iteration of an optimisation algorithm.
  
 CMakeLists.txt
 	A CMake file to say which files to build.
@@ -71,6 +79,10 @@ demo_obj_fun.par
 	An example parameter file for demo4_obj_fun.cxx, used to
 	compute the objective function value of an image and perform 
 	some iterative gradient ascent updates.
+
+demo5_line_search.par
+	An example parameter file for demo5_line_search.cxx, used to
+	perform a line search of a image and objective function.
 
 generate_image.par
 	An example parameter file for generate_image that allows it
@@ -100,7 +112,7 @@ cd your-build-dir
 ccmake -DSTIR_LOCAL=/where/ever/the/STIR/source/is/STIR/examples/src  .
 
 # make the examples
-make demo1 demo2 demo3 demo4_obj_fun
+make demo1 demo2 demo3 demo4_obj_fun demo5_line_search
 # optionally install everything, including the demos
 make install
 
@@ -137,7 +149,12 @@ EXE_LOC=/whereever/you/built/STIR/src/examples/src
 	# Feel free to alter the "step size" and "number of iterations" in "demo_obj_fun.par".
 	# However, it is quite easy to cause unstable behaviour in the estimates.
 	# Additionally, there is a lack of positivity constraint on the density images (typical for PET reconstruction).
-	
+
+# demo5_line_search
+	$EXE_LOC/demo5_line_search demo5_line_search.par
+	# Feel free to alter the objective function, image filename, and the step size configuration in the parameter file.
+	# Try plotting the output `alphas.dat` and `Phis.dat` and visualise how the step size can impact the
+	  objective function value
 
 What now ?
 ----------
@@ -148,4 +165,4 @@ Good luck
 Kris Thielemans
 12 November 2004
 (with minor updates until 2017)
-Robert Twyman, 2020 (addition of demo4_obj_fun)
+Robert Twyman, 2020,2021 (addition of demo4_obj_fun and demo5_line_search)

--- a/examples/C++/src/demo5_line_search.cxx
+++ b/examples/C++/src/demo5_line_search.cxx
@@ -85,6 +85,7 @@ compute_exponential_alphas(const float alpha_min, const float alpha_max, const f
   return alphas;
 }
 
+
 void
 save_doubles_vector_to_file(std::string filename, std::vector<double> vector)
 {
@@ -150,6 +151,7 @@ LineSearcher::LineSearcher()
   set_defaults();
 }
 
+
 void
 LineSearcher::set_defaults()
 {
@@ -162,6 +164,7 @@ LineSearcher::set_defaults()
   image_lower_bound = 0.0;
   output_file_format_sptr = OutputFileFormat<DiscretisedDensity<3,float> >::default_sptr();
 }
+
 
 void
 LineSearcher::initialise_keymap()
@@ -177,6 +180,7 @@ LineSearcher::initialise_keymap()
   parser.add_stop_key("End");
 }
 
+
 bool LineSearcher::
 post_processing()
 {
@@ -187,6 +191,7 @@ post_processing()
   }
   return false;
 }
+
 
 void LineSearcher::
 setup()
@@ -276,6 +281,7 @@ LineSearcher::apply_update_step(const double alpha)
   this->eval_image_sptr->apply_lower_threshold(this->image_lower_bound);
 }
 
+
 void
 LineSearcher::save_data()
 {
@@ -290,6 +296,7 @@ LineSearcher::save_data()
   std::cout << "Saving LineSearchGradient.hv\n";
   output_file_format_sptr->write_to_file("LineSearchGradient.hv", *this->gradient_sptr);
 }
+
 
 void
 LineSearcher::save_max_line_search_image()
@@ -317,6 +324,7 @@ LineSearcher::save_max_line_search_image()
     std::cout << "Max line search value image is at alpha = 0.0\n";
   }
 }
+
 
 int main(int argc, char **argv)
 {

--- a/examples/C++/src/demo5_line_search.cxx
+++ b/examples/C++/src/demo5_line_search.cxx
@@ -29,10 +29,10 @@
 #include "stir/is_null_ptr.h"
 
 
-std::vector<float>
+std::vector<double>
 compute_linear_alphas(const float alpha_min, const float alpha_max, const float num_evaluations)
 {
-  std::vector<float> alphas;
+  std::vector<double> alphas;
   float d_alpha = (alpha_max - alpha_min) / num_evaluations;
 
   std::cout << "\nComputing linear alphas:"
@@ -53,10 +53,10 @@ compute_linear_alphas(const float alpha_min, const float alpha_max, const float 
 }
 
 
-std::vector<float>
+std::vector<double>
 compute_exponential_alphas(const float alpha_min, const float alpha_max, const float num_evaluations)
 {
-  std::vector<float> alphas;
+  std::vector<double> alphas;
   float d_alpha = (alpha_max - alpha_min) / num_evaluations;
 
   std::cout << "\nComputing exponential alphas:"
@@ -86,7 +86,7 @@ public:
     ////// Methods
     void set_defaults();
     void setup();
-    float compute_line_search_value(const float alpha);
+    double compute_line_search_value(const double alpha);
     void perform_line_search();
 
     typedef DiscretisedDensity<3,float> target_type;
@@ -98,8 +98,8 @@ public:
     bool use_exponential_alphas;
 
     /// Measurements
-    std::vector<float> alphas;
-    std::vector<float> Phis;
+    std::vector<double> alphas;
+    std::vector<double> Phis;
 
     shared_ptr<DiscretisedDensity<3,float> > image_sptr;
     shared_ptr<DiscretisedDensity<3,float> > gradient_sptr;
@@ -185,7 +185,7 @@ LineSearcher::perform_line_search() {
   if (!is_setup)
     error("LineSearcher is not setup, please run setup()");
 
-  float phi;
+  double phi;
 
   std::cout << "Computing objective function values of alphas from "  << this->alpha_min << " to "
             << this->alpha_max << " in increments of " << this->num_evaluations << "\n";
@@ -208,14 +208,13 @@ LineSearcher::perform_line_search() {
   std::cout << "\n\n"
                "====================================\n"
                "Alpha and Phi values: \n";
-  for (int i = 0 ; i < alphas.size() ; ++i){
-    std::cout << "  alpha = " << alphas[i] << ". Phis = " << Phis[i] << "\n";
-  }
+  for (int i = 0 ; i < alphas.size() ; ++i)
+    std::cout << std::setprecision(10) << "  alpha = " << alphas[i] << ". Phis = " << Phis[i] << "\n";
 }
 
 
-float
-LineSearcher::compute_line_search_value(const float alpha)
+double
+LineSearcher::compute_line_search_value(const double alpha)
 {
   eval_image_sptr->fill(0.0);
   *eval_image_sptr += *this->image_sptr + *this->gradient_sptr * alpha;

--- a/examples/C++/src/demo5_line_search.cxx
+++ b/examples/C++/src/demo5_line_search.cxx
@@ -6,10 +6,11 @@
   All parameters can be parsed from a parameter file. See `demo5_line_search.par`.
 
   Give an image and objective function configuration, this script will perform a line search
-  from an minimum to an maximum step size (alpha).
+```suggestion
+  from a minimum to a maximum step size (alpha).
   Options are included to perform this line search linearly or using exponential step
-  size iterations.
-  Additionally, a lower positivity bound is applied to all computed image.
+  sizes.
+  Additionally, a lower positivity bound is applied to all computed images.
 
   The results are saved to files: `alphas.dat` contains the step size values investigated,
   and `Phis.dat` contains the objective function evaluations.

--- a/examples/C++/src/demo5_line_search.cxx
+++ b/examples/C++/src/demo5_line_search.cxx
@@ -47,7 +47,31 @@ compute_linear_alphas(const float alpha_min, const float alpha_max, const float 
 
   /// create a vector from (alpha_min + d_alpha) to alpha_max
   for (int i = 1; i <= num_evaluations; i++)
-    alphas.push_back(i * d_alpha);
+    alphas.push_back(i * d_alpha + alpha_min);
+
+  return alphas;
+}
+
+
+std::vector<float>
+compute_exponential_alphas(const float alpha_min, const float alpha_max, const float num_evaluations)
+{
+  std::vector<float> alphas;
+  float d_alpha = (alpha_max - alpha_min) / num_evaluations;
+
+  std::cout << "\nComputing exponential alphas:"
+               "\n  exponential min =    " << alpha_min <<
+               "\n  exponential max =    " << alpha_max <<
+               "\n  exponential delta  = " << d_alpha << "\n";
+
+
+
+  /// Explicitly add alpha = 0.0 and/or alpha_min
+  alphas.push_back(0.0);
+
+  /// create a vector from (alpha_min + d_alpha) to alpha_max
+  for (int i = 1; i <= num_evaluations; i++)
+    alphas.push_back(pow(10, i * d_alpha + alpha_min));
 
   return alphas;
 }

--- a/examples/C++/src/demo5_line_search.cxx
+++ b/examples/C++/src/demo5_line_search.cxx
@@ -254,6 +254,11 @@ LineSearcher::save_data()
     error("Length of alpha and Phi vectors is not equal.");
   save_doubles_vector_to_file("alphas.dat", this->alphas);
   save_doubles_vector_to_file("Phis.dat", this->Phis);
+
+  /// Save gradient to file
+  shared_ptr<OutputFileFormat<DiscretisedDensity<3,float> > > output_file_format_sptr;
+  output_file_format_sptr = OutputFileFormat<DiscretisedDensity<3,float> >::default_sptr();
+  output_file_format_sptr->write_to_file("LineSearchGradient.hv", *this->gradient_sptr);
 }
 
 int main(int argc, char **argv)

--- a/examples/C++/src/demo5_line_search.cxx
+++ b/examples/C++/src/demo5_line_search.cxx
@@ -140,18 +140,25 @@ setup()
 }
 
 
+void LineSearcher::perform_line_search() {
+
+  std::vector<float> alphas = compute_linear_alphas(this->alpha_min, this->alpha_max, this->num_evaluations);
+  std::vector<float> Phi;
+
+  std::cout << "Computing objective function values of alphas from "  << this->alpha_min << " to "
+            << this->alpha_max << " in increments of " << this->num_evaluations << "\n";
+  for (auto a = alphas.begin(); a != alphas.end(); ++a)
+  {
+    std::cout << "alpha = " << *a << "\n";
+  }
 }
+
 
 float LineSearcher::
 compute_line_search_value(const float alpha)
 {
   return 0;
 }
-
-void LineSearcher::perform_line_search() {
-
-}
-
 
 int main(int argc, char **argv)
 {

--- a/examples/C++/src/demo5_line_search.cxx
+++ b/examples/C++/src/demo5_line_search.cxx
@@ -101,6 +101,7 @@ public:
     void set_defaults();
     void setup();
     double compute_line_search_value(const double alpha);
+    void apply_update_step(const double alpha);
     void perform_line_search();
     void save_data();
 
@@ -237,14 +238,20 @@ LineSearcher::perform_line_search() {
 double
 LineSearcher::compute_line_search_value(const double alpha)
 {
-  eval_image_sptr->fill(0.0);
-  *eval_image_sptr += *this->image_sptr + *this->gradient_sptr * alpha;
-  eval_image_sptr->apply_lower_threshold(this->image_lower_bound);
+  apply_update_step(alpha);
 
   std::cout << "\nimage_min  = " <<  image_sptr->find_min()
             << "\ngrad_min = " << gradient_sptr->find_min()
             << "\neval_min = " << eval_image_sptr->find_min() << "\n";
   return objective_function_sptr->compute_objective_function(*eval_image_sptr);
+}
+
+void
+LineSearcher::apply_update_step(const double alpha)
+{
+  this->eval_image_sptr->fill(0.0);
+  *this->eval_image_sptr += *this->image_sptr + *this->gradient_sptr * alpha;
+  this->eval_image_sptr->apply_lower_threshold(this->image_lower_bound);
 }
 
 void

--- a/examples/C++/src/demo5_line_search.cxx
+++ b/examples/C++/src/demo5_line_search.cxx
@@ -76,6 +76,20 @@ compute_exponential_alphas(const float alpha_min, const float alpha_max, const f
   return alphas;
 }
 
+void
+save_doubles_vector_to_file(std::string filename, std::vector<double> vector)
+{
+  /// This function is used to save the line search results (alpha and Phi values) to separate files.
+  std::ofstream myfile (filename);
+  int precision = 40;
+  if (myfile.is_open()){
+    for (double v : vector){
+      myfile << std::fixed << std::setprecision(precision) << v << std::endl;
+    }
+    myfile.close();
+  }
+}
+
 
 using namespace stir;
 
@@ -88,6 +102,7 @@ public:
     void setup();
     double compute_line_search_value(const double alpha);
     void perform_line_search();
+    void save_data();
 
     typedef DiscretisedDensity<3,float> target_type;
 
@@ -213,7 +228,8 @@ LineSearcher::perform_line_search() {
     std::cout << "\n\n====================================\n"
                  "Alpha and Phi values: \n";
     for (int i = 0 ; i < alphas.size() ; ++i)
-      std::cout << std::setprecision(10) << "  alpha = " << alphas[i] << ". Phis = " << Phis[i] << "\n";
+      std::cout << std::setprecision(20) << "  alpha = " << alphas[i] << ". Phis = " << Phis[i] << "\n";
+
   }
 }
 
@@ -229,6 +245,15 @@ LineSearcher::compute_line_search_value(const double alpha)
             << "\ngrad_min = " << gradient_sptr->find_min()
             << "\neval_min = " << eval_image_sptr->find_min() << "\n";
   return objective_function_sptr->compute_objective_function(*eval_image_sptr);
+}
+
+void
+LineSearcher::save_data()
+{
+  if (alphas.size() != Phis.size())
+    error("Length of alpha and Phi vectors is not equal.");
+  save_doubles_vector_to_file("alphas.dat", this->alphas);
+  save_doubles_vector_to_file("Phis.dat", this->Phis);
 }
 
 int main(int argc, char **argv)
@@ -247,6 +272,7 @@ int main(int argc, char **argv)
     my_stuff.parse(argv[1]);
   my_stuff.setup();
   my_stuff.perform_line_search();
+  my_stuff.save_data();
 
 
   return EXIT_SUCCESS;

--- a/examples/C++/src/demo5_line_search.cxx
+++ b/examples/C++/src/demo5_line_search.cxx
@@ -70,16 +70,13 @@ public:
     float alpha_max;
     bool use_log_alphas;
 
-
-
+    shared_ptr<DiscretisedDensity<3,float> > image_sptr;
+    shared_ptr<DiscretisedDensity<3,float> > gradient_sptr;
 
 protected:
     shared_ptr<GeneralisedObjectiveFunction<target_type> >  objective_function_sptr;
 
 private:
-    std::string input_filename; // data
-    std::string additive_sinogram_filename;
-//    std::string multiplicative_factors_filename;
     std::string image_filename; //image
 
     void initialise_keymap();
@@ -95,7 +92,6 @@ void
 LineSearcher::set_defaults()
 {
   objective_function_sptr.reset(new PoissonLogLikelihoodWithLinearModelForMeanAndProjData<target_type>);
-  output_file_format_sptr = OutputFileFormat<DiscretisedDensity<3,float> >::default_sptr();
   num_evaluations = 10;
   alpha_min = 0.0;
   alpha_max = 1.0;
@@ -128,10 +124,21 @@ post_processing()
 void LineSearcher::
 setup()
 {
+  objective_function_sptr->set_num_subsets(1);
+
   /////// load initial density from file
   shared_ptr<DiscretisedDensity<3,float> > image_sptr(read_from_file<DiscretisedDensity<3,float> >(image_filename));
 
-  /////// Select
+  /////// setup the objective function
+  objective_function_sptr->set_up(image_sptr);
+
+  //////// gradient it copied Density filled with 0's
+  shared_ptr<DiscretisedDensity<3,float> > gradient_sptr(image_sptr->get_empty_copy());
+
+  //////// compute the gradient
+  objective_function_sptr->compute_sub_gradient(*gradient_sptr, *image_sptr, 0);
+}
+
 
 }
 

--- a/examples/C++/src/demo5_line_search.cxx
+++ b/examples/C++/src/demo5_line_search.cxx
@@ -36,11 +36,13 @@ compute_linear_alphas(const float alpha_min, const float alpha_max, const float 
   float alpha;
   float d_alpha = (alpha_max - alpha_min) / num_evaluations;
 
-  std::cout << "Computing linear alphas:"
+  std::cout << "\nComputing linear alphas:"
                "\n  alpha_min =   " << alpha_min <<
-            "\n  alpha_max =   " << alpha_max <<
-            "\n  delta_alpha = " << d_alpha << "\n";
+               "\n  alpha_max =   " << alpha_max <<
+               "\n  delta_alpha = " << d_alpha << "\n";
 
+  // create a vector from (alpha_min + d_alpha) to alpha_max
+  // assumes general case that alpha_min = 0 and therefore line search does not compute alpha = 0
   for (int i = 1; i <= num_evaluations; i++)
   {
     alpha = i * d_alpha;

--- a/examples/C++/src/demo5_line_search.cxx
+++ b/examples/C++/src/demo5_line_search.cxx
@@ -134,11 +134,11 @@ setup()
   if (image_filename == "")
     error("LineSearcher setup. No image filename has been given.");
   std::cout << "Loading image: \n    " << image_filename << "\n";
-  shared_ptr<DiscretisedDensity<3,float> > image_sptr(read_from_file<DiscretisedDensity<3,float> >(image_filename));
+  this->image_sptr  = read_from_file<DiscretisedDensity<3,float> >(image_filename);
 
   //////// gradient it copied Density filled with 0's
-  shared_ptr<DiscretisedDensity<3,float> > gradient_sptr(image_sptr->get_empty_copy());
-  shared_ptr<DiscretisedDensity<3,float> > eval_image_sptr(image_sptr->get_empty_copy());
+  this->gradient_sptr.reset(this->image_sptr->get_empty_copy());
+  this->eval_image_sptr.reset(this->image_sptr->get_empty_copy());
 
   /////// setup the objective function
   objective_function_sptr->set_num_subsets(1);
@@ -166,12 +166,15 @@ LineSearcher::perform_line_search() {
   float p = 0.0;
   std::cout << this->image_sptr->find_max();
 
-  for (auto i = alphas.begin(); i != alphas.end(); ++i)
+  for (auto a = alphas.begin(); a != alphas.end(); ++a)
   {
-    const float alpha = *i;
-    p = this->compute_line_search_value(*i);
+    p = this->compute_line_search_value(*a);
     Phi.push_back(p);
-    std::cout << "alpha = " << alpha << ". Phi = " << p << "\n";
+    std::cout << "alpha = " << *a << ". Phi = " << p << "\n";
+  }
+
+  for (int i = 0 ; i < alphas.size() ; ++i){
+    std::cout << "alpha = " << alphas[i] << ". Phi = " << Phi[i] << "\n";
   }
 }
 

--- a/examples/C++/src/demo5_line_search.cxx
+++ b/examples/C++/src/demo5_line_search.cxx
@@ -97,6 +97,10 @@ public:
     float alpha_max;
     bool use_exponential_alphas;
 
+    /// Measurements
+    std::vector<float> alphas;
+    std::vector<float> Phis;
+
     shared_ptr<DiscretisedDensity<3,float> > image_sptr;
     shared_ptr<DiscretisedDensity<3,float> > gradient_sptr;
     shared_ptr<DiscretisedDensity<3,float> > eval_image_sptr;
@@ -169,8 +173,7 @@ setup()
   objective_function_sptr->set_num_subsets(1);
   objective_function_sptr->set_up(image_sptr);
 
-
-  //////// compute the gradient
+  //////// compute the gradient and store
   objective_function_sptr->compute_sub_gradient(*gradient_sptr, *image_sptr, 0);
 
   this->is_setup = true;
@@ -182,38 +185,31 @@ LineSearcher::perform_line_search() {
   if (!is_setup)
     error("LineSearcher is not setup, please run setup()");
 
-  std::vector<float> alphas;
-  std::vector<float> Phi;
+  float phi;
 
   std::cout << "Computing objective function values of alphas from "  << this->alpha_min << " to "
             << this->alpha_max << " in increments of " << this->num_evaluations << "\n";
 
-
   /// get alpha values as a vector
   {
     if ( this->use_exponential_alphas )
-      error("exponential alphas not yet implemented.");
+      alphas = compute_exponential_alphas(this->alpha_min, this->alpha_max, this->num_evaluations);
     else
       alphas = compute_linear_alphas(this->alpha_min, this->alpha_max, this->num_evaluations);
   }
 
-
-
-
-  std::cout << this->image_sptr->find_max();
-
   for (auto a = alphas.begin(); a != alphas.end(); ++a)
   {
     phi = this->compute_line_search_value(*a);
-    Phi.push_back(phi);
+    Phis.push_back(phi);
     std::cout << "alpha = " << *a << ". Phi = " << phi << "\n";
   }
 
   std::cout << "\n\n"
                "====================================\n"
-               "Alphas and Phi values: \n";
+               "Alpha and Phi values: \n";
   for (int i = 0 ; i < alphas.size() ; ++i){
-    std::cout << "  alpha = " << alphas[i] << ". Phi = " << Phi[i] << "\n";
+    std::cout << "  alpha = " << alphas[i] << ". Phis = " << Phis[i] << "\n";
   }
 }
 

--- a/examples/C++/src/demo5_line_search.cxx
+++ b/examples/C++/src/demo5_line_search.cxx
@@ -185,6 +185,9 @@ LineSearcher::compute_line_search_value(const float alpha)
   //////// gradient it copied Density filled with 0's
   eval_image_sptr->fill(0.0);
   *eval_image_sptr += *this->image_sptr + *this->gradient_sptr * alpha;
+  std::cout << "\nimage_max  = " <<  image_sptr->find_max()
+            << "\ngrad_max = " << gradient_sptr->find_max()
+            << "\neval_max = " << eval_image_sptr->find_max() << "\n";
   return objective_function_sptr->compute_objective_function(*eval_image_sptr);
 }
 

--- a/examples/C++/src/demo5_line_search.cxx
+++ b/examples/C++/src/demo5_line_search.cxx
@@ -1,0 +1,145 @@
+/*!
+  \file
+  \ingroup examples
+  \brief An example of a method to compute a line search evaluation in the direction of the gradient of a given image.
+  All parameters can be parsed from a parameter file.
+
+  It illustrates
+    - TODO
+
+  Note that the same functionality could be provided without deriving
+  a new class from stir::ParsingObject. One could have a stir::KeyParser object
+  in main() and fill it in directly.
+
+  See README.txt in the directory where this file is located.
+
+  \author Robert Twyman
+*/
+/*
+    Copyright (C) 2021 University College London
+
+    This software is distributed under the terms
+    of the GNU General  Public Licence (GPL)
+    See STIR/LICENSE.txt for details
+*/
+
+#include "stir/IO/OutputFileFormat.h"
+#include "stir/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMeanAndProjData.h"
+#include "stir/IO/read_from_file.h"
+#include "stir/is_null_ptr.h"
+
+namespace stir {
+
+class LineSearcher: public ParsingObject
+{
+public:
+    LineSearcher();
+    ////// Methods
+    void set_defaults();
+    void setup();
+    float compute_line_search_value(const float alpha);
+    void perform_line_search();
+
+    typedef DiscretisedDensity<3,float> target_type;
+
+    ////// Class variables
+    int num_evaluations;
+    float alpha_min;
+    float alpha_max;
+    bool use_log_alphas;
+
+
+
+
+protected:
+    shared_ptr<GeneralisedObjectiveFunction<target_type> >  objective_function_sptr;
+
+private:
+    std::string input_filename; // data
+    std::string additive_sinogram_filename;
+//    std::string multiplicative_factors_filename;
+    std::string image_filename; //image
+
+    void initialise_keymap();
+    bool post_processing();
+};
+
+LineSearcher::LineSearcher()
+{
+  set_defaults();
+}
+
+void
+LineSearcher::set_defaults()
+{
+  objective_function_sptr.reset(new PoissonLogLikelihoodWithLinearModelForMeanAndProjData<target_type>);
+  output_file_format_sptr = OutputFileFormat<DiscretisedDensity<3,float> >::default_sptr();
+  num_evaluations = 10;
+  alpha_min = 0.0;
+  alpha_max = 1.0;
+  use_log_alphas = false;
+}
+
+void
+LineSearcher::initialise_keymap()
+{
+  parser.add_start_key("LineSearcher parameters");
+  parser.add_key("image filename", &image_filename);
+  parser.add_parsing_key("objective function type", &objective_function_sptr);
+  parser.add_key("number of evaluations", &num_evaluations);
+  parser.add_key("alpha min", &alpha_min);
+  parser.add_key("alpha max", &alpha_max);
+  parser.add_stop_key("End");
+}
+
+bool LineSearcher::
+post_processing()
+{
+  if (is_null_ptr(this->objective_function_sptr))
+  {
+    error("objective_function_sptr is null");
+    return true;
+  }
+  return false;
+}
+
+void LineSearcher::
+setup()
+{
+  /////// load initial density from file
+  shared_ptr<DiscretisedDensity<3,float> > image_sptr(read_from_file<DiscretisedDensity<3,float> >(image_filename));
+
+  /////// Select
+
+}
+
+float LineSearcher::
+compute_line_search_value(const float alpha)
+{
+  return 0;
+}
+
+void LineSearcher::perform_line_search() {
+
+}
+
+}// end of namespace stir
+
+int main(int argc, char **argv)
+{
+  using namespace stir;
+
+  if (argc!=2)
+  {
+    std::cerr << "Normal usage: " << argv[0] << " parameter-file\n";
+    std::cerr << "I will now ask you the questions interactively\n";
+  }
+  LineSearcher my_stuff;
+  my_stuff.set_defaults();
+  if (argc!=2)
+    my_stuff.ask_parameters();
+  else
+    my_stuff.parse(argv[1]);
+//  my_stuff.run();
+  return EXIT_SUCCESS;
+}

--- a/examples/C++/src/demo5_line_search.cxx
+++ b/examples/C++/src/demo5_line_search.cxx
@@ -33,7 +33,6 @@ std::vector<float>
 compute_linear_alphas(const float alpha_min, const float alpha_max, const float num_evaluations)
 {
   std::vector<float> alphas;
-  float alpha;
   float d_alpha = (alpha_max - alpha_min) / num_evaluations;
 
   std::cout << "\nComputing linear alphas:"
@@ -41,13 +40,15 @@ compute_linear_alphas(const float alpha_min, const float alpha_max, const float 
                "\n  alpha_max =   " << alpha_max <<
                "\n  delta_alpha = " << d_alpha << "\n";
 
-  // create a vector from (alpha_min + d_alpha) to alpha_max
-  // assumes general case that alpha_min = 0 and therefore line search does not compute alpha = 0
+  /// Explicitly add alpha = 0.0 and/or alpha_min
+  alphas.push_back(0.0);
+  if (alpha_min != 0.0)
+    alphas.push_back(alpha_min);
+
+  /// create a vector from (alpha_min + d_alpha) to alpha_max
   for (int i = 1; i <= num_evaluations; i++)
-  {
-    alpha = i * d_alpha;
-    alphas.push_back(alpha);
-  }
+    alphas.push_back(i * d_alpha);
+
   return alphas;
 }
 

--- a/examples/C++/src/demo5_line_search.cxx
+++ b/examples/C++/src/demo5_line_search.cxx
@@ -28,7 +28,29 @@
 #include "stir/IO/read_from_file.h"
 #include "stir/is_null_ptr.h"
 
-namespace stir {
+
+std::vector<float>
+compute_linear_alphas(const float alpha_min, const float alpha_max, const float num_evaluations)
+{
+  std::vector<float> alphas;
+  float alpha;
+  float d_alpha = (alpha_max - alpha_min) / num_evaluations;
+
+  std::cout << "Computing linear alphas:"
+               "\n  alpha_min =   " << alpha_min <<
+            "\n  alpha_max =   " << alpha_max <<
+            "\n  delta_alpha = " << d_alpha << "\n";
+
+  for (int i = 1; i <= num_evaluations; i++)
+  {
+    alpha = i * d_alpha;
+    alphas.push_back(alpha);
+  }
+  return alphas;
+}
+
+
+using namespace stir;
 
 class LineSearcher: public ParsingObject
 {
@@ -123,7 +145,6 @@ void LineSearcher::perform_line_search() {
 
 }
 
-}// end of namespace stir
 
 int main(int argc, char **argv)
 {

--- a/examples/C++/src/demo5_line_search.cxx
+++ b/examples/C++/src/demo5_line_search.cxx
@@ -1,7 +1,7 @@
 /*!
   \file
   \ingroup examples
-  \brief An example of a method to compute a line search evaluation in the direction of
+  \brief A class to compute a line search evaluation in the direction of
   the gradient of a given image and objective function.
   All parameters can be parsed from a parameter file. See `demo5_line_search.par`.
 
@@ -106,7 +106,7 @@ class LineSearcher: public ParsingObject
 {
 public:
     LineSearcher();
-    ////// Methods
+    /// Methods
     void set_defaults();
     void setup();
     double compute_line_search_value(const double alpha);
@@ -117,7 +117,7 @@ public:
 
     typedef DiscretisedDensity<3,float> target_type;
 
-    ////// Class variables
+    /// Class variables
     int num_evaluations;
     float alpha_min;
     float alpha_max;
@@ -141,7 +141,7 @@ private:
     bool post_processing();
 
     std::string image_filename;
-    bool is_setup = false;
+    bool is_setup;
     shared_ptr<OutputFileFormat<DiscretisedDensity<3,float> > > output_file_format_sptr;
 };
 

--- a/examples/C++/src/demo5_line_search.par
+++ b/examples/C++/src/demo5_line_search.par
@@ -3,18 +3,18 @@ LineSearcher parameters :=
     ; The image from which the line search will be performed
     image filename :=
 
-    ; The number of objective function evaluations to perform
+    ; The number of objective function evaluations to perform (default: 10)
     number of evaluations := 2000
 
-    ; The interval between the step sizes (alphas) can be either exponential (1) or linear (default: 0)
+    ; The interval between the step sizes (alphas) can be either exponential (1) or linear (0) (default: 0)
     use exponential alphas := 1
 
     ; Control the minimum and maximum of alpha values to compute
     ; `use exponential alphas := 1` then this controls the exponential e.g. 10^(alpha min) to 10^(alpha max)
-    alpha min := -10
-    alpha max := -2
+    alpha min := -10  ; default: 0.0
+    alpha max := -2   ; default: 1.0
 
-    ; Apply a lower threshold to every voxel in the computed images
+    ; Apply a lower threshold to every voxel in the computed images (default: 0.0)
     line search image lower bound = 0.0
 
     ; Objective function configuration
@@ -42,6 +42,7 @@ LineSearcher parameters :=
             end ray tracing matrix parameters :=
         end projector pair using matrix parameters :=
 
+        ; Prior configuration
         prior type := Quadratic
         Quadratic Prior Parameters:=
             penalisation factor := 0.0
@@ -51,7 +52,7 @@ LineSearcher parameters :=
         END Quadratic Prior Parameters:=
 
         use subset sensitivities:= 0
-        recompute sensitivity := 1
+        recompute sensitivity := 0
 
     end PoissonLogLikelihoodWithLinearModelForMeanAndProjData Parameters:=
 End :=

--- a/examples/C++/src/demo5_line_search.par
+++ b/examples/C++/src/demo5_line_search.par
@@ -1,0 +1,58 @@
+LineSearcher parameters :=
+
+    ; The image from which the line search will be performed
+    image filename :=
+
+    ; The number of objective function evaluations to perform
+    number of evaluations := 2000
+
+    ; The interval between the step sizes (alphas) can be either exponential (1) or linear (default: 0)
+    use exponential alphas := 1
+
+    ; Control the minimum and maximum of alpha values to compute
+    ; `use exponential alphas := 1` then this controls the exponential e.g. 10^(alpha min) to 10^(alpha max)
+    alpha min := -10
+    alpha max := -2
+
+    ; Apply a lower threshold to every voxel in the computed images
+    line search image lower bound = 0.0
+
+    ; Objective function configuration
+    objective function type := PoissonLogLikelihoodWithLinearModelForMeanAndProjData
+    PoissonLogLikelihoodWithLinearModelForMeanAndProjData Parameters:=
+
+        input file :=
+
+        additive_sinogram :=
+
+        projector pair type := Matrix
+        projector pair using matrix parameters :=
+            matrix type := Ray Tracing
+            ray tracing matrix parameters :=
+                disable caching := 0
+                store only basic bins in cache := 1
+                restrict to cylindrical fov := 0
+                number of rays in tangential direction to trace for each bin := 50
+                use actual detector boundaries := 1
+                do symmetry 90degrees min phi := 0
+                do symmetry 180degrees min phi := 0
+                do symmetry swap segment := 1
+                do symmetry swap s := 1
+                do symmetry shift z := 1
+            end ray tracing matrix parameters :=
+        end projector pair using matrix parameters :=
+
+        prior type := Quadratic
+        Quadratic Prior Parameters:=
+            penalisation factor := 0.0
+            only 2D:= 0
+            ;kappa filename:= 
+            gamma value := 2
+        END Quadratic Prior Parameters:=
+
+        use subset sensitivities:= 0
+        recompute sensitivity := 1
+
+    end PoissonLogLikelihoodWithLinearModelForMeanAndProjData Parameters:=
+End :=
+

--- a/examples/C++/src/demo5_line_search.par
+++ b/examples/C++/src/demo5_line_search.par
@@ -31,16 +31,7 @@ LineSearcher parameters :=
         projector pair using matrix parameters :=
             matrix type := Ray Tracing
             ray tracing matrix parameters :=
-                disable caching := 0
-                store only basic bins in cache := 1
-                restrict to cylindrical fov := 0
-                number of rays in tangential direction to trace for each bin := 50
-                use actual detector boundaries := 1
-                do symmetry 90degrees min phi := 0
-                do symmetry 180degrees min phi := 0
-                do symmetry swap segment := 1
-                do symmetry swap s := 1
-                do symmetry shift z := 1
+                number of rays in tangential direction to trace for each bin := 10
             end ray tracing matrix parameters :=
         end projector pair using matrix parameters :=
 
@@ -48,9 +39,6 @@ LineSearcher parameters :=
         prior type := Quadratic
         Quadratic Prior Parameters:=
             penalisation factor := 0.0
-            only 2D:= 0
-            ;kappa filename:= 
-            gamma value := 2
         END Quadratic Prior Parameters:=
 
     end PoissonLogLikelihoodWithLinearModelForMeanAndProjData Parameters:=

--- a/examples/C++/src/demo5_line_search.par
+++ b/examples/C++/src/demo5_line_search.par
@@ -1,7 +1,7 @@
 LineSearcher parameters :=
 
     ; The image from which the line search will be performed
-    image filename :=
+    image filename := demo3_density.hv
 
     ; The number of objective function evaluations to perform (default: 10)
     number of evaluations := 2000
@@ -22,10 +22,10 @@ LineSearcher parameters :=
     PoissonLogLikelihoodWithLinearModelForMeanAndProjData Parameters:=
 
         ; Measured sinogram data filename
-        input file :=
+        input file := sino.hs	
 
         ; Additive sinogram data filename
-        additive_sinogram :=
+        additive_sinogram := 0
 
         projector pair type := Matrix
         projector pair using matrix parameters :=

--- a/examples/C++/src/demo5_line_search.par
+++ b/examples/C++/src/demo5_line_search.par
@@ -15,14 +15,16 @@ LineSearcher parameters :=
     alpha max := -2   ; default: 1.0
 
     ; Apply a lower threshold to every voxel in the computed images (default: 0.0)
-    line search image lower bound = 0.0
+    line search image lower bound := 0.0
 
     ; Objective function configuration
     objective function type := PoissonLogLikelihoodWithLinearModelForMeanAndProjData
     PoissonLogLikelihoodWithLinearModelForMeanAndProjData Parameters:=
 
+        ; Measured sinogram data filename
         input file :=
 
+        ; Additive sinogram data filename
         additive_sinogram :=
 
         projector pair type := Matrix
@@ -50,9 +52,6 @@ LineSearcher parameters :=
             ;kappa filename:= 
             gamma value := 2
         END Quadratic Prior Parameters:=
-
-        use subset sensitivities:= 0
-        recompute sensitivity := 0
 
     end PoissonLogLikelihoodWithLinearModelForMeanAndProjData Parameters:=
 End :=

--- a/examples/C++/src/demo5_line_search.par
+++ b/examples/C++/src/demo5_line_search.par
@@ -4,7 +4,7 @@ LineSearcher parameters :=
     image filename := demo3_density.hv
 
     ; The number of objective function evaluations to perform (default: 10)
-    number of evaluations := 2000
+    number of evaluations := 10
 
     ; The interval between the step sizes (alphas) can be either exponential (1) or linear (0) (default: 0)
     use exponential alphas := 1
@@ -22,7 +22,7 @@ LineSearcher parameters :=
     PoissonLogLikelihoodWithLinearModelForMeanAndProjData Parameters:=
 
         ; Measured sinogram data filename
-        input file := sino.hs	
+        input file := sino.hs
 
         ; Additive sinogram data filename
         additive_sinogram := 0


### PR DESCRIPTION
A piece of code I developed for my own research that adds the ability to perform a line search in C++ using STIR. I feel this is a natural progression from `demo4_obj_fun.cxx` to do something that is optimisation based but not already in STIR.

From the file brief:
A class to compute a line search evaluation in the direction of the gradient of a given image and objective function. All parameters can be parsed from a parameter file. See `demo5_line_search.par`.

Give an image and objective function configuration, this script will perform a line searchfrom an minimum to an maximum step size (alpha). Options are included to perform this line search linearly or using exponential step
size iterations. Additionally, a lower positivity bound is applied to all computed image.

The results are saved to files: `alphas.dat` contains the step size values investigated, and `Phis.dat` contains the objective function evaluations. Furthermore, the image corresponding to the maximum objective function and the gradient used in the line search are saved to file.
