### PR TITLE
Fix bug with iteration limit

### DIFF
--- a/src/modelling_utilities/make_parametric_image_from_components.cxx
+++ b/src/modelling_utilities/make_parametric_image_from_components.cxx
@@ -49,7 +49,7 @@ int main(int argc, char *argv[])
         std::vector<VoxelsOnCartesianGrid<float> > params;
 
         // Loop over all parameters
-        for (int i=2; i<=argc; ++i) {
+        for (int i=2; i<argc; ++i) {
 
             // Read
             shared_ptr<DiscretisedDensity<3,float> > im(read_from_file<DiscretisedDensity<3,float> >(argv[i]));


### PR DESCRIPTION
Loops for 1 more argc than exits, errors with ambiguous message:

    	basic_string::_M_construct null not valid


I suspect this is not tested, but I will submit without the skipping command just in case. 