### PR TITLE
remove threshold in division by sensitivity

### DIFF
--- a/documentation/release_5.0.htm
+++ b/documentation/release_5.0.htm
@@ -91,6 +91,11 @@ Backward compatibility for reconstructed images can be achieved by setting the <
    Fixing this isssue means that images reconstructed with <tt>OSSPS</tt> are different from previous versions of STIR when the above conditions are met.
    See <a href=https://github.com/UCL/STIR/issues/873>Issue #873</a> and associated <a href=https://github.com/UCL/STIR/issues/893>PR #893</a>.
 </li>
+<li>
+  Parametric image reconstruction with <tt>POSMAPOSL</tt> could lead to zeroes being introduced
+  gradually during reconstruction.
+   See <a href=https://github.com/UCL/STIR/issues/906>Issue #906</a> and associated <a href=https://github.com/UCL/STIR/issues/978>PR #978</a>.
+</li>
 </ul>
 
 <h3>New functionality</h3>

--- a/recon_test_pack/run_tests_modelling.sh
+++ b/recon_test_pack/run_tests_modelling.sh
@@ -155,7 +155,7 @@ extract_single_images_from_dynamic_image dyn_from_p0005-p5_img_f%dg1d0b0.hv dyn_
 # if [ ! -r fwd_dyn_from_p0005-p5.S ]; then
 
 for fr in `count 23 28`; do
-    forward_project fwd_dyn_from_p0005-p5_f${fr}g1d0b0  dyn_from_p0005-p5_img_f${fr}g1d0b0.hv ${INPUTDIR}ECAT_931_projdata_template.hs
+    forward_project fwd_dyn_from_p0005-p5_f${fr}g1d0b0  dyn_from_p0005-p5_img_f${fr}g1d0b0.hv ${INPUTDIR}ECAT_931_projdata_template.hs > fwd_dyn_from_p0005-p5_f${fr}g1d0b0.log 2>&1
 done
 #fi
 

--- a/src/iterative/OSMAPOSL/OSMAPOSLReconstruction.cxx
+++ b/src/iterative/OSMAPOSL/OSMAPOSLReconstruction.cxx
@@ -462,7 +462,7 @@ update_estimate(TargetT &current_image_estimate)
       divide(multiplicative_update_image_ptr->begin_all(),
              multiplicative_update_image_ptr->end_all(), 
              sensitivity.begin_all(),
-             small_num);
+             0.F); // no need to find a threshold for division by sensitivity
     }
     else
     {
@@ -514,7 +514,12 @@ update_estimate(TargetT &current_image_estimate)
             ++sensitivity_iter;
           }
         }
-      }         
+      }
+
+      // do the division
+      // TODO: The thresholding implied in "divide" potentially fails with parametric images
+      // as the different parametric images can have very different scales.
+      // See https://github.com/UCL/STIR/issues/906
       divide(multiplicative_update_image_ptr->begin_all(),
              multiplicative_update_image_ptr->end_all(), 
              denominator_ptr->begin_all(),


### PR DESCRIPTION
We used a small threshold to detect 0/0 when dividing by the sensitivity image in the Poisson log likelihood. However, this threshold was problematic, and actually caused problems in parametric imaging due to different scales of the parametric images.

We now set that threshold to zero.

See https://github.com/UCL/STIR/issues/906 (although this doesn't fix it completely)