### PR TITLE
Add a Hessian test to PoissonLogLikelihoodWithLinearModelForMeanAndProjData (and fix Hessian)

### DIFF
--- a/documentation/release_5.0.htm
+++ b/documentation/release_5.0.htm
@@ -61,6 +61,11 @@ To reflect this change, <code>Scanner::get_default_intrinsic_tilt()</code> has b
 Note: start angle was already supported for SPECT<br />
 Backward compatibility for reconstructed images can be achieved by setting the <tt>STIR_LEGACY_IGNORE_VIEW_OFFSET</tt> CMake option to <tt>ON</tt>. (However, copied sinogram data will then always have the offset set to 0, in contrast to earlier versions of STIR).
 </li>
+<li>
+    PoissonLogLikelihood Hessian methods have been corrected to reflect the concavity of the function. Hessian vector products now return non-positive voxels, if the vector (input) is non-negative.
+    STIR usages of these methods (OSSPS and SqrtHessianRowSum) have been updated to see no effective change in functionality.
+    However, calling the Hessian vector product methods, via python etc., will result in a change in functionality as the sign of the output voxel values has changed.
+</li>
 </ul>
 
 

--- a/src/include/stir/OSSPS/OSSPSReconstruction.h
+++ b/src/include/stir/OSSPS/OSSPSReconstruction.h
@@ -134,7 +134,8 @@ public:
 
     This method assumes that the objective function is concave and the output
     add_multiplication_with_approximate_Hessian_without_penalty is non-positive.
-    This method flips the sign of all voxels in the computed denominator
+    This method flips the sign of all voxels in the computed denominator as for this OSSPS
+    implementation, the denominator is expected to be non-negative.
 
     The computed denominator is saved to file as output_filename_prefix
     plus "_precomputed_denominator".

--- a/src/include/stir/OSSPS/OSSPSReconstruction.h
+++ b/src/include/stir/OSSPS/OSSPSReconstruction.h
@@ -131,6 +131,13 @@ public:
     GeneralisedObjectiveFunction::add_multiplication_with_approximate_Hessian_without_penalty
     on a vector filled with ones. For emission and transmission tomography,
     this corresponds to Erdogan and Fessler's approximations.
+
+    This method assumes that the objective function is concave and the output
+    add_multiplication_with_approximate_Hessian_without_penalty is non-positive.
+    This method flips the sign of all voxels in the computed denominator
+
+    The computed denominator is saved to file as output_filename_prefix
+    plus "_precomputed_denominator".
 */
   Succeeded 
     precompute_denominator_of_conditioner_without_penalty();

--- a/src/include/stir/OSSPS/OSSPSReconstruction.h
+++ b/src/include/stir/OSSPS/OSSPSReconstruction.h
@@ -132,10 +132,8 @@ public:
     on a vector filled with ones. For emission and transmission tomography,
     this corresponds to Erdogan and Fessler's approximations.
 
-    This method assumes that the objective function is concave and the output
+    This method assumes that the objective function is concave and the output of
     add_multiplication_with_approximate_Hessian_without_penalty is non-positive.
-    This method flips the sign of all voxels in the computed denominator as for this OSSPS
-    implementation, the denominator is expected to be non-negative.
 
     The computed denominator is saved to file as output_filename_prefix
     plus "_precomputed_denominator".
@@ -205,4 +203,3 @@ END_NAMESPACE_STIR
 #endif
 
 // __OSSPSReconstruction_h__
-

--- a/src/include/stir/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMeanAndProjData.h
+++ b/src/include/stir/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMeanAndProjData.h
@@ -272,11 +272,11 @@ public:
     The Hessian (without penalty) is approximately given by:
     \f[ H_{jk} = - \sum_i P_{ij} h_i^{''}(y_i) P_{ik} \f]
     where
-    \f[ h_i(l) = y_i log (l) - l; h_i^{''}(y_i) = y_i / ((P \lambda)_i + a_i)^2; \f]
+    \f[ h_i(l) = y_i log (l) - l; h_i^{''}(y_i) = - y_i / ((P \lambda)_i + a_i)^2; \f]
     and \f$P_{ij} \f$ is the probability matrix.
 
     Hence
-    \f[ H_{jk} =  \sum_i P_{ij}(y_i / ((P \lambda)_i + a_i)^2) P_{ik} \f]
+    \f[ H_{jk} = - \sum_i P_{ij}(y_i / ((P \lambda)_i + a_i)^2) P_{ik} \f]
 
     This function is computationally expensive and can be approximated, see
     add_multiplication_with_approximate_sub_Hessian_without_penalty()

--- a/src/include/stir/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMeanAndProjData.h
+++ b/src/include/stir/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMeanAndProjData.h
@@ -244,11 +244,15 @@ public:
     This function uses the approximation of the hessian
     \f[ h_i^{''}(y_i) \approx -1/y_i \f]
     Hence
-    \f[ H_{jk} =  \sum_i P_{ij}(1/y_i) P_{ik} \f]
+    \f[ H_{jk} = - \sum_i P_{ij}(1/y_i) P_{ik} \f]
 
     In the above, we've used the plug-in approximation by replacing 
     forward projection of the true image by the measured data. However, the
     later are noisy and this can create problems. 
+
+    The LogLikelihood is a concave function and therefore the Hessian is non-positive.
+    Thus, this (approximate-)Hessian vector product methods output volumes with negative values,
+    if the input is non-negative.
 
     \todo Two work-arounds for the noisy estimate of the Hessian are listed below, 
     but they are currently not implemented.
@@ -280,6 +284,10 @@ public:
 
     This function is computationally expensive and can be approximated, see
     add_multiplication_with_approximate_sub_Hessian_without_penalty()
+
+    The loglikelihood is a concave function, see
+    add_multiplication_with_approximate_sub_Hessian_without_penalty() for
+    more details regarding Hessian methods.
   */
   virtual Succeeded
         actual_accumulate_sub_Hessian_times_input_without_penalty(TargetT& output,

--- a/src/iterative/OSSPS/OSSPSReconstruction.cxx
+++ b/src/iterative/OSSPS/OSSPSReconstruction.cxx
@@ -227,6 +227,11 @@ precompute_denominator_of_conditioner_without_penalty()
     add_multiplication_with_approximate_Hessian_without_penalty(
 								*precomputed_denominator_ptr, 
 								*data_full_of_ones_aptr);
+
+  // The precomputed_denominator_ptr is negative. Here we flip the sign on each voxel.
+  std::for_each(precomputed_denominator_ptr->begin_all(), precomputed_denominator_ptr->end_all(),
+                [](float& a) { return a=-a; } );
+
   timer.stop();
   info(boost::format("Precomputing denominator took %1% s CPU time") % timer.value());
   info(boost::format("min and max in precomputed denominator %1%, %2%") % *std::min_element(precomputed_denominator_ptr->begin_all(), precomputed_denominator_ptr->end_all()) % *std::max_element(precomputed_denominator_ptr->begin_all(), precomputed_denominator_ptr->end_all()));  

--- a/src/iterative/OSSPS/OSSPSReconstruction.cxx
+++ b/src/iterative/OSSPS/OSSPSReconstruction.cxx
@@ -223,13 +223,14 @@ precompute_denominator_of_conditioner_without_penalty()
 	    data_full_of_ones_aptr->end_all(),
 	    1.F);
 
-  // Assume that the objective function is convex and thus the precomputed_denominator_ptr is non-positive.
+  // Assume that the objective function is convex and add_multiplication_with_approximate_Hessian_without_penalty
+  // will compute the precomputed_denominator_ptr to be non-positive.
   this->objective_function_sptr->
     add_multiplication_with_approximate_Hessian_without_penalty(
 								*precomputed_denominator_ptr, 
 								*data_full_of_ones_aptr);
 
-  // Flip the sign on each voxel value, each voxel value should be non-negative
+  // In fact, for for OSSPS, we want a non-negative precomputed denominator, so flip the signs on the voxels
   std::for_each(precomputed_denominator_ptr->begin_all(), precomputed_denominator_ptr->end_all(),
                 [](float& a) { return a=-a; } );
 

--- a/src/iterative/OSSPS/OSSPSReconstruction.cxx
+++ b/src/iterative/OSSPS/OSSPSReconstruction.cxx
@@ -223,18 +223,24 @@ precompute_denominator_of_conditioner_without_penalty()
 	    data_full_of_ones_aptr->end_all(),
 	    1.F);
 
+  // Assume that the objective function is convex and thus the precomputed_denominator_ptr is non-positive.
   this->objective_function_sptr->
     add_multiplication_with_approximate_Hessian_without_penalty(
 								*precomputed_denominator_ptr, 
 								*data_full_of_ones_aptr);
 
-  // The precomputed_denominator_ptr is negative. Here we flip the sign on each voxel.
+  // Flip the sign on each voxel value, each voxel value should be non-negative
   std::for_each(precomputed_denominator_ptr->begin_all(), precomputed_denominator_ptr->end_all(),
                 [](float& a) { return a=-a; } );
 
   timer.stop();
   info(boost::format("Precomputing denominator took %1% s CPU time") % timer.value());
-  info(boost::format("min and max in precomputed denominator %1%, %2%") % *std::min_element(precomputed_denominator_ptr->begin_all(), precomputed_denominator_ptr->end_all()) % *std::max_element(precomputed_denominator_ptr->begin_all(), precomputed_denominator_ptr->end_all()));  
+  float min_val = *std::min_element(precomputed_denominator_ptr->begin_all(), precomputed_denominator_ptr->end_all());
+  float max_val = *std::max_element(precomputed_denominator_ptr->begin_all(), precomputed_denominator_ptr->end_all());
+  info(boost::format("min and max in precomputed denominator %1%, %2%") % min_val % max_val);
+  if (min_val < -0)
+    warning("Precomputing denominator has negative values! "
+            "This may be due to the objective function not being concave");
 
   // Write it to file
   {

--- a/src/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMeanAndProjData.cxx
+++ b/src/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMeanAndProjData.cxx
@@ -1052,10 +1052,10 @@ actual_accumulate_sub_Hessian_times_input_without_penalty(TargetT& output,
 
   shared_ptr<TargetT> tmp(output.get_empty_copy());
   this->get_projector_pair().get_back_projector_sptr()->get_output(*tmp);
-  // output += tmp;
+  // output -= tmp;
   std::transform(output.begin_all(), output.end_all(),
                  tmp->begin_all(), output.begin_all(),
-                 std::plus<typename TargetT::full_value_type>());
+                 std::minus<typename TargetT::full_value_type>());
 
   return Succeeded::yes;
 }

--- a/src/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMeanAndProjData.cxx
+++ b/src/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMeanAndProjData.cxx
@@ -910,7 +910,7 @@ actual_add_multiplication_with_approximate_sub_Hessian_without_penalty(TargetT& 
   // output += tmp;
   std::transform(output.begin_all(), output.end_all(),
                  tmp->begin_all(), output.begin_all(),
-		 std::plus<typename TargetT::full_value_type>());
+		 std::minus<typename TargetT::full_value_type>());
 
   return Succeeded::yes;
 }

--- a/src/recon_buildblock/SqrtHessianRowSum.cxx
+++ b/src/recon_buildblock/SqrtHessianRowSum.cxx
@@ -197,9 +197,10 @@ process_data()
     compute_Hessian_row_sum();
   }
 
-  // Square Root the output of the Hessian_row_sum methods
+  // Square Root the negative output of the Hessian_row_sum methods
+  // (approximate) Hessian times a non-negative vector will result in a negative output. Flip the sign before sqrt.
   std::for_each(output_target_sptr->begin_all(), output_target_sptr->end_all(),
-                [](float& a) { return a=sqrt(a); } );
+                [](float& a) { return a=sqrt(-a); } );
 
   // Save the output
   if (!output_filename.empty())

--- a/src/recon_test/test_PoissonLogLikelihoodWithLinearModelForMeanAndProjData.cxx
+++ b/src/recon_test/test_PoissonLogLikelihoodWithLinearModelForMeanAndProjData.cxx
@@ -113,8 +113,8 @@ protected:
                                         target_type& target);
 
   //! Test the Hessian of the objective function by testing the (x^T Hx > 0) condition
-  void test_objective_function_Hessian(GeneralisedObjectiveFunction<target_type>& objective_function,
-                                       target_type& target);
+  void test_objective_function_Hessian_concavity(GeneralisedObjectiveFunction<target_type>& objective_function,
+                                                 target_type& target);
 };
 
 PoissonLogLikelihoodWithLinearModelForMeanAndProjDataTests::
@@ -131,8 +131,8 @@ run_tests_for_objective_function(GeneralisedObjectiveFunction<PoissonLogLikeliho
                                    target);
 
   std::cerr << "----- testing Hessian-vector product (accumulate_Hessian_times_input)\n";
-  test_objective_function_Hessian(objective_function,
-                                  target);
+  test_objective_function_Hessian_concavity(objective_function,
+                                            target);
 }
 
 void
@@ -190,8 +190,8 @@ test_objective_function_gradient(GeneralisedObjectiveFunction<target_type> &obje
 }
 void
 PoissonLogLikelihoodWithLinearModelForMeanAndProjDataTests::
-test_objective_function_Hessian(GeneralisedObjectiveFunction<target_type> &objective_function,
-                                 target_type &target){
+test_objective_function_Hessian_concavity(GeneralisedObjectiveFunction<target_type> &objective_function,
+                                          target_type &target){
   /// setup images
   shared_ptr<target_type> output(target.get_empty_copy());
 

--- a/src/recon_test/test_PoissonLogLikelihoodWithLinearModelForMeanAndProjData.cxx
+++ b/src/recon_test/test_PoissonLogLikelihoodWithLinearModelForMeanAndProjData.cxx
@@ -206,16 +206,7 @@ test_objective_function_Hessian_concavity(GeneralisedObjectiveFunction<target_ty
   objective_function.accumulate_Hessian_times_input(*output, target, target);
 
   /// Compute dot(x,(H x))
-  float my_sum = 0.0;
-  {
-    target_type::full_iterator target_iter = target.begin_all();
-    target_type::full_iterator output_iter = output->begin_all();
-    while (target_iter != target.end_all())// && testOK)
-    {
-      my_sum += *target_iter * *output_iter;
-      ++target_iter; ++output_iter;
-    }
-  }
+  const float my_sum = std::inner_product(target.begin_all(), target.end_all(), output->begin_all(), 0.F);
 
   // test for a CONCAVE function
   if (this->check_if_less( my_sum, 0)) {
@@ -241,16 +232,7 @@ test_objective_function_approximate_Hessian_concavity(GeneralisedObjectiveFuncti
   objective_function.add_multiplication_with_approximate_Hessian(*output, target);
 
   /// Compute dot(x,(H x))
-  float my_sum = 0.0;
-  {
-    target_type::full_iterator target_iter = target.begin_all();
-    target_type::full_iterator output_iter = output->begin_all();
-    while (target_iter != target.end_all())// && testOK)
-    {
-      my_sum += *target_iter * *output_iter;
-      ++target_iter; ++output_iter;
-    }
-  }
+  const float my_sum = std::inner_product(target.begin_all(), target.end_all(), output->begin_all(), 0.F);
 
   // test for a CONCAVE function
   if (this->check_if_less( my_sum, 0)) {

--- a/src/recon_test/test_PoissonLogLikelihoodWithLinearModelForMeanAndProjData.cxx
+++ b/src/recon_test/test_PoissonLogLikelihoodWithLinearModelForMeanAndProjData.cxx
@@ -132,12 +132,11 @@ PoissonLogLikelihoodWithLinearModelForMeanAndProjDataTests::
 run_tests_for_objective_function(GeneralisedObjectiveFunction<PoissonLogLikelihoodWithLinearModelForMeanAndProjDataTests::target_type>& objective_function,
                                  PoissonLogLikelihoodWithLinearModelForMeanAndProjDataTests::target_type& target) {
   std::cerr << "----- testing Gradient\n";
-  test_objective_function_gradient(objective_function,
-                                   target);
+  test_objective_function_gradient(objective_function,target);
 
   std::cerr << "----- testing Hessian-vector product (accumulate_Hessian_times_input)\n";
-  test_objective_function_Hessian_concavity(objective_function,
-                                            target);
+  test_objective_function_Hessian_concavity(objective_function,target);
+
   std::cerr << "----- testing approximate-Hessian-vector product (accumulate_Hessian_times_input)\n";
   test_objective_function_approximate_Hessian_concavity(objective_function, target);
 }
@@ -195,6 +194,7 @@ test_objective_function_gradient(GeneralisedObjectiveFunction<target_type> &obje
     }
 
 }
+
 void
 PoissonLogLikelihoodWithLinearModelForMeanAndProjDataTests::
 test_objective_function_Hessian_concavity(GeneralisedObjectiveFunction<target_type> &objective_function,
@@ -219,10 +219,10 @@ test_objective_function_Hessian_concavity(GeneralisedObjectiveFunction<target_ty
 
   // test for a CONCAVE function
   if (this->check_if_less( my_sum, 0)) {
-//    info("PASS: Computation of x^T H x = " + std::to_string(my_sum) + " < 0" and is therefore concave);
+//    info("PASS: Computation of x^T H x = " + std::to_string(my_sum) + " < 0" (Hessian) and is therefore concave);
   } else {
     // print to console the FAILED configuration
-    info("FAIL: Computation of x^T H x = " + std::to_string(my_sum) + " > 0 and is therefore NOT concave" +
+    info("FAIL: Computation of x^T H x = " + std::to_string(my_sum) + " > 0 (Hessian) and is therefore NOT concave" +
          "\n >target image max=" + std::to_string(target.find_max()) +
          "\n >target image min=" + std::to_string(target.find_min()));
   }
@@ -254,10 +254,10 @@ test_objective_function_approximate_Hessian_concavity(GeneralisedObjectiveFuncti
 
   // test for a CONCAVE function
   if (this->check_if_less( my_sum, 0)) {
-//    info("PASS: Computation of x^T H x = " + std::to_string(my_sum) + " < 0" and is therefore concave);
+//    info("PASS: Computation of x^T H x = " + std::to_string(my_sum) + " < 0" (approximate-Hessian) and is therefore concave);
   } else {
     // print to console the FAILED configuration
-    info("FAIL: Computation of x^T H x = " + std::to_string(my_sum) + " > 0 and is therefore NOT concave" +
+    info("FAIL: Computation of x^T H x = " + std::to_string(my_sum) + " > 0 (approximate-Hessian) and is therefore NOT concave" +
          "\n >target image max=" + std::to_string(target.find_max()) +
          "\n >target image min=" + std::to_string(target.find_min()));
   }

--- a/src/recon_test/test_PoissonLogLikelihoodWithLinearModelForMeanAndProjData.cxx
+++ b/src/recon_test/test_PoissonLogLikelihoodWithLinearModelForMeanAndProjData.cxx
@@ -211,10 +211,10 @@ test_objective_function_Hessian(GeneralisedObjectiveFunction<target_type> &objec
   }
   // test for a CONCAVE function
   if (this->check_if_less( my_sum, 0)) {
-//    info("PASS: Computation of x^T H x = " + std::to_string(my_sum) + " > 0");
+//    info("PASS: Computation of x^T H x = " + std::to_string(my_sum) + " < 0" and is therefore concave);
   } else {
     // print to console the FAILED configuration
-    info("FAIL: Computation of x^T H x = " + std::to_string(my_sum) + " < 0" +
+    info("FAIL: Computation of x^T H x = " + std::to_string(my_sum) + " > 0 and is therefore NOT concave" +
          "\n >target image max=" + std::to_string(target.find_max()) +
          "\n >target image min=" + std::to_string(target.find_min()));
   }


### PR DESCRIPTION
Addresses #911

- Adds `test_objective_function_Hessian` which utilises `objective_function.accumulate_Hessian_times_input` to test the concavity condition `x^T H x <= 0`. 

- Modifies `actual_accumulate_sub_Hessian_times_input_without_penalty` (and approximate version) in `PoissonLogLikelihoodWithLinearModelForMeanAndProjData` to be a concave functions (plus -> minus)
 