### PR TITLE
remove obsolete scanner_orientation (for block scanner)

### DIFF
--- a/src/IO/InterfileHeader.cxx
+++ b/src/IO/InterfileHeader.cxx
@@ -619,10 +619,6 @@ InterfilePDFSHeader::InterfilePDFSHeader()
           &reference_energy);
 
   // new keys for block geometry
-  scanner_orientation = "X";
-  add_key("Scanner orientation (X or Y)",
-          KeyArgument::ASCII, &scanner_orientation);
-
   scanner_geometry = "Cylindrical";
   add_key("Scanner geometry (BlocksOnCylindrical/Cylindrical/Generic)",
           KeyArgument::ASCII, &scanner_geometry);
@@ -1389,7 +1385,6 @@ bool InterfilePDFSHeader::post_processing()
                 num_detector_layers,
                 energy_resolution,
                 reference_energy,
-                scanner_orientation,
                 scanner_geometry,
                 static_cast<float>(axial_distance_between_crystals_in_cm*10.),
                 static_cast<float>(transaxial_distance_between_crystals_in_cm*10.),

--- a/src/buildblock/GeometryBlocksOnCylindrical.cxx
+++ b/src/buildblock/GeometryBlocksOnCylindrical.cxx
@@ -76,10 +76,8 @@ build_crystal_maps(const Scanner& scanner)
 	float transaxial_block_spacing = scanner.get_transaxial_block_spacing();
 	float axial_crystal_spacing = scanner.get_axial_crystal_spacing();
 	float transaxial_crystal_spacing = scanner.get_transaxial_crystal_spacing();
-	std::string scanner_orientation = scanner.get_scanner_orientation();
 
 	det_pos_to_coord_type cartesian_coord_map_given_detection_position_keys;
-	// check for the scanner orientation
 	/*Building starts from a bucket perpendicular to y axis, from its first crystal.
 		see start_x*/
 

--- a/src/buildblock/Scanner.cxx
+++ b/src/buildblock/Scanner.cxx
@@ -542,7 +542,6 @@ break;
              1, //num_detector_layers_v
              -1, //energy_resolution_v
              -1, //reference_energy_v
-             "", //scanner_orientation_v
              "", //scanner_geometry_v
              2.2, //axial_crystal_spacing_v
              2.2, //transaxial_crystal_spacing_v
@@ -588,7 +587,6 @@ Scanner::Scanner(Type type_v, const list<string>& list_of_names_v,
                  int num_detector_layers_v,
                  float energy_resolution_v,
                  float reference_energy_v,
-                 const string& scanner_orientation_v,
                  const string& scanner_geometry_v,
                  float axial_crystal_spacing_v,
                  float transaxial_crystal_spacing_v,
@@ -611,7 +609,6 @@ Scanner::Scanner(Type type_v, const list<string>& list_of_names_v,
              num_detector_layers_v,
              energy_resolution_v,
              reference_energy_v,
-             scanner_orientation_v,
              scanner_geometry_v,
              axial_crystal_spacing_v,
              transaxial_crystal_spacing_v,
@@ -635,7 +632,6 @@ Scanner::Scanner(Type type_v, const string& name,
                  int num_detector_layers_v,
                  float energy_resolution_v,
                  float reference_energy_v,
-                 const string& scanner_orientation_v,
                  const string& scanner_geometry_v,
                  float axial_crystal_spacing_v,
                  float transaxial_crystal_spacing_v,
@@ -658,7 +654,6 @@ Scanner::Scanner(Type type_v, const string& name,
              num_detector_layers_v,
              energy_resolution_v,
              reference_energy_v,
-             scanner_orientation_v,
              scanner_geometry_v,
              axial_crystal_spacing_v,
              transaxial_crystal_spacing_v,
@@ -690,7 +685,6 @@ set_params(Type type_v,const list<string>& list_of_names_v,
            int num_detector_layers_v,
            float energy_resolution_v,
            float reference_energy_v,
-           const string& scanner_orientation_v,
            const string& scanner_geometry_v,
            float axial_crystal_spacing_v,
            float transaxial_crystal_spacing_v,
@@ -712,7 +706,6 @@ set_params(Type type_v,const list<string>& list_of_names_v,
 	     num_detector_layers_v,
              energy_resolution_v,
              reference_energy_v,
-             scanner_orientation_v,
              scanner_geometry_v,
              axial_crystal_spacing_v,
              transaxial_crystal_spacing_v,
@@ -740,7 +733,6 @@ set_params(Type type_v,const list<string>& list_of_names_v,
            int num_detector_layers_v,
            float energy_resolution_v,
            float reference_energy_v,
-           const string& scanner_orientation_v,
            const string& scanner_geometry_v,
            float axial_crystal_spacing_v,
            float transaxial_crystal_spacing_v,
@@ -772,8 +764,6 @@ set_params(Type type_v,const list<string>& list_of_names_v,
       reference_energy = 511.f;
   else
       reference_energy = reference_energy_v;
-  
-  scanner_orientation = scanner_orientation_v;
   
   axial_crystal_spacing = axial_crystal_spacing_v;
   transaxial_crystal_spacing = transaxial_crystal_spacing_v;
@@ -913,7 +903,7 @@ check_consistency() const
 	  get_num_transaxial_blocks() *
 	  get_num_transaxial_crystals_per_block();
     // exclusion of generic as 'get_num_transaxial_crystals_per_block()' is sometimes false for asymmetric detectors and not important for generic
-	if ( dets_per_ring != get_num_detectors_per_ring() && scanner_orientation != "Generic")
+	if ( dets_per_ring != get_num_detectors_per_ring() && scanner_geometry != "Generic")
 	  { 
 	    warning("Scanner %s: inconsistent transaxial block info",
 		    this->get_name().c_str()); 
@@ -932,7 +922,7 @@ check_consistency() const
 	  get_num_transaxial_buckets() *
 	  get_num_transaxial_blocks_per_bucket();
     // exclusion of generic as 'get_num_transaxial_blocks_per_bucket()' is sometimes false for asymmetric detectors and not important for generic
-	if ( blocks_per_ring != get_num_transaxial_blocks() && scanner_orientation != "Generic")
+	if ( blocks_per_ring != get_num_transaxial_blocks() && scanner_geometry != "Generic")
 	  { 
 	    warning("Scanner %s: inconsistent transaxial block/bucket info",
 		    this->get_name().c_str()); 
@@ -952,7 +942,7 @@ check_consistency() const
 	  get_num_axial_crystals_per_block();
 
 	// exclusion of generic as 'get_num_axial_crystals_per_block()' is sometimes false for asymmetric detectors and not important for generic
-  if ( dets_axial != (get_num_rings() + get_num_virtual_axial_crystals_per_block())  && scanner_orientation != "Generic")
+  if ( dets_axial != (get_num_rings() + get_num_virtual_axial_crystals_per_block())  && scanner_geometry != "Generic")
 	  { 
 	    warning("Scanner %s: inconsistent axial block info: %d vs %d",
 		    this->get_name().c_str(),
@@ -972,7 +962,7 @@ check_consistency() const
 	  get_num_axial_buckets() *
 	  get_num_axial_blocks_per_bucket();
     // exclusion of generic as 'get_num_axial_blocks_per_bucket()' is sometimes false for asymmetric detectors and not important for generic
-	if ( blocks_axial != get_num_axial_blocks() && scanner_orientation != "Generic")
+	if ( blocks_axial != get_num_axial_blocks() && scanner_geometry != "Generic")
 	  { 
 	    warning("Scanner %s: inconsistent axial block/bucket info",
 		    this->get_name().c_str()); 
@@ -1198,11 +1188,6 @@ Scanner::parameter_info() const
     s << "Scanner geometry (BlocksOnCylindrical/Cylindrical/Generic)  := "
       <<get_scanner_geometry() << '\n';
   }
-  if (get_scanner_orientation() != "")
-  {
-    s << "Scanner orientation (X or Y)                                := "
-      <<get_scanner_orientation() << '\n';
-  }
   if (get_axial_crystal_spacing() >=0)
     s << "Distance between crystals in axial direction (cm)           := "
       << get_axial_crystal_spacing()/10 << '\n';
@@ -1339,8 +1324,6 @@ Scanner* Scanner::ask_parameters()
       int num_detector_layers =
     ask_num("Enter number of detector layers per block: ",1,100,1);
            
-      const string ScannerOrientation =
-  ask_string("Enter the scanner orientation, i.e. which axis passes through two opposite blocks ('X' or 'Y')", "Y");
       const string ScannerGeometry =
   ask_string("Enter the scanner geometry ( BlocksOnCylindrical / Cylindrical / Generic ) :", "Cylindrical");
       
@@ -1373,7 +1356,6 @@ Scanner* Scanner::ask_parameters()
                         num_detector_layers,
                         EnergyResolution,
                         ReferenceEnergy,
-                        ScannerOrientation,
                         ScannerGeometry,
                         TransaxialCrystalSpacing,
                         AxialCrystalSpacing,

--- a/src/include/stir/IO/InterfileHeader.h
+++ b/src/include/stir/IO/InterfileHeader.h
@@ -289,7 +289,6 @@ private:
   
   //! \name new variables for block geometry
   //@{
-  std::string scanner_orientation;
   std::string scanner_geometry;
   float axial_distance_between_crystals_in_cm;
   float transaxial_distance_between_crystals_in_cm;

--- a/src/include/stir/Scanner.h
+++ b/src/include/stir/Scanner.h
@@ -161,7 +161,6 @@ class Scanner
           int num_detector_layers_v,
           float energy_resolution_v = -1.0f,
           float reference_energy_v = -1.0f,
-          const std::string& scanner_orientation_v = "X",
           const std::string& scanner_geometry_v = "Cylindrical",
           float axial_crystal_spacing_v = -1.0f,
           float transaxial_crystal_spacing_v = -1.0f,
@@ -187,7 +186,6 @@ class Scanner
           int num_detector_layers_v,
           float energy_resolution_v = -1.0f,
           float reference_energy_v = -1.0f,
-          const std::string& scanner_orientation_v = "X",
           const std::string& scanner_geometry_v = "Cylindrical",
           float axial_crystal_spacing_v = -1.0f,
           float transaxial_crystal_spacing_v = -1.0f,
@@ -319,8 +317,6 @@ class Scanner
 
   //! \name functions to get block geometry info
   //@{
-  //! get scanner orientation
-  inline std::string get_scanner_orientation() const;
   //! get scanner geometry
   inline std::string get_scanner_geometry() const;
   //! get crystal spacing in axial direction
@@ -397,8 +393,6 @@ class Scanner
   // TODO accomodate more complex geometries of singles units.
   //@{
   //! name functions to set block geometry info
-  //! set scanner orientation
-  inline void set_scanner_orientation(const std::string& new_scanner_orientation);
   //! set scanner geometry
   /*! Will also read the detector map from file if the geometry is \c Generic */
   void set_scanner_geometry(const std::string& new_scanner_geometry);
@@ -500,7 +494,6 @@ private:
   //! \brief scanner info needed for block geometry
   //! \author Parisa Khateri
   //! A negative value indicates unknown.
-  std::string scanner_orientation;       /*! scanner orientation */
   std::string scanner_geometry;          /*! scanner geometry */
   float axial_crystal_spacing;           /*! crystal pitch in axial direction in mm*/
   float transaxial_crystal_spacing;      /*! crystal pitch in transaxial direction in mm*/
@@ -532,7 +525,6 @@ private:
                   int num_detector_layers_v,
                   float energy_resolution_v = -1.0f,
                   float reference_energy = -1.0f,
-                  const std::string& scanner_orientation_v = "",
                   const std::string& scanner_geometry_v = "",
                   float axial_crystal_spacing_v = -1.0f,
                   float transaxial_crystal_spacing_v = -1.0f,
@@ -557,7 +549,6 @@ private:
                   int num_detector_layers_v,
                   float energy_resolution_v = -1.0f,
                   float reference_energy = -1.0f,
-                  const std::string& scanner_orientation_v = "",
                   const std::string& scanner_geometry_v = "",
                   float axial_crystal_spacing_v = -1.0f,
                   float transaxial_crystal_spacing_v = -1.0f,

--- a/src/include/stir/Scanner.inl
+++ b/src/include/stir/Scanner.inl
@@ -233,12 +233,6 @@ Scanner::get_reference_energy() const
 }
 
 std::string
-Scanner::get_scanner_orientation() const
-{
-  return scanner_orientation;
-}
-
-std::string
 Scanner::get_scanner_geometry() const
 {
   return scanner_geometry;
@@ -398,12 +392,6 @@ void
 Scanner::set_reference_energy(const float new_num)
 {
     reference_energy = new_num;
-   _already_setup = false;
-}
-
-void Scanner::set_scanner_orientation(const std::string& new_scanner_orientation)
-{
-  scanner_orientation = new_scanner_orientation;
    _already_setup = false;
 }
 


### PR DESCRIPTION
@pkhateri introduced X/Y orientation for BlocksOnCylindrical but this wasn't used anymore. This PR removes the member from `Scanner` and also from the Interfile header.

Also removed a small bug for Generic that a check was using `scanner_orientation` as opposed to `scanner_geometry`.