### PR TITLE
Prior parabolic_surrogate_curvature_depends_on_argument fixes

### DIFF
--- a/src/include/stir/recon_buildblock/LogcoshPrior.h
+++ b/src/include/stir/recon_buildblock/LogcoshPrior.h
@@ -108,10 +108,6 @@ public:
     //! Constructs it explicitly with scalar
     LogcoshPrior(const bool only_2D, float penalization_factor, const float scalar);
 
-    virtual bool
-    parabolic_surrogate_curvature_depends_on_argument() const
-    { return false; }
-
     //! compute the value of the function
     double
     compute_value(const DiscretisedDensity<3,elemT> &current_image_estimate);

--- a/src/include/stir/recon_buildblock/RelativeDifferencePrior.h
+++ b/src/include/stir/recon_buildblock/RelativeDifferencePrior.h
@@ -112,10 +112,6 @@ class RelativeDifferencePrior:  public
 
   //! Constructs it explicitly
   RelativeDifferencePrior(const bool only_2D, float penalization_factor, float gamma, float epsilon);
-  
-  virtual bool
-    parabolic_surrogate_curvature_depends_on_argument() const
-    { return false; }
 
   //! compute the value of the function
   double


### PR DESCRIPTION
Fixes #955

Logcosh is true so remove the overload and default to the `PriorWithParabolicSurrogate`'s implementation  

Not sure how the RDP method got in there (probably from initial QP copy) but lets remove it.