### PR TITLE
Relax the condition on z position in FORE

### DIFF
--- a/src/recon_buildblock/FourierRebinning.cxx
+++ b/src/recon_buildblock/FourierRebinning.cxx
@@ -409,8 +409,7 @@ rebinning(Array<3,std::complex<float> > &FT_rebinned_data, Array<3,float> &Weigh
   const int maxplane = FT_rebinned_data.get_max_index();
   //CON determine z position (sino identifier)
   const int z = round(z_in_mm/half_distance_between_rings);
-  // TODO replace call to error() by warning() and returning Succeeded::no
-  if(fabs(static_cast<float>(z_in_mm/half_distance_between_rings - z)) > .0001)
+  if(fabs(static_cast<float>(z_in_mm/half_distance_between_rings - z)) > .005F)
        error("FORE rebinning :: rebinning kernel expected integer z coordinate but found a non integer value %g\n", z_in_mm);
           
   //CL t is the tangent of the angle theta between the LOR and the transaxial plane


### PR DESCRIPTION
A condition (i.e. z_in_mm/half_distance_between_rings - z > 0.0001) is set on z position to prevent rebinning to non existing z-positions (sinograms), however, this value of 0.0001 may not always be satisfied (due to numerical precision). For example, I got an error message when trying FORE with a PET having more than 1000 axial positions, although SSRB goes well; For verification I done manual calculation with the returned z value, and that gives a difference of 0.0035 (z_in_mm/half_distance_between_rings - z = 0.0035) wich is indeed > 0.0001 (so the condition is not satisfied), although the z position in mm is correct and corresponds to one of the PET's actual axial positions.
After re-building and re-installing STIR on virtual machine with this value of 0.0001 relaxed to 0.005F the FORE is running well for all z positions.

Also I deleted the // TODO comment.