### PR TITLE
work-around LLVM clang bug (?)

### DIFF
--- a/src/include/stir/recon_buildblock/TrivialBinNormalisation.h
+++ b/src/include/stir/recon_buildblock/TrivialBinNormalisation.h
@@ -46,7 +46,7 @@ public:
   virtual inline bool is_trivial() const override { return true;}  
 
 private:
-  virtual inline void set_defaults() override {}
+  virtual void set_defaults() override;
   virtual inline void initialise_keymap() override {}
   
 };

--- a/src/include/stir/recon_buildblock/TrivialBinNormalisation.h
+++ b/src/include/stir/recon_buildblock/TrivialBinNormalisation.h
@@ -38,6 +38,7 @@ public:
   //! Name which will be used when parsing a BinNormalisation object
   static const char * const registered_name; 
 
+  TrivialBinNormalisation() {}
   virtual inline void apply(RelatedViewgrams<float>&) const override {}
   virtual inline void undo(RelatedViewgrams<float>&) const override {}
   

--- a/src/recon_buildblock/TrivialBinNormalisation.cxx
+++ b/src/recon_buildblock/TrivialBinNormalisation.cxx
@@ -24,5 +24,8 @@ START_NAMESPACE_STIR
 const char * const 
 TrivialBinNormalisation::registered_name = "None";
 
+void TrivialBinNormalisation::set_defaults()
+{}
+
 END_NAMESPACE_STIR
 


### PR DESCRIPTION
We get linking errors on MacOSX with LLVM clang related to TrivialBinNormalisation's vtable. This is probably because it has
only inline functions, so now we have a non-inline one.

Fixes #910