### PR TITLE
Modification on test_IO.m and test_buildblock.m

### DIFF
--- a/src/swig/test/matlab/test_IO.m
+++ b/src/swig/test/matlab/test_IO.m
@@ -29,7 +29,7 @@ import stir.*
     output_format=InterfileOutputFileFormat();
     output_format.write_to_file('stir_matlab_test.hv', image) ;
     image2=FloatVoxelsOnCartesianGrid.read_from_file('stir_matlab_test.hv');
-    assert (isequal(image.get_voxel_size(),image2.get_voxel_size()))
+    assert (eq(image.get_voxel_size(),image2.get_voxel_size())) % isequal to eq
     %assert (image.shape()==image2.shape())
     %assert (get_physical_coordinates_for_bounding_box(image) == get_physical_coordinates_for_bounding_box(image2))
     assert(image2(ind - image.get_min_indices() + image2.get_min_indices()) == image(ind))
@@ -47,18 +47,18 @@ import stir.*
     projdatainfo=ProjDataInfo.ProjDataInfoCTI(s,3,6,8,6);
     assert (projdatainfo.get_scanner().get_num_rings()==32)
     projdata=ProjDataInterfile(examinfo, projdatainfo, 'stir_matlab_test.hs');
-    assert (projdata.get_min_segment_num()==-1)
-    assert( projdata.get_max_segment_num()==+1)
+    assert (projdata.get_min_segment_num()==-2) 
+    assert (projdata.get_max_segment_num()==+2) 
     for seg=projdata.get_min_segment_num() : projdata.get_max_segment_num()
         segment=projdatainfo.get_empty_segment_by_view(seg);
         segment.fill(double(seg)+100.)
-        assert(isequal(projdata.set_segment(segment),Succeeded(Succeeded.yes)))
+        assert(eq(projdata.set_segment(segment),Succeeded(Succeeded.yes)))
     end
     % now delete object such that the file gets closed and we can read it
     delete( projdata)
 
     projdata2=ProjData.read_from_file('stir_matlab_test.hs');
-    assert (isequal(projdatainfo,projdata2.get_proj_data_info()))
+    assert (eq(projdatainfo,projdata2.get_proj_data_info()))
     for seg=projdatainfo.get_min_segment_num() : projdatainfo.get_max_segment_num()
         % construct same segment data as above (TODO: better to stick it into a list or so)
         segment=projdatainfo.get_empty_segment_by_view(seg);

--- a/src/swig/test/matlab/test_buildblock.m
+++ b/src/swig/test/matlab/test_buildblock.m
@@ -154,7 +154,7 @@ assert( sinogram.sum()==0)
 assert( sinogram.get_segment_num()==2)
 assert( sinogram.get_axial_pos_num()==1)
 assert( sinogram.get_num_views() == projdatainfo.get_num_views())
-assert( isequal(sinogram.get_proj_data_info(), projdatainfo))
+assert(eq(sinogram.get_proj_data_info(), projdatainfo)) % change isequal to eq
 % create some empty objects
 segment=projdatainfo.get_empty_segment_by_view(0);
 assert(segment.find_max()==0)
@@ -175,6 +175,7 @@ seg=proj_data.get_segment_by_sinogram(0);
 assert(seg.find_min()==0);
 seg.fill(4);
 assert(seg.find_min()==4);
-assert(isequal(proj_data.set_segment(seg), success));
+assert(eq(proj_data.set_segment(seg), success)); % change isequal to eq
+seg_temp = proj_data.set_segment(seg);
 seg2=proj_data.get_segment_by_sinogram(0);
 assert(isequal(seg2.to_matlab(), seg.to_matlab()));


### PR DESCRIPTION
In these two test files, function 'isequal' is used in some places and that would throw out errors because of possible conflicts with the current version of STIR. So I just replaced all 'isequal' by 'eq', which probably has the same feature and work well with current STIR. Now the these two tests can be run successfully without any errors.