### PR TITLE
Adds DMI 5 ring to STIR Scanners

### DIFF
--- a/src/buildblock/Scanner.cxx
+++ b/src/buildblock/Scanner.cxx
@@ -423,6 +423,27 @@ break;
                511.F);
     break;
 
+    case DiscoveryMI5ring: // This is the 5-ring DMI
+      // as above, but one extra block
+      // Hsu et al. 2017 JNM
+      // crystal size 3.95 x 5.3 x 25
+      set_params(DiscoveryMI5ring, string_list("GE Discovery MI 5 rings", "Discovery MI5", "Discovery MI"), // needs to include last value as used by GE in RDF files
+                 45,
+                 415,
+                 401, // TODO should compute num_arccorrected_bins from effective_FOV/default_bin_size
+                 2 * 272,
+                 380.5F - 9.4F,//TODO inner_ring_radius and DOI, currently set such that effective ring-radius is correct
+                 9.4F,//TODO DOI
+                 5.52296F, // ring-spacing
+                 2.206F,//TODO currently using the central bin size default bin size. GE might be using something else
+                 static_cast<float>(-4.399*_PI/180), //TODO check sign
+                 5, 4,
+                 9, 4,
+                 1, 1,
+                 1,
+                 0.0944F, // energy resolution from Hsu et al. 2017
+                 511.F);
+      break;
   case HZLR:
 
     set_params(HZLR, string_list("Positron HZL/R"), 

--- a/src/include/stir/Scanner.h
+++ b/src/include/stir/Scanner.h
@@ -118,7 +118,8 @@ class Scanner
      any given parameters.
   */
   enum Type {E931, E951, E953, E921, E925, E961, E962, E966, E1080, Siemens_mMR,Siemens_mCT, RPT,HiDAC,
-	     Advance, DiscoveryLS, DiscoveryST, DiscoverySTE, DiscoveryRX, Discovery600, PETMR_Signa, Discovery690, DiscoveryMI3ring, DiscoveryMI4ring,
+	     Advance, DiscoveryLS, DiscoveryST, DiscoverySTE, DiscoveryRX, Discovery600, PETMR_Signa,
+	     Discovery690, DiscoveryMI3ring, DiscoveryMI4ring, DiscoveryMI5ring,
 	     HZLR, RATPET, PANDA, HYPERimage, nanoPET, HRRT, Allegro, GeminiTF, User_defined_scanner,
 	     Unknown_scanner};
   


### PR DESCRIPTION
GE Discovery MI with 5 (GE) rings. This is the same as the DMI 4 ring but `num_ring_v=45` and `num_axial_blocks_per_bucket_v=5`.
_____
Generated interfile header.
```
!INTERFILE  :=
name of data file := prompts_f1b1.s
originating system := GE Discovery MI 5 rings
!version of keys := STIR4.0
!GENERAL DATA :=
!GENERAL IMAGE DATA :=
!type of data := PET
imagedata byte order := LITTLEENDIAN
!PET STUDY (General) :=
!PET data type := Emission
applied corrections := {None}
!number format := float
!number of bytes per pixel := 4
number of dimensions := 4
matrix axis label [4] := segment
!matrix size [4] := 45
matrix axis label [3] := view
!matrix size [3] := 272
matrix axis label [2] := axial coordinate
!matrix size [2] := { 1,5,9,13,17,21,25,29,33,37,41,45,49,53,57,61,65,69,73,77,81,85,89,85,81,77,73,69,65,61,57,53,49,45,41,37,33,29,25,21,17,13,9,5,1}
matrix axis label [1] := tangential coordinate
!matrix size [1] := 415
minimum ring difference per segment := { -44,-43,-41,-39,-37,-35,-33,-31,-29,-27,-25,-23,-21,-19,-17,-15,-13,-11,-9,-7,-5,-3,-1,2,4,6,8,10,12,14,16,18,20,22,24,26,28,30,32,34,36,38,40,42,44}
maximum ring difference per segment := { -44,-42,-40,-38,-36,-34,-32,-30,-28,-26,-24,-22,-20,-18,-16,-14,-12,-10,-8,-6,-4,-2,1,3,5,7,9,11,13,15,17,19,21,23,25,27,29,31,33,35,37,39,41,43,44}
Scanner parameters:= 
Scanner type := GE Discovery MI 5 rings
Number of rings                          := 45
Number of detectors per ring             := 544
Inner ring diameter (cm)                 := 74.22
Average depth of interaction (cm)        := 0.94
Distance between rings (cm)              := 0.552296
Default bin size (cm)                    := 0.2206
View offset (degrees)                    := -4.399
Maximum number of non-arc-corrected bins := 415
Default number of arc-corrected bins     := 401
Energy resolution := 0.0944
Reference energy (in keV) := 511
Number of blocks per bucket in transaxial direction         := 4
Number of blocks per bucket in axial direction              := 5
Number of crystals per block in axial direction             := 9
Number of crystals per block in transaxial direction        := 4
Number of detector layers                                   := 1
Number of crystals per singles unit in axial direction      := 1
Number of crystals per singles unit in transaxial direction := 1
end scanner parameters:=
effective central bin size (cm) := 0.219737
number of time frames := 1
start vertical bed position (mm) := 0
start horizontal bed position (mm) := 0
!END OF INTERFILE :=

```