### PR TITLE
Better error message when reading Interfile projdata 

### DIFF
--- a/documentation/release_5.0.htm
+++ b/documentation/release_5.0.htm
@@ -155,6 +155,7 @@ Backward compatibility for reconstructed images can be achieved by setting the <
 	<li><tt>ROOT</tt> file I/O improvements. An entire entry's tree is no longer loaded by default and instead individual branches are loaded as needed.
     ROOT file event processing is now up to 4x faster. In addition, there is now an option to <tt>check energy window information</tt> (defaulting to on).
     Futhermore, added functionality to exclude true and unscattered event types from list mode processing. </li>
+<li>Reading of Interfile projection-data will now write a more explicit warning when the binary file is non-existent or empty (improving over the cryptic <tt>WARNING: read_data: error after reading from stream</tt> that we wrote before).</li>
 </ul>
 
 

--- a/documentation/release_5.0.htm
+++ b/documentation/release_5.0.htm
@@ -271,6 +271,12 @@ as used by <code>copy_to</code> and <code>fill_from</code>
     Overloaded <code>compute_total_ROI_values</code> and <code>compute_ROI_values_per_plane</code> functions to allow the passing of  a<code>VoxelsOnCartesianGrid</code> object instead of a <code>Shape3D</code> as the ROI shape.
     This allows the ROI volume to be constructed during preprocessing for multiple image analysis.
 </li>
+<li><code>stir::open_read_binary</code> improvements:
+   <ul>
+     <li>now has an optional argument to be able to open a stream read/write.</li>
+     <li>errors if stream is empty after opening</li>
+   </ul>
+</li>
 </ul>
 
 

--- a/src/IO/interfile.cxx
+++ b/src/IO/interfile.cxx
@@ -1006,12 +1006,8 @@ read_interfile_PDFS_SPECT(istream& input,
   
   assert(!is_null_ptr(hdr.data_info_sptr));
 
-   shared_ptr<iostream> data_in(new fstream (full_data_file_name, open_mode | ios::binary));
-   if (!data_in->good())
-     {
-       warning("interfile parsing: error opening file %s",full_data_file_name);
-       return 0;
-     }
+  shared_ptr<fstream> data_in(new fstream);
+  open_read_binary(*data_in, full_data_file_name, open_mode);
 
    return new ProjDataFromStream(hdr.get_exam_info_sptr(), 
 				 hdr.data_info_sptr,
@@ -1045,12 +1041,8 @@ read_interfile_PDFS_Siemens(istream& input,
   strcpy(full_data_file_name, hdr.data_file_name.c_str());
   prepend_directory_name(full_data_file_name, directory_for_data.c_str());
 
-  shared_ptr<iostream> data_in(new fstream(full_data_file_name, open_mode | ios::binary));
-  if (!data_in->good())
-    {
-    warning("interfile parsing: error opening file %s", full_data_file_name);
-    return 0;
-    }
+  shared_ptr<fstream> data_in(new fstream);
+  open_read_binary(*data_in, full_data_file_name, open_mode);
 
   if (hdr.compression)
     warning("Siemens projection data is compressed. Reading of raw data will fail.");
@@ -1121,12 +1113,8 @@ read_interfile_PDFS(istream& input,
   
    assert(!is_null_ptr(hdr.data_info_sptr));
 
-   shared_ptr<iostream> data_in(new fstream (full_data_file_name, open_mode | ios::binary));
-   if (!data_in->good())
-     {
-       warning("interfile parsing: error opening file %s",full_data_file_name);
-       return 0;
-     }
+   shared_ptr<fstream> data_in(new fstream);
+   open_read_binary(*data_in, full_data_file_name, open_mode);
 
    return new ProjDataFromStream(hdr.get_exam_info_sptr(),
 				 hdr.data_info_sptr->create_shared_clone(),

--- a/src/include/stir/utilities.h
+++ b/src/include/stir/utilities.h
@@ -164,10 +164,15 @@ void * read_stream_in_memory(std::istream& input, std::streamsize& file_size);
 std::streamsize find_remaining_size (std::istream& input);
 
 //! opens a stream for reading binary data. Calls error() when it does not succeed.
-/*! \warning probably does not work if you are not in the C-locale */
+/*! actual open mode is `in|binary|open_mode`. This function calls error() if the opened
+    stream is empty.
+    \warning probably does not work if you are not in the C-locale.
+*/
 template <class IFSTREAM>
 inline IFSTREAM& open_read_binary(IFSTREAM& s, 
-                                  const std::string& name);
+                                  const std::string& name,
+                                  const std::ios::openmode open_mode = std::ios::in);
+
 //! opens a FILE for reading binary data. Calls error() when it does not succeed.
 /*! \warning probably does not work if you are not in the C-locale*/
 FILE*& open_read_binary(FILE*& fptr, 

--- a/src/include/stir/utilities.inl
+++ b/src/include/stir/utilities.inl
@@ -9,6 +9,7 @@
 /*
     Copyright (C) 2000 PARAPET partners
     Copyright (C) 2000-2009, Hammersmith Imanet Ltd
+    Copyright (C) 2021, University College London
     This file is part of STIR.
 
     SPDX-License-Identifier: Apache-2.0 AND License-ref-PARAPET-license
@@ -21,6 +22,7 @@
 #else
 #include <sstream>
 #endif
+#include <fstream>
 
 START_NAMESPACE_STIR
 /*!
@@ -64,21 +66,14 @@ ask_num (const std::string& str,
 
 template <class IFSTREAM>
 inline IFSTREAM& open_read_binary(IFSTREAM& s, 
-				  const std::string& name)
+				  const std::string& name,
+                                  const std::ios::openmode open_mode)
 {
-#if 0
-  //KT 30/07/98 The next lines are only necessary (in VC 5.0) when importing 
-  // <fstream.h>. We use <fstream> now, so they are disabled.
-
-  // Visual C++ does not complain when opening a nonexisting file for reading,
-  // unless using std::ios::nocreate
-  s.open(name.c_str(), std::ios::in | std::ios::binary | std::ios::nocreate); 
-#else
-  s.open(name.c_str(), std::ios::in | std::ios::binary); 
-#endif
-  // KT 14/01/2000 added name of file in error message
+  s.open(name.c_str(), std::ios::in | std::ios::binary | open_mode);
   if (s.fail() || s.bad())
-    { error("Error opening file %s\n", name.c_str());  }
+    error("Error opening file for reading. Filename:\n'" + name + "'");
+  if (s.peek() == std::ifstream::traits_type::eof())
+    error("Error opening file for reading (non-existent or empty file). Filename:\n'" + name + "'");
   return s;
 }
 


### PR DESCRIPTION
Reading of Interfile projection-data will now write a more explicit warning when the binary file is non-existent or empty improving over the cryptic `WARNING: read_data: error after reading from stream` that we wrote before).