### PR TITLE
Use forward projector parfile with calculate_attenuation_coefficients utility.

### DIFF
--- a/recon_test_pack/simulate_data.sh
+++ b/recon_test_pack/simulate_data.sh
@@ -30,7 +30,7 @@ if [ $# -gt 4 ]; then
   suffix=$5
 fi
 echo "===  create ACFs"
-calculate_attenuation_coefficients --ACF my_acfs$suffix.hs ${atten_image} ${template_sino} > my_create_acfs.log 2>&1
+calculate_attenuation_coefficients --ACF my_acfs$suffix.hs ${atten_image} ${template_sino} forward_projector_proj_matrix_ray_tracing.par > my_create_acfs.log 2>&1
 if [ $? -ne 0 ]; then 
   echo "ERROR running calculate_attenuation_coefficients. Check my_create_acfs.log"; exit 1; 
 fi

--- a/src/utilities/calculate_attenuation_coefficients.cxx
+++ b/src/utilities/calculate_attenuation_coefficients.cxx
@@ -81,9 +81,19 @@ static void print_usage_and_exit()
     std::cerr<<"\nUsage: calculate_attenuation_coefficients [--PMRT --NOPMRT]  --AF|--ACF <output filename > <input image file name> <template_proj_data> [forwardprojector-parfile]\n"
 	     <<"\t--ACF  calculates the attenuation correction factors\n"
 	     <<"\t--AF  calculates the attenuation factor (i.e. the inverse of the ACFs)\n"
-             <<"\t--PMRT uses the Ray Tracing Projection Matrix (default) (ignored if parfile provided)\n"
-             <<"\t--NOPMRT uses the (old) Ray Tracing forward projector (ignored if parfile provided)\n"
-             <<"The input image has to give the attenuation (or mu) values at 511 keV, and be in units of cm^-1.\n";
+       <<"\t--PMRT uses the Ray Tracing Projection Matrix (default) (ignored if parfile provided)\n"
+       <<"\t--NOPMRT uses the (old) Ray Tracing forward projector (ignored if parfile provided)\n"
+       <<"The input image has to give the attenuation (or mu) values at 511 keV, and be in units of cm^-1.\n\n"
+       <<"Example forward projector parameter file:\n\n"
+       <<"Forward Projector parameters:=\n"
+       <<"   type := Matrix\n"
+       <<"   Forward projector Using Matrix Parameters :=\n"
+       <<"      Matrix type := Ray Tracing\n"
+       <<"         Ray tracing matrix parameters :=\n"
+       <<"         End Ray tracing matrix parameters :=\n"
+       <<"      End Forward Projector Using Matrix Parameters :=\n"
+       <<"End:=\n";
+
     exit(EXIT_FAILURE);
 }
 

--- a/src/utilities/calculate_attenuation_coefficients.cxx
+++ b/src/utilities/calculate_attenuation_coefficients.cxx
@@ -28,6 +28,18 @@
 
   The option <tt>--NOPMRT</tt> forces forward projection using the (old) Ray Tracing
 
+  \par Optionially include parameter file for specifying the forward projector (overrules --PMRT and --NOPMRT options)
+  \verbatim
+  Forward Projector parameters:=
+    type := Matrix
+      Forward projector Using Matrix Parameters :=
+        Matrix type := Ray Tracing
+         Ray tracing matrix parameters :=
+         End Ray tracing matrix parameters :=
+        End Forward Projector Using Matrix Parameters :=
+  End:=
+  \endverbatim
+
   The attenuation_image has to contain an estimate of the mu-map for the image. It will be used
   to estimate attenuation factors as exp(-forw_proj(*attenuation_image_ptr)).
 

--- a/src/utilities/calculate_attenuation_coefficients.cxx
+++ b/src/utilities/calculate_attenuation_coefficients.cxx
@@ -117,7 +117,7 @@ main (int argc, char * argv[])
       parser.add_start_key("Forward Projector parameters");
       parser.add_parsing_key("type", &forw_projector_sptr);
       parser.add_stop_key("END");
-      parser.parse(argv[5]);
+      parser.parse(argv[4]);
   }
   else if (use_PMRT)
   {

--- a/src/utilities/calculate_attenuation_coefficients.cxx
+++ b/src/utilities/calculate_attenuation_coefficients.cxx
@@ -18,13 +18,15 @@
   \par Usage
   \verbatim
      calculate_attenuation_coefficients
-             [--PMRT]  --AF|--ACF <output filename > <input image file name> <template_proj_data>
+             [--PMRT --NOPMRT]  --AF|--ACF <output filename > <input image file name> <template_proj_data> [forwardprojector-parfile]
   \endverbatim
   <tt>--ACF</tt>  calculates the attenuation correction factors, <tt>--AF</tt>  calculates
   the attenuation factor (i.e. the inverse of the ACFs).
 
   The option <tt>--PMRT</tt> forces forward projection using the Probability Matrix Using Ray Tracing 
   (stir::ProjMatrixByBinUsingRayTracing).
+
+  The option <tt>--NOPMRT</tt> forces forward projection using the (old) Ray Tracing
 
   The attenuation_image has to contain an estimate of the mu-map for the image. It will be used
   to estimate attenuation factors as exp(-forw_proj(*attenuation_image_ptr)).

--- a/src/utilities/calculate_attenuation_coefficients.cxx
+++ b/src/utilities/calculate_attenuation_coefficients.cxx
@@ -89,7 +89,7 @@ main (int argc, char * argv[])
       use_PMRT=true; 
       --argc; ++argv;
     }
-  if (argc!=5 || argc!=6)
+  if (!(argc==5 || argc==6))
     print_usage_and_exit();
 
   bool doACF=true;// initialise to avoid compiler warning

--- a/src/utilities/calculate_attenuation_coefficients.cxx
+++ b/src/utilities/calculate_attenuation_coefficients.cxx
@@ -28,7 +28,7 @@
 
   The option <tt>--NOPMRT</tt> forces forward projection using the (old) Ray Tracing
 
-  \par Optionially include parameter file for specifying the forward projector (overrules --PMRT and --NOPMRT options)
+  \par Optionally include a parameter file for specifying the forward projector (overrules --PMRT and --NOPMRT options)
   \verbatim
   Forward Projector parameters:=
     type := Matrix

--- a/src/utilities/calculate_attenuation_coefficients.cxx
+++ b/src/utilities/calculate_attenuation_coefficients.cxx
@@ -110,7 +110,7 @@ main (int argc, char * argv[])
   shared_ptr<ProjData> template_proj_data_ptr = 
     ProjData::read_from_file(argv[3]);
 
-  shared_ptr<ForwardProjectorByBin> forw_projector_ptr;
+  shared_ptr<ForwardProjectorByBin> forw_projector_sptr;
   if (argc>=5)
   {
       KeyParser parser;
@@ -122,14 +122,14 @@ main (int argc, char * argv[])
   else if (use_PMRT)
   {
       shared_ptr<ProjMatrixByBin> PM(new  ProjMatrixByBinUsingRayTracing());
-      forw_projector_ptr.reset(new ForwardProjectorByBinUsingProjMatrixByBin(PM)); 
+      forw_projector_sptr.reset(new ForwardProjectorByBinUsingProjMatrixByBin(PM));
   }
   else
   {
-    forw_projector_ptr.reset(new ForwardProjectorByBinUsingRayTracing());
+    forw_projector_sptr.reset(new ForwardProjectorByBinUsingRayTracing());
   }
 
-  cerr << "\n\nForward projector used:\n" << forw_projector_ptr->parameter_info();  
+  cerr << "\n\nForward projector used:\n" << forw_projector_sptr->parameter_info();
 
   const std::string output_file_name = argv[1];
   shared_ptr<ProjData> 
@@ -145,7 +145,7 @@ main (int argc, char * argv[])
   // construct a normalisation object that does all the work for us.
   shared_ptr<BinNormalisation> normalisation_ptr
 	(new BinNormalisationFromAttenuationImage(atten_image_filename,
-						  forw_projector_ptr));
+						  forw_projector_sptr));
   
   if (
       normalisation_ptr->set_up(template_proj_data_ptr->get_exam_info_sptr(), template_proj_data_ptr->get_proj_data_info_sptr()->create_shared_clone())
@@ -158,7 +158,7 @@ main (int argc, char * argv[])
   // dummy values currently necessary for BinNormalisation, but they will be ignored
   const double start_frame = 0;
   const double end_frame = 0;
-  shared_ptr<DataSymmetriesForViewSegmentNumbers> symmetries_sptr(forw_projector_ptr->get_symmetries_used()->clone());
+  shared_ptr<DataSymmetriesForViewSegmentNumbers> symmetries_sptr(forw_projector_sptr->get_symmetries_used()->clone());
   if (doACF)
     {
       normalisation_ptr->apply(*out_proj_data_ptr, symmetries_sptr);


### PR DESCRIPTION
Add an optional extra argument to 'calculate_attenuation_coefficients' utility to allow the use of a parameter file to describe the forward projector to use. The parameter file follows the format of the 'forward_project' utility.

This has been useful to allow caching to be disabled when working with large system matrices (particularly for block geometries).