### PR TITLE
bin processing swap_zq::transform_proj_matrix_elems_for_one_bin

### DIFF
--- a/src/recon_buildblock/SymmetryOperations_PET_CartesianGrid.cxx
+++ b/src/recon_buildblock/SymmetryOperations_PET_CartesianGrid.cxx
@@ -361,6 +361,10 @@ SymmetryOperation_PET_CartesianGrid_swap_zq::
 transform_proj_matrix_elems_for_one_bin(
                                         ProjMatrixElemsForOneBin& lor) const
 {
+  Bin bin = lor.get_bin();
+  transform_bin_coordinates(bin);
+  lor.set_bin(bin);
+
   ProjMatrixElemsForOneBin::iterator element_ptr = lor.begin();
   while (element_ptr != lor.end()) 
   {


### PR DESCRIPTION
Identified in https://github.com/UCL/STIR/issues/995#issue-1146279287. The `transform_bin_coordinates` was not processed. 

This an issue that is somewhat related to https://github.com/UCL/STIR/issues/999 but I think merge this before addressing that issue.

P.S. #1000 😄 