### PR TITLE
Compute ROI values from voxelised shape

### DIFF
--- a/documentation/release_5.0.htm
+++ b/documentation/release_5.0.htm
@@ -251,6 +251,10 @@ as used by <code>copy_to</code> and <code>fill_from</code>
   Before this, the <code>add_multiplication_with_approximate_Hessian(output, input)</code> method was used that assumed a quadratic function and therefore <code>hessian = 1</code>.
 </li>
 <li><code>Exam_info</code>, <code>TimeFrameDefinition</code> and <code>PatientPosition </code> have now a <code>==</code> operator</li>
+<li>
+    Overloaded <code>compute_total_ROI_values</code> and <code>compute_ROI_values_per_plane</code> functions to allow the parsing of <code>VoxelsOnCartesianGrid</code> instead of <code>Shape3D</code> as the ROI shape.
+    This allows the ROI volume to be constructed during preprocessing for multiple image analysis.
+</li>
 </ul>
 
 

--- a/documentation/release_5.0.htm
+++ b/documentation/release_5.0.htm
@@ -252,7 +252,7 @@ as used by <code>copy_to</code> and <code>fill_from</code>
 </li>
 <li><code>Exam_info</code>, <code>TimeFrameDefinition</code> and <code>PatientPosition </code> have now a <code>==</code> operator</li>
 <li>
-    Overloaded <code>compute_total_ROI_values</code> and <code>compute_ROI_values_per_plane</code> functions to allow the parsing of <code>VoxelsOnCartesianGrid</code> instead of <code>Shape3D</code> as the ROI shape.
+    Overloaded <code>compute_total_ROI_values</code> and <code>compute_ROI_values_per_plane</code> functions to allow the passing of  a<code>VoxelsOnCartesianGrid</code> object instead of a <code>Shape3D</code> as the ROI shape.
     This allows the ROI volume to be constructed during preprocessing for multiple image analysis.
 </li>
 </ul>

--- a/examples/python/ROI_demo.py
+++ b/examples/python/ROI_demo.py
@@ -1,9 +1,15 @@
-# Demo of how to use STIR from Python to compute ROI values
+# Demo of how to use STIR from Python to compute ROI values using two overloaded versions of the same function.
+# The first usage take a STIR shape and internally generates the shape into a voxelised shape before performing ROI
+# analysis.
+# For the second usage, this python script pre-generates the voxelised shape and passes this as argument to STIR.
+# The preprocessing of the voxelised shape reduces the time spent on the evalution of multiple images for a given ROI.
+
 # To run in "normal" Python, you would type the following in the command line
 #  execfile('projector_demo.py')
 # In ipython, you can use
 #  %run projector_demo.py
 
+# Author: Robert Twyman
 # Copyright 2021 - University College London
 # This file is part of STIR.
 #
@@ -16,6 +22,7 @@ import stir
 import stirextra
 import os
 import numpy as np
+import time
 #%% go to directory with input files
 
 print("\nRunning ROI_demo.py")
@@ -33,21 +40,48 @@ image_numpy = np.random.random(image_numpy.shape)
 image.fill(image_numpy.flat)
 
 # Construct an example shape
-print("Constructing a EllipsoidalCylinder as the Region Of Interest (ROI)...")
+print("Creating a EllipsoidalCylinder object as the Region Of Interest (ROI)...")
 ROI_shape = stir.EllipsoidalCylinder(10, 5, 4, stir.FloatCartesianCoordinate3D(0, 0, 0))
-
-
 
 # number_of_sample needs to be a 3D Int CartesianCoordinate
 n = 10
 print(f"Setting the number of samples of each axis to be {n}...")
 number_of_samples = stir.IntCartesianCoordinate3D(n, n, n)
 
-# Do ROI evaluation
-print("Computing ROI value...")
-ROI_eval = stir.compute_total_ROI_values(image, ROI_shape, number_of_samples)
 
-# Print the mean and standard deviation
-print(f"ROI mean value = {ROI_eval.get_mean()}")
-print(f"ROI stddev value = {ROI_eval.get_stddev()}")
+print("\n\nComputing ROI values using different functions to demonstrate acceleration.")
+# Do ROI evaluation
+print("Method 1: Pass ROI shape to compute_total_ROI_values...")
+print(" - Computing ROI values...")
+t0 = time.time()
+ROI_eval1 = stir.compute_total_ROI_values(image, ROI_shape, number_of_samples)
+t1 = time.time()
+print(f" - Time taken = {round(t1-t0,6)} seconds")
+
+# Print ROI details
+print("\n - ROI details:")
+print(ROI_eval1.report())
+
+
+print("\nMethod 2: construct the ROI_image for analysis.")
+print(" - Constructing ROI volume...")
+ROI_volume = image.get_empty_copy()
+# construct_volume constructs the ROI_shape in ROI_volume
+ROI_shape.construct_volume(ROI_volume, number_of_samples)
+
+print(" - Computing ROI values...")
+t2 = time.time()
+ROI_eval2 = stir.compute_total_ROI_values(image, ROI_volume)
+t3 = time.time()
+print(f" - Time taken = {round(t3-t2, 6)} seconds")
+# Print ROI details
+print("\n - ROI details:")
+print(ROI_eval2.report())
+
+
+# ROI analysis of multiple images should precompute ROI
+# However, for a single image the preprocessing in python is likely slower...
+print(f"The ROI analysis is ~{round((t1-t0)/(t3-t2),1)}x faster when a ROI volume is passed (Method 2),"
+      f" instead of a shape (Method 1).")
+
 

--- a/src/eval_buildblock/compute_ROI_values.cxx
+++ b/src/eval_buildblock/compute_ROI_values.cxx
@@ -49,7 +49,7 @@ compute_ROI_values_per_plane(VectorWithOffset<ROIValues>& values,
 void
 compute_ROI_values_per_plane(VectorWithOffset<ROIValues>& values,
                              const DiscretisedDensity<3,float>& density,
-                             const VoxelsOnCartesianGrid<float>& discretised_shape)
+                             const DiscretisedDensity<3,float>& discretised_shape)
 {
 
   const int min_z = density.get_min_index();
@@ -139,7 +139,7 @@ compute_total_ROI_values(const DiscretisedDensity<3,float>& image,
 
 ROIValues
 compute_total_ROI_values(const DiscretisedDensity<3,float>& image,
-                         const VoxelsOnCartesianGrid<float>& discretised_shape)
+                         const DiscretisedDensity<3,float>& discretised_shape)
 {
   VectorWithOffset<ROIValues> values;
   compute_ROI_values_per_plane(values, image, discretised_shape);

--- a/src/eval_buildblock/compute_ROI_values.cxx
+++ b/src/eval_buildblock/compute_ROI_values.cxx
@@ -140,11 +140,11 @@ compute_total_ROI_values(const DiscretisedDensity<3,float>& image,
 
 ROIValues
 compute_total_ROI_values(const DiscretisedDensity<3,float>& image,
-                         const VoxelsOnCartesianGrid<float>& discretised_shape_ptr,
+                         const VoxelsOnCartesianGrid<float>& discretised_shape,
                          const CartesianCoordinate3D<int>& num_samples)
 {
   VectorWithOffset<ROIValues> values;
-    compute_ROI_values_per_plane(values, image, discretised_shape_ptr, num_samples);
+    compute_ROI_values_per_plane(values, image, discretised_shape, num_samples);
     return compute_total_ROI_values(values);
 }
 

--- a/src/eval_buildblock/compute_ROI_values.cxx
+++ b/src/eval_buildblock/compute_ROI_values.cxx
@@ -43,14 +43,13 @@ compute_ROI_values_per_plane(VectorWithOffset<ROIValues>& values,
 
   shape.construct_volume(*discretised_shape_ptr, num_samples);
 
-  compute_ROI_values_per_plane(values, density, *discretised_shape_ptr, num_samples);
+  compute_ROI_values_per_plane(values, density, *discretised_shape_ptr);
 }
 
 void
 compute_ROI_values_per_plane(VectorWithOffset<ROIValues>& values,
                              const DiscretisedDensity<3,float>& density,
-                             const VoxelsOnCartesianGrid<float>& discretised_shape,
-                             const CartesianCoordinate3D<int>& num_samples)
+                             const VoxelsOnCartesianGrid<float>& discretised_shape)
 {
 
   const int min_z = density.get_min_index();
@@ -140,11 +139,10 @@ compute_total_ROI_values(const DiscretisedDensity<3,float>& image,
 
 ROIValues
 compute_total_ROI_values(const DiscretisedDensity<3,float>& image,
-                         const VoxelsOnCartesianGrid<float>& discretised_shape,
-                         const CartesianCoordinate3D<int>& num_samples)
+                         const VoxelsOnCartesianGrid<float>& discretised_shape)
 {
   VectorWithOffset<ROIValues> values;
-    compute_ROI_values_per_plane(values, image, discretised_shape, num_samples);
+  compute_ROI_values_per_plane(values, image, discretised_shape);
     return compute_total_ROI_values(values);
 }
 

--- a/src/eval_buildblock/compute_ROI_values.cxx
+++ b/src/eval_buildblock/compute_ROI_values.cxx
@@ -51,6 +51,8 @@ compute_ROI_values_per_plane(VectorWithOffset<ROIValues>& values,
                              const DiscretisedDensity<3,float>& density,
                              const DiscretisedDensity<3,float>& discretised_shape)
 {
+  if (!density.has_same_characteristics(discretised_shape))
+    error("compute_ROI_values_per_plane: density and discretised_shape do not have the same characteristics.");
 
   const int min_z = density.get_min_index();
   const int max_z = density.get_max_index();
@@ -141,6 +143,9 @@ ROIValues
 compute_total_ROI_values(const DiscretisedDensity<3,float>& image,
                          const DiscretisedDensity<3,float>& discretised_shape)
 {
+  if (!image.has_same_characteristics(discretised_shape))
+    error("compute_total_ROI_values: image and discretised_shape do not have the same characteristics.");
+
   VectorWithOffset<ROIValues> values;
   compute_ROI_values_per_plane(values, image, discretised_shape);
     return compute_total_ROI_values(values);

--- a/src/include/stir/evaluation/compute_ROI_values.h
+++ b/src/include/stir/evaluation/compute_ROI_values.h
@@ -51,7 +51,7 @@ compute_ROI_values_per_plane(VectorWithOffset<ROIValues>& values,
 void
 compute_ROI_values_per_plane(VectorWithOffset<ROIValues>& values,
                              const DiscretisedDensity<3,float>& image,
-                             const VoxelsOnCartesianGrid<float>& discretised_shape);
+                             const DiscretisedDensity<3,float>& discretised_shape);
 
 
 ROIValues
@@ -65,7 +65,7 @@ compute_total_ROI_values(const DiscretisedDensity<3,float>& image,
 
 ROIValues
 compute_total_ROI_values(const DiscretisedDensity<3,float>& image,
-                         const VoxelsOnCartesianGrid<float>& discretised_shape);
+                         const DiscretisedDensity<3,float>& discretised_shape);
 
 // function that calculate the 
 void

--- a/src/include/stir/evaluation/compute_ROI_values.h
+++ b/src/include/stir/evaluation/compute_ROI_values.h
@@ -20,6 +20,7 @@
 #define __stir_evaluation_compute_ROI_values__H__
 
 #include "stir/evaluation/ROIValues.h"
+#include "stir/VoxelsOnCartesianGrid.h"
 
 START_NAMESPACE_STIR
 
@@ -32,8 +33,8 @@ class Shape3D;
 /*! \ingroup evaluation
     \name Functions to compute ROI values
     
-    Shapes are first discretised using Shape3D::construct_volume. This can make fuzzy 
-    boundaries (when the \a num_samples argument is not (1,1,1), or when DiscretisedShape3D 
+    Shapes can be first discretised using Shape3D::construct_volume or a Shape3D parsed.
+    This can make fuzzy boundaries (when the \a num_samples argument is not (1,1,1), or when DiscretisedShape3D
     needs zooming). Mean and stddev are computed using weighted versions, taking this smoothness 
     into account, while ROI_min and max are ignore those weights.
 */
@@ -46,6 +47,14 @@ compute_ROI_values_per_plane(VectorWithOffset<ROIValues>& values,
 			     const DiscretisedDensity<3,float>& image, 
                              const Shape3D& shape,
                              const CartesianCoordinate3D<int>& num_samples);
+
+void
+compute_ROI_values_per_plane(VectorWithOffset<ROIValues>& values,
+                             const DiscretisedDensity<3,float>& image,
+                             const VoxelsOnCartesianGrid<float>& discretised_shape,
+                             const CartesianCoordinate3D<int>& num_samples);
+
+
 ROIValues
 compute_total_ROI_values(const VectorWithOffset<ROIValues>& values);
 
@@ -54,6 +63,11 @@ compute_total_ROI_values(const DiscretisedDensity<3,float>& image,
                          const Shape3D& shape, 
                          const CartesianCoordinate3D<int>& num_samples
 			 );
+
+ROIValues
+compute_total_ROI_values(const DiscretisedDensity<3,float>& image,
+                         const VoxelsOnCartesianGrid<float>& discretised_shape_ptr,
+                         const CartesianCoordinate3D<int>& num_samples);
 
 // function that calculate the 
 void

--- a/src/include/stir/evaluation/compute_ROI_values.h
+++ b/src/include/stir/evaluation/compute_ROI_values.h
@@ -51,8 +51,7 @@ compute_ROI_values_per_plane(VectorWithOffset<ROIValues>& values,
 void
 compute_ROI_values_per_plane(VectorWithOffset<ROIValues>& values,
                              const DiscretisedDensity<3,float>& image,
-                             const VoxelsOnCartesianGrid<float>& discretised_shape,
-                             const CartesianCoordinate3D<int>& num_samples);
+                             const VoxelsOnCartesianGrid<float>& discretised_shape);
 
 
 ROIValues
@@ -66,8 +65,7 @@ compute_total_ROI_values(const DiscretisedDensity<3,float>& image,
 
 ROIValues
 compute_total_ROI_values(const DiscretisedDensity<3,float>& image,
-                         const VoxelsOnCartesianGrid<float>& discretised_shape,
-                         const CartesianCoordinate3D<int>& num_samples);
+                         const VoxelsOnCartesianGrid<float>& discretised_shape);
 
 // function that calculate the 
 void

--- a/src/include/stir/evaluation/compute_ROI_values.h
+++ b/src/include/stir/evaluation/compute_ROI_values.h
@@ -66,7 +66,7 @@ compute_total_ROI_values(const DiscretisedDensity<3,float>& image,
 
 ROIValues
 compute_total_ROI_values(const DiscretisedDensity<3,float>& image,
-                         const VoxelsOnCartesianGrid<float>& discretised_shape_ptr,
+                         const VoxelsOnCartesianGrid<float>& discretised_shape,
                          const CartesianCoordinate3D<int>& num_samples);
 
 // function that calculate the 


### PR DESCRIPTION
Addresses #914 

Overloads `compute_total_ROI_values` and `compute_ROI_values_per_plane`The new functions take `discretised_shape` (a `VoxelsOnCartesianGrid<float>` object) as argument. This was implemented as 75% of ROI value computation is creating the shapes. This change allows that command to be run once.