### PR TITLE
set CMAKE_CXX_STANDARD_REQUIRED=ON

### DIFF
--- a/src/cmake/SetC++Version.cmake
+++ b/src/cmake/SetC++Version.cmake
@@ -30,6 +30,7 @@ function(UseCXX VERSION)
       endif ()
     else ()
       set (CMAKE_CXX_STANDARD ${VERSION} PARENT_SCOPE)
+      set (CMAKE_CXX_STANDARD_REQUIRED ON PARENT_SCOPE)
     endif ()
 
     message(STATUS "Using C++ version ${VERSION}")


### PR DESCRIPTION
Without it, CMake can fall back to old  versions, which will create confusing errors.

Also, it means that try_compile et al. will test with the required C++ version.

Fixes #983