### PR TITLE
Randoms from singles fix and half life improvements

### DIFF
--- a/src/IO/GEHDF5Wrapper.cxx
+++ b/src/IO/GEHDF5Wrapper.cxx
@@ -716,6 +716,17 @@ float GEHDF5Wrapper::get_coincidence_time_window() const
     return (2*posCoincidenceWindow+1) *coincTimingPrecision*1e-9;
 }
 
+float GEHDF5Wrapper::get_halflife() const
+{
+  if(!is_list_file() && !is_sino_file())
+    error("The file provided is not list or sino data. Aborting");
+
+  H5::DataSet ds_halflife = file.openDataSet("/HeaderData/ExamData/halfLife");
+  float halflife = 0;
+  ds_halflife.read(&halflife,H5::PredType::NATIVE_FLOAT);
+  return halflife;
+}
+
 
 // Developed for listmode access
 Succeeded GEHDF5Wrapper::read_list_data( char* output,

--- a/src/data_buildblock/randoms_from_singles.cxx
+++ b/src/data_buildblock/randoms_from_singles.cxx
@@ -30,7 +30,7 @@
 START_NAMESPACE_STIR
 
 void randoms_from_singles(ProjData& proj_data, const SinglesRates& singles,
-                          const float coincidence_time_window, float isotope_halflife=-1.F)
+                          const float coincidence_time_window, float isotope_halflife)
 {
   if (isotope_halflife == -1.F)
     isotope_halflife = proj_data.get_exam_info().get_radionuclide().get_half_life();

--- a/src/data_buildblock/randoms_from_singles.cxx
+++ b/src/data_buildblock/randoms_from_singles.cxx
@@ -30,7 +30,7 @@
 START_NAMESPACE_STIR
 
 void randoms_from_singles(ProjData& proj_data, const SinglesRates& singles,
-                          const float coincidence_time_window)
+                          const float coincidence_time_window, const float isotope_halflife)
 {
   const int num_rings =
     proj_data.get_proj_data_info_sptr()->get_scanner_ptr()->get_num_rings();
@@ -73,13 +73,15 @@ void randoms_from_singles(ProjData& proj_data, const SinglesRates& singles,
        That leads to the formula below (as it turns out that the above ratio only depends t2-t1)
     */
     const double duration = frame_defs.get_duration(1);
-    warning("Assuming F-18 tracer!!!");
-    const double isotope_halflife = 6586.2;
     const double decay_corr_factor = decay_correction_factor(isotope_halflife, 0., duration);
     const double double_decay_corr_factor = decay_correction_factor(0.5*isotope_halflife, 0., duration);
     const double corr_factor = square(decay_corr_factor) / double_decay_corr_factor / duration;
-    info(boost::format("RFS: decay correction factor: %1%, time frame duration: %2%. total correction factor from (singles_totals)^2 to randoms_totals: %3%")
-         % decay_corr_factor % duration % (1/corr_factor),
+
+    info(boost::format("Isotope half-life: %1%\n"
+                       "RFS: decay correction factor: %2%,\n"
+                       "time frame duration: %3%.\n"
+                       "total correction factor from (singles_totals)^2 to randoms_totals: %4%.\n")
+         % isotope_halflife % corr_factor % duration % (1/corr_factor),
          2);
 
     multiply_crystal_factors(proj_data, total_singles,

--- a/src/data_buildblock/randoms_from_singles.cxx
+++ b/src/data_buildblock/randoms_from_singles.cxx
@@ -81,7 +81,7 @@ void randoms_from_singles(ProjData& proj_data, const SinglesRates& singles,
                        "RFS: decay correction factor: %2%,\n"
                        "time frame duration: %3%.\n"
                        "total correction factor from (singles_totals)^2 to randoms_totals: %4%.\n")
-         % isotope_halflife % corr_factor % duration % (1/corr_factor),
+         % isotope_halflife % decay_corr_factor % duration % (1/corr_factor),
          2);
 
     multiply_crystal_factors(proj_data, total_singles,

--- a/src/data_buildblock/randoms_from_singles.cxx
+++ b/src/data_buildblock/randoms_from_singles.cxx
@@ -30,8 +30,11 @@
 START_NAMESPACE_STIR
 
 void randoms_from_singles(ProjData& proj_data, const SinglesRates& singles,
-                          const float coincidence_time_window, const float isotope_halflife)
+                          const float coincidence_time_window, float isotope_halflife=-1.F)
 {
+  if (isotope_halflife == -1.F)
+    isotope_halflife = proj_data.get_exam_info().get_radionuclide().get_half_life();
+
   const int num_rings =
     proj_data.get_proj_data_info_sptr()->get_scanner_ptr()->get_num_rings();
   const int num_detectors_per_ring =

--- a/src/data_buildblock/randoms_from_singles.cxx
+++ b/src/data_buildblock/randoms_from_singles.cxx
@@ -76,7 +76,7 @@ void randoms_from_singles(ProjData& proj_data, const SinglesRates& singles,
     warning("Assuming F-18 tracer!!!");
     const double isotope_halflife = 6586.2;
     const double decay_corr_factor = decay_correction_factor(isotope_halflife, 0., duration);
-    const double double_decay_corr_factor = decay_correction_factor(2*isotope_halflife, 0., duration);
+    const double double_decay_corr_factor = decay_correction_factor(0.5*isotope_halflife, 0., duration);
     const double corr_factor = square(decay_corr_factor) / double_decay_corr_factor / duration;
     info(boost::format("RFS: decay correction factor: %1%, time frame duration: %2%. total correction factor from (singles_totals)^2 to randoms_totals: %3%")
          % decay_corr_factor % duration % (1/corr_factor),

--- a/src/include/stir/IO/GEHDF5Wrapper.h
+++ b/src/include/stir/IO/GEHDF5Wrapper.h
@@ -94,6 +94,9 @@ public:
     //! reads coincidence time window from file (in secs)
     float get_coincidence_time_window() const;
 
+    //! reads the isotope half-life from file (in secs)
+    float get_halflife() const;
+
     //! reads listmode event(s)
     /* \param[output] output: has to be pre-allocated and of the correct size
        \param[in] offset: start in listmode data (in number of bytes)

--- a/src/include/stir/data/randoms_from_singles.h
+++ b/src/include/stir/data/randoms_from_singles.h
@@ -52,11 +52,10 @@ class SinglesRates;
   For more details, see:
   Stearns, C. W., McDaniel, D. L., Kohlmyer, S. G., Arul, P. R., Geiser, B. P., & Shanmugam, V. (2003).
   Random coincidence estimation from single event rates on the Discovery ST PET/CT scanner.
-  2003 IEEE Nuclear Science Symposium. Conference Record (IEEE Cat. No.03CH37515), 5, 3067–3069.
+  2003 IEEE Nuclear Science Symposium. Conference Record (IEEE Cat. No.03CH37515), 5, 3067-3069.
   https://doi.org/10.1109/NSSMIC.2003.1352545
 
   \todo Dead-time is currently completely ignored.
-  \todo The function currently assumes F-18 half-life.
 */
 void randoms_from_singles(ProjData& proj_data, const SinglesRates& singles, const float coincidence_time_window, float isotope_halflife=-1.F);
 

--- a/src/include/stir/data/randoms_from_singles.h
+++ b/src/include/stir/data/randoms_from_singles.h
@@ -58,6 +58,6 @@ class SinglesRates;
   \todo Dead-time is currently completely ignored.
   \todo The function currently assumes F-18 half-life.
 */
-void randoms_from_singles(ProjData& proj_data, const SinglesRates& singles, const float coincidence_time_window, const float isotope_halflife);
+void randoms_from_singles(ProjData& proj_data, const SinglesRates& singles, const float coincidence_time_window, float isotope_halflife=-1.F);
 
 END_NAMESPACE_STIR

--- a/src/include/stir/data/randoms_from_singles.h
+++ b/src/include/stir/data/randoms_from_singles.h
@@ -58,6 +58,6 @@ class SinglesRates;
   \todo Dead-time is currently completely ignored.
   \todo The function currently assumes F-18 half-life.
 */
-void randoms_from_singles(ProjData& proj_data, const SinglesRates& singles, const float coincidence_time_window);
+void randoms_from_singles(ProjData& proj_data, const SinglesRates& singles, const float coincidence_time_window, const float isotope_halflife);
 
 END_NAMESPACE_STIR

--- a/src/include/stir/data/randoms_from_singles.h
+++ b/src/include/stir/data/randoms_from_singles.h
@@ -49,6 +49,12 @@ class SinglesRates;
      r_{ij} = \tau s_i s_j \frac{ \int_{t_1}^{t_2} dt\,exp (-2 \lambda t)}{\left(\int_{t1}^{t2} dt\,exp (-\lambda t)\right)^2}
   \f]
 
+  For more details, see:
+  Stearns, C. W., McDaniel, D. L., Kohlmyer, S. G., Arul, P. R., Geiser, B. P., & Shanmugam, V. (2003).
+  Random coincidence estimation from single event rates on the Discovery ST PET/CT scanner.
+  2003 IEEE Nuclear Science Symposium. Conference Record (IEEE Cat. No.03CH37515), 5, 3067–3069.
+  https://doi.org/10.1109/NSSMIC.2003.1352545
+
   \todo Dead-time is currently completely ignored.
   \todo The function currently assumes F-18 half-life.
 */

--- a/src/include/stir/data/randoms_from_singles.h
+++ b/src/include/stir/data/randoms_from_singles.h
@@ -33,6 +33,8 @@ class SinglesRates;
   for finding the randoms-rate in terms of the
   singles-rates. The function then takes duration properly into account using the following
   procedure.
+  This uses \c isotope_halflife in the computation of \f$\lambda\f$. Default value is -1 and the function will
+  extract \c isotope_halflife from \c proj_data. If set, will use the passed value.
 
   We actually have total counts in the singles for sinograms and need total counts in the randoms.
   Assuming the radioactivity distribution is stationary and only decays, and dropping indices \f$i,j\f$,

--- a/src/utilities/construct_randoms_from_GEsingles.cxx
+++ b/src/utilities/construct_randoms_from_GEsingles.cxx
@@ -87,10 +87,7 @@ int main(int argc, char **argv)
   GE::RDF_HDF5::SinglesRatesFromGEHDF5  singles(input_filename);
   const float coincidence_time_window = input_file.get_coincidence_time_window();
 
-  // If half-life exists in proj_data, use that value, otherwise get it from the input_file
-  const float isotope_halflife = proj_data.get_exam_info().get_radionuclide().get_half_life(false) != -1
-                                 ? proj_data.get_exam_info().get_radionuclide().get_half_life()
-                                 : input_file.get_halflife();
+  const float isotope_halflife = input_file.get_halflife();
 
   randoms_from_singles(proj_data, singles, coincidence_time_window, isotope_halflife);
   return EXIT_SUCCESS;

--- a/src/utilities/construct_randoms_from_GEsingles.cxx
+++ b/src/utilities/construct_randoms_from_GEsingles.cxx
@@ -86,7 +86,8 @@ int main(int argc, char **argv)
 
   GE::RDF_HDF5::SinglesRatesFromGEHDF5  singles(input_filename);
   const float coincidence_time_window = input_file.get_coincidence_time_window();
+  const float isotope_halflife = input_file.get_halflife();
 
-  randoms_from_singles(proj_data, singles, coincidence_time_window);
+  randoms_from_singles(proj_data, singles, coincidence_time_window, isotope_halflife);
   return EXIT_SUCCESS;
 }

--- a/src/utilities/construct_randoms_from_GEsingles.cxx
+++ b/src/utilities/construct_randoms_from_GEsingles.cxx
@@ -86,7 +86,11 @@ int main(int argc, char **argv)
 
   GE::RDF_HDF5::SinglesRatesFromGEHDF5  singles(input_filename);
   const float coincidence_time_window = input_file.get_coincidence_time_window();
-  const float isotope_halflife = input_file.get_halflife();
+
+  // If half-life exists in proj_data, use that value, otherwise get it from the input_file
+  const float isotope_halflife = proj_data.get_exam_info().get_radionuclide().get_half_life(false) != -1
+                                 ? proj_data.get_exam_info().get_radionuclide().get_half_life()
+                                 : input_file.get_halflife();
 
   randoms_from_singles(proj_data, singles, coincidence_time_window, isotope_halflife);
   return EXIT_SUCCESS;


### PR DESCRIPTION
- Fixes #960 by correcting the `decay_correction_factor` input.

- Goes further to unhardcode the `isotope_halflife` by getting from `projdata` (if exists) or from the `input_file`. To do this `GEHDF5Wrapper::get_halflife()` was added. This also required the `randoms_from_singles` function to have a `isotope_halflife` as an argument because that information was not necessarily present in the `projdata`.

- Improved the info output in `randoms_from_singles.cxx`, e.g:
 ```
INFO: Isotope half-life: 6586.2
RFS: decay correction factor: 1.20137,
time frame duration: 3600.
total correction factor from (singles_totals)^2 to randoms_totals: 3557.55.
```