### PR TITLE
 ExamInfo: removed check on originating system for operator ==: #892

### DIFF
--- a/src/buildblock/ExamInfo.cxx
+++ b/src/buildblock/ExamInfo.cxx
@@ -85,7 +85,6 @@ ExamInfo::operator == (const ExamInfo &p1) const {
             ((this->calibration_factor<=0 && p1.calibration_factor<=0) || 
              abs(this->calibration_factor/p1.calibration_factor -1.)<=1E-3) &&
             this->imaging_modality==p1.imaging_modality &&
-            this->originating_system==p1.originating_system &&
             this->patient_position==p1.patient_position &&
             abs(this->start_time_in_secs_since_1970 - p1.start_time_in_secs_since_1970)<=.5;/* sec */ }
 

--- a/src/include/stir/ExamInfo.h
+++ b/src/include/stir/ExamInfo.h
@@ -45,6 +45,8 @@ START_NAMESPACE_STIR
 
   \todo This should be an abtract registered object, in order to serve as a complete
   base function for every input data type.
+  
+  Warning: the operator == does not check that originating system is consistent!
   */
 class ExamInfo
 {

--- a/src/include/stir/ExamInfo.h
+++ b/src/include/stir/ExamInfo.h
@@ -46,7 +46,6 @@ START_NAMESPACE_STIR
   \todo This should be an abtract registered object, in order to serve as a complete
   base function for every input data type.
   
-  Warning: the operator == does not check that originating system is consistent!
   */
 class ExamInfo
 {
@@ -128,6 +127,7 @@ public :
       time_frame_definitions = new_time_frame_definitions;
     }
 
+  //!  Warning: the operator == does not check that originating system is consistent!
   bool operator == (const ExamInfo &p1) const ;
   
   //! Clone and create shared_ptr of the copy


### PR DESCRIPTION
fixing #892 