### PR TITLE
Change all OpenMP schedules to dynamic

### DIFF
--- a/documentation/release_5.0.htm
+++ b/documentation/release_5.0.htm
@@ -294,6 +294,9 @@ as used by <code>copy_to</code> and <code>fill_from</code>
 <li><code>LOR</code> classes now no longer require phi at input to be between 0 and pi,
   nor psi to be between 0 and 2 pi. They will standardise the input automatically.
   </li>
+  <li>
+    OpenMP loop scheduling changed to use <code>dynamic</code> instead of <code>runtime</code>. On some machines, this was causing slower projection operations due to a <code>static</code> scheduler being selected by default. See <a href=https://github.com/UCL/STIR/issues/935>Issue #935</a> for more details.
+  </li>
 </ul>
 
 </body>

--- a/src/analytic/FBP2D/FBP2DReconstruction.cxx
+++ b/src/analytic/FBP2D/FBP2DReconstruction.cxx
@@ -292,7 +292,7 @@ actual_reconstruct(shared_ptr<DiscretisedDensity<3,float> > const & density_ptr)
   set_num_threads();
   {
 #ifdef STIR_OPENMP
-#pragma omp for schedule(runtime)  
+#pragma omp for schedule(dynamic)  
 #endif
     for (int view_num=proj_data_ptr->get_min_view_num(); view_num <= proj_data_ptr->get_max_view_num(); ++view_num) 
       {         

--- a/src/recon_buildblock/BackProjectorByBin.cxx
+++ b/src/recon_buildblock/BackProjectorByBin.cxx
@@ -204,7 +204,7 @@ BackProjectorByBin::back_project(const ProjData& proj_data, int subset_num, int 
 #endif
   {
 #ifdef STIR_OPENMP
-#pragma omp for schedule(runtime)
+#pragma omp for schedule(dynamic)
 #endif
     // note: older versions of openmp need an int as loop
     for (int i=0; i<static_cast<int>(vs_nums_to_process.size()); ++i)

--- a/src/recon_buildblock/BinNormalisation.cxx
+++ b/src/recon_buildblock/BinNormalisation.cxx
@@ -145,7 +145,7 @@ apply(ProjData& proj_data,
                                          0, 1/*subset_num, num_subsets*/);
 
 #ifdef STIR_OPENMP
-#pragma omp parallel for  shared(proj_data, symmetries_sptr) schedule(runtime)  
+#pragma omp parallel for  shared(proj_data, symmetries_sptr) schedule(dynamic)  
 #endif
     // note: older versions of openmp need an int as loop
   for (int i=0; i<static_cast<int>(vs_nums_to_process.size()); ++i)
@@ -192,7 +192,7 @@ undo(ProjData& proj_data,
                                          0, 1/*subset_num, num_subsets*/);
 
 #ifdef STIR_OPENMP
-#pragma omp parallel for  shared(proj_data, symmetries_sptr) schedule(runtime)  
+#pragma omp parallel for  shared(proj_data, symmetries_sptr) schedule(dynamic)  
 #endif
     // note: older versions of openmp need an int as loop
   for (int i=0; i<static_cast<int>(vs_nums_to_process.size()); ++i)

--- a/src/recon_buildblock/ForwardProjectorByBin.cxx
+++ b/src/recon_buildblock/ForwardProjectorByBin.cxx
@@ -195,7 +195,7 @@ ForwardProjectorByBin::forward_project(ProjData& proj_data,
                                          proj_data.get_min_segment_num(), proj_data.get_max_segment_num(),
                                          subset_num, num_subsets);
 #ifdef STIR_OPENMP
-#pragma omp parallel for  shared(proj_data, symmetries_sptr) schedule(runtime)
+#pragma omp parallel for  shared(proj_data, symmetries_sptr) schedule(dynamic)
 #endif
     // note: older versions of openmp need an int as loop
   for (int i=0; i<static_cast<int>(vs_nums_to_process.size()); ++i)

--- a/src/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMeanAndProjData.cxx
+++ b/src/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMeanAndProjData.cxx
@@ -858,7 +858,7 @@ actual_add_multiplication_with_approximate_sub_Hessian_without_penalty(TargetT& 
 
   info("Forward projecting input image.", 2);
 #ifdef STIR_OPENMP
-#pragma omp parallel for schedule(runtime)
+#pragma omp parallel for schedule(dynamic)
 #endif
   // note: older versions of openmp need an int as loop
   for (int i=0; i<static_cast<int>(vs_nums_to_process.size()); ++i)
@@ -985,7 +985,7 @@ actual_accumulate_sub_Hessian_times_input_without_penalty(TargetT& output,
   // Forward project input image
   info("Forward projecting input image.",2);
 #ifdef STIR_OPENMP
-#pragma omp parallel for schedule(runtime)
+#pragma omp parallel for schedule(dynamic)
 #endif
   for (int i=0; i<static_cast<int>(vs_nums_to_process.size()); ++i)
   {  // Loop over eah of the viewgrams in input_viewgrams_vec, forward projecting input into them
@@ -1007,7 +1007,7 @@ actual_accumulate_sub_Hessian_times_input_without_penalty(TargetT& output,
   info("Forward projecting current image estimate and back projecting to output.", 2);
   this->get_projector_pair().get_forward_projector_sptr()->set_input(current_image_estimate);
 #ifdef STIR_OPENMP
-#pragma omp parallel for schedule(runtime)
+#pragma omp parallel for schedule(dynamic)
 #endif
   for (int i = 0; i < static_cast<int>(vs_nums_to_process.size()); ++i)
   {

--- a/src/recon_buildblock/distributable.cxx
+++ b/src/recon_buildblock/distributable.cxx
@@ -426,7 +426,7 @@ void distributable_computation(
       local_counts.resize(omp_get_max_threads(), 0);
       local_count2s.resize(omp_get_max_threads(), 0);
     }
-#pragma omp for schedule(runtime)  
+#pragma omp for schedule(dynamic)  
 #endif
     // note: older versions of openmp need an int as loop
     for (int i=0; i<static_cast<int>(vs_nums_to_process.size()); ++i)


### PR DESCRIPTION
Fixes #935.

Changes all `#pragma omp for schedule(runtime)` to `#pragma omp for schedule(dynamic)`. This forces OpenMP projectors to a more efficient methodology. This change should realise faster reconstructions on all machines.