### PR TITLE
Radionuclide code improvements

### DIFF
--- a/recon_test_pack/run_test_zoom_image.sh
+++ b/recon_test_pack/run_test_zoom_image.sh
@@ -168,7 +168,7 @@ if [ $? -ne 0 ]; then
   exit 1
 fi
 
-org_sum=`list_projdata_info --sum my_prompts.hs | awk -F: '{ print $2}'`
+org_sum=`list_projdata_info --sum my_prompts.hs | awk -F: '/sum/{ print $2}'`
 
 ./simulate_data.sh my_zoom_test4.hv my_atten_image.hv ${template_sino} 0
 if [ $? -ne 0 ]; then
@@ -176,7 +176,7 @@ if [ $? -ne 0 ]; then
   exit 1
 fi
 
-new_sum=`list_projdata_info --sum my_prompts.hs | awk -F: '{ print $2}'`
+new_sum=`list_projdata_info --sum my_prompts.hs | awk -F: '/sum/{ print $2}'`
 
 if compare_values $org_sum $new_sum .01
 then

--- a/recon_test_pack/run_tests_modelling.sh
+++ b/recon_test_pack/run_tests_modelling.sh
@@ -1,3 +1,4 @@
+
 #! /bin/bash
 #
 #  Copyright (C) 2009 - 2011, Hammersmith Imanet Ltd
@@ -202,7 +203,7 @@ extract_single_images_from_parametric_image test_mult_dyn_with_model_img_f%dg1d0
 echo " "
 echo "Min Counts for Par 1 "
 
-value_1=`list_image_info --min test_mult_dyn_with_model_img_f1g1d0b0.hv | awk '{print $3}' `
+value_1=`list_image_info --min test_mult_dyn_with_model_img_f1g1d0b0.hv | awk '/min/ {print $3}' `
 is_differ=`echo ${value_1} | awk ' { print ($1>.0001) } '` 
 if [  ${is_differ} -eq 1 ]; then   
     echo "When estimate min_counts_in_images values do not match. Check mult_model_with_dyn_images.cxx"
@@ -212,7 +213,7 @@ else
 fi
 
 echo "Min Counts for Par 2 "
-value_2=`list_image_info --min test_mult_dyn_with_model_img_f2g1d0b0.hv | awk '{print $3}' `
+value_2=`list_image_info --min test_mult_dyn_with_model_img_f2g1d0b0.hv | awk '/min/ {print $3}' `
 is_differ=`echo ${value_2} | awk ' { print ($1>.0001) } '` 
 if [  ${is_differ} -eq 1 ]; then   
     echo "When estimate min_counts_in_images values do not match. Check mult_model_with_dyn_images.cxx"
@@ -222,7 +223,7 @@ else
 fi
 
 echo "Max Counts for Par 1 "
-value_3=`list_image_info --max test_mult_dyn_with_model_img_f1g1d0b0.hv | awk '{print $3}' `
+value_3=`list_image_info --max test_mult_dyn_with_model_img_f1g1d0b0.hv | awk '/max/ {print $3}' `
 # 6.391818 is the scale due to the zoom factor.
 is_differ=`echo ${value_3} | awk ' { print (($1-1619.32*6.391818*6.391818)*($1-1619.32*6.391818*6.391818)>.5*6.391818*6.391818*6.391818*6.391818*.5) } '` 
 if [  ${is_differ} -eq 1 ]; then   
@@ -233,7 +234,7 @@ else
 fi
 
 echo "Max Counts for Par 2 "
-value_4=`list_image_info --max test_mult_dyn_with_model_img_f2g1d0b0.hv | awk '{print $3}' `
+value_4=`list_image_info --max test_mult_dyn_with_model_img_f2g1d0b0.hv | awk '/max/ {print $3}' `
 is_differ=`echo ${value_4} | awk ' { print (($1-0.356552*6.391818*6.391818)*($1-0.356552*6.391818*6.391818)>.001*6.391818*6.391818*.001) } '` 
 if [  ${is_differ} -eq 1 ]; then   
     echo "When estimate max_counts_in_images values do not match. Check mult_model_with_dyn_images.cxx"

--- a/src/buildblock/CMakeLists.txt
+++ b/src/buildblock/CMakeLists.txt
@@ -127,7 +127,7 @@ if (HAVE_JSON)
   # In that case, we will need to add it in STIRConfig.cmake.in
   #
   get_target_property(TMP nlohmann_json::nlohmann_json INTERFACE_INCLUDE_DIRECTORIES)
-  target_include_directories(buildblock PRIVATE "${TMP}")
+  target_include_directories(buildblock PUBLIC "${TMP}")
 endif()
 
 # TODO Remove but currently needed for ProjData.cxx, DynamicDisc*cxx, TimeFrameDef

--- a/src/buildblock/RadionuclideDB.cxx
+++ b/src/buildblock/RadionuclideDB.cxx
@@ -42,8 +42,6 @@ read_from_file(const std::string& arg)
 #ifdef nlohmann_json_FOUND
     this->database_filename = arg;
     
-//    modality_str=modality.get_name();
-    
     //Read Radionuclide file and set JSON member for DB
     
     std::string s =this->database_filename;
@@ -123,20 +121,31 @@ get_radionuclide_from_json(ImagingModality rmodality, const std::string &rname) 
 #ifdef nlohmann_json_FOUND
   //Extract appropriate chunk of JSON file for given nuclide.
   //nlohmann::json target = radionuclide_json["nuclide"][name]["modality"][rmodality.get_name()]["properties"];
+  std::string modality_string;
+  switch (rmodality.get_modality())
+    {
+    case ImagingModality::PT:
+      modality_string = "PET"; break;
+    case ImagingModality::NM:
+      modality_string = "nucmed"; break;
+    default:
+      error("RadionuclideDB::get_radionuclide_from_json called with unknown modality");
+    }
+
   auto rnuclide_entry = radionuclide_json["nuclide"].find(name);
   if (rnuclide_entry == radionuclide_json["nuclide"].end())
     {
       error("RadionuclideDB: radionuclide " + rname + " not found in JSON database");
     }
-  auto rnuclide_entry2 = (*rnuclide_entry)["modality"].find(rmodality.get_name());
+  auto rnuclide_entry2 = (*rnuclide_entry)["modality"].find(modality_string);
   if (rnuclide_entry2 == (*rnuclide_entry)["modality"].end())
     {
-      error("RadionuclideDB: radionuclide " + rname + " modality " + rmodality.get_name() + " not found in JSON database");
+      error("RadionuclideDB: radionuclide " + rname + " modality " + modality_string + " not found in JSON database");
     }
   auto rnuclide_entry3 = rnuclide_entry2->find("properties");
   if (rnuclide_entry3 == rnuclide_entry2->end())
     {
-      error("RadionuclideDB: radionuclide " + rname + " modality " + rmodality.get_name() + " found but properties not in JSON database");
+      error("RadionuclideDB: radionuclide " + rname + " modality " + modality_string + " found but properties not in JSON database");
     }
   auto& target = *rnuclide_entry3;
 

--- a/src/buildblock/RadionuclideDB.cxx
+++ b/src/buildblock/RadionuclideDB.cxx
@@ -81,7 +81,7 @@ get_radionuclide_name_from_lookup_table(const std::string& rname) const
   std::ifstream json_file_stream(this->radionuclide_lookup_table_filename);
     
   if (!json_file_stream)
-    error("Could not open radionuclude lookup file:'" + this->radionuclide_lookup_table_filename + "'");
+    error("Could not open radionuclide lookup file:'" + this->radionuclide_lookup_table_filename + "'");
     
   nlohmann::json table_json;
   json_file_stream >> table_json;
@@ -126,17 +126,17 @@ get_radionuclide_from_json(ImagingModality rmodality, const std::string &rname) 
   auto rnuclide_entry = radionuclide_json["nuclide"].find(name);
   if (rnuclide_entry == radionuclide_json["nuclide"].end())
     {
-      error("RadionuclideDB: radionuclude " + rname + " not found in JSON database");
+      error("RadionuclideDB: radionuclide " + rname + " not found in JSON database");
     }
   auto rnuclide_entry2 = (*rnuclide_entry)["modality"].find(rmodality.get_name());
   if (rnuclide_entry2 == (*rnuclide_entry)["modality"].end())
     {
-      error("RadionuclideDB: radionuclude " + rname + " modality " + rmodality.get_name() + " not found in JSON database");
+      error("RadionuclideDB: radionuclide " + rname + " modality " + rmodality.get_name() + " not found in JSON database");
     }
   auto rnuclide_entry3 = rnuclide_entry2->find("properties");
   if (rnuclide_entry3 == rnuclide_entry2->end())
     {
-      error("RadionuclideDB: radionuclude " + rname + " modality " + rmodality.get_name() + " found but properties not in JSON database");
+      error("RadionuclideDB: radionuclide " + rname + " modality " + rmodality.get_name() + " found but properties not in JSON database");
     }
   auto& target = *rnuclide_entry3;
 
@@ -160,7 +160,7 @@ get_radionuclide_from_json(ImagingModality rmodality, const std::string &rname) 
   }
   try
     {
-      keV = properties["kev"];
+      keV = properties["keV"];
     }
   catch (...)
     {
@@ -168,11 +168,11 @@ get_radionuclide_from_json(ImagingModality rmodality, const std::string &rname) 
     }
   try
     {
-  branching_ratio = properties["BRatio"];
+  branching_ratio = properties["branching_ratio"];
     }
   catch (...)
     {
-      error("RadionuclideDB: BRatio not set for " + rname);
+      error("RadionuclideDB: branching_ratio not set for " + rname);
     }
   try
     {

--- a/src/buildblock/RadionuclideDB.cxx
+++ b/src/buildblock/RadionuclideDB.cxx
@@ -129,23 +129,27 @@ get_radionuclide_from_json(ImagingModality rmodality, const std::string &rname) 
     case ImagingModality::NM:
       modality_string = "nucmed"; break;
     default:
-      error("RadionuclideDB::get_radionuclide_from_json called with unknown modality");
+      warning("RadionuclideDB::get_radionuclide_from_json called with unknown modality. Returning \"unknown\" radionuclide.");
+      return Radionuclide();
     }
 
   auto rnuclide_entry = radionuclide_json["nuclide"].find(name);
   if (rnuclide_entry == radionuclide_json["nuclide"].end())
     {
-      error("RadionuclideDB: radionuclide " + rname + " not found in JSON database");
+      warning("RadionuclideDB: radionuclide " + rname + " not found in JSON database. Returning \"unknown\" radionuclide.");
+      return Radionuclide();
     }
   auto rnuclide_entry2 = (*rnuclide_entry)["modality"].find(modality_string);
   if (rnuclide_entry2 == (*rnuclide_entry)["modality"].end())
     {
-      error("RadionuclideDB: radionuclide " + rname + " modality " + modality_string + " not found in JSON database");
+     warning("RadionuclideDB: radionuclide " + rname + " modality " + modality_string + " not found in JSON database. Returning \"unknown\" radionuclide.");
+      return Radionuclide();
     }
   auto rnuclide_entry3 = rnuclide_entry2->find("properties");
   if (rnuclide_entry3 == rnuclide_entry2->end())
     {
-      error("RadionuclideDB: radionuclide " + rname + " modality " + modality_string + " found but properties not in JSON database");
+      warning("RadionuclideDB: radionuclide " + rname + " modality " + modality_string + " found but properties not in JSON database. Returning \"unknown\" radionuclide.");
+      return Radionuclide();
     }
   auto& target = *rnuclide_entry3;
 
@@ -156,9 +160,11 @@ get_radionuclide_from_json(ImagingModality rmodality, const std::string &rname) 
     pos++;
   }
 
-  if (location == -1){
-    error("RadionuclideDB: Desired radionuclide not found!");
-  }
+  if (location == -1)
+    {
+      warning("RadionuclideDB: Desired radionuclide not found! Returning \"unknown\" radionuclide.");
+      return Radionuclide();
+    }
 
   //Extract properties for specific nuclide and modality.
   nlohmann::json properties = target[location];
@@ -216,7 +222,10 @@ get_radionuclide(ImagingModality rmodality, const std::string& rname)
       else if (rmodality.get_modality()==ImagingModality::NM)
         return get_radionuclide(rmodality, "^99m^Technetium");
       else
-        error("RadioNuclideDB::get_radionuclide: unknown modality");
+        {
+          warning("RadioNuclideDB::get_radionuclide: unknown modality. Returning \"unknown\" radionuclide.");
+          return Radionuclide();
+        }
     }
 
   std::string nuclide_name = get_radionuclide_name_from_lookup_table(rname);
@@ -229,7 +238,10 @@ get_radionuclide(ImagingModality rmodality, const std::string& rname)
 
     if(rmodality.get_modality()==ImagingModality::PT){
         if (rname != "^18^Fluorine")
-          error("RadioNuclideDB::get_radionuclide: since STIR was compiled without nlohmann-json-dev, We only have information for ^18^Fluorine for the PET modality.");
+          {
+            warning("RadioNuclideDB::get_radionuclide: since STIR was compiled without nlohmann-json-dev, We only have information for ^18^Fluorine for the PET modality. Returning \"unknown\" radionuclide.");
+            return Radionuclide();
+          }
 
         return Radionuclide("^18^Fluorine",
                               511,
@@ -238,7 +250,10 @@ get_radionuclide(ImagingModality rmodality, const std::string& rname)
                               rmodality);
     }else if(rmodality.get_modality()==ImagingModality::NM){
         if (rname != "^99m^Technetium")
-          error("RadioNuclideDB::get_radionuclide: since STIR was compiled without nlohmann-json-dev, We only have information for ^99m^Technetium for the NM modality.");
+          {
+            warning("RadioNuclideDB::get_radionuclide: since STIR was compiled without nlohmann-json-dev, We only have information for ^99m^Technetium for the NM modality. Returning \"unknown\" radionuclide.");
+            return Radionuclide();
+          }
 
         return Radionuclide("^99m^Technetium",
                               140.511,
@@ -247,7 +262,10 @@ get_radionuclide(ImagingModality rmodality, const std::string& rname)
                               rmodality);
     }
     else
-      error("RadioNuclideDB::get_radionuclide: unknown modality");
+      {
+        warning("RadioNuclideDB::get_radionuclide: unknown modality. Returning \"unknown\" radionuclide.");
+        return Radionuclide();
+      }
 
 #endif
 }

--- a/src/buildblock/RadionuclideDB.cxx
+++ b/src/buildblock/RadionuclideDB.cxx
@@ -118,7 +118,7 @@ get_radionuclide_from_json(ImagingModality rmodality, const std::string &rname) 
   
 #ifdef nlohmann_json_FOUND
   info("RadionuclideDB: finding record radionuclide: " + rname+
-       " in file "+ this->database_filename);
+       " in file "+ this->database_filename, 3);
 
   // convert modality string
   std::string modality_string;
@@ -185,7 +185,7 @@ get_radionuclide_from_json(ImagingModality rmodality, const std::string &rname) 
 
   //Extract properties for specific nuclide and modality.
   const auto properties = *decay_entry;
-  info("RadionuclideDB: JSON record found:" + properties.dump(6),2);
+  info("RadionuclideDB: JSON record found:" + properties.dump(6), 3);
 
   try
     {

--- a/src/cmake/stir_test_exe_targets.cmake
+++ b/src/cmake/stir_test_exe_targets.cmake
@@ -48,6 +48,10 @@ if(NOT TARGET BUILD_TESTS)
 endif()
 
 #### define macros
+macro(add_STIR_CONFIG_DIR test_target)
+  set_tests_properties(${test_target}
+    PROPERTIES ENVIRONMENT "STIR_CONFIG_DIR=${PROJECT_SOURCE_DIR}/src/config")
+endmacro()
 
 macro (create_stir_involved_test source  libraries dependencies)
  if(BUILD_TESTING)
@@ -65,6 +69,7 @@ macro (create_stir_test source  libraries dependencies)
  if(BUILD_TESTING)
    create_stir_involved_test(${source}  "${libraries}" "${dependencies}")
    ADD_TEST(${executable} ${CMAKE_CURRENT_BINARY_DIR}/${executable})
+   add_STIR_CONFIG_DIR(${executable})
  endif()
 endmacro( create_stir_test)
 
@@ -74,6 +79,7 @@ macro (create_stir_mpi_test source  libraries dependencies)
    if(STIR_MPI)
      create_stir_involved_test(${source}  "${libraries}" "${dependencies}")
      ADD_TEST(${executable}  ${MPIEXEC} ${MPIEXEC_NUMPROC_FLAG} ${MPIEXEC_MAX_NUMPROCS}  ${MPIEXEC_PREFLAGS} ${CMAKE_CURRENT_BINARY_DIR}/${executable} ${MPIEXEC_POSTFLAGS})
+     add_STIR_CONFIG_DIR(${executable})
    else()
      create_stir_test(${source}  "${libraries}" "${dependencies}")
    endif()

--- a/src/config/radionuclide_info.json
+++ b/src/config/radionuclide_info.json
@@ -7,8 +7,8 @@
     {   "PET":
       {  "properties": [
                {
-                "kev": 511,
-                "BRatio": 0.9686,
+                "keV": 511,
+                "branching_ratio": 0.9686,
                 "half_life": 6584.04
                 }      ]
       }
@@ -21,8 +21,8 @@
      {   "PET":
       {  "properties": [
                {
-               "kev": 511,
-               "BRatio": 0.9975,
+               "keV": 511,
+               "branching_ratio": 0.9975,
                "half_life": 1221.66
                }      ]
      }
@@ -35,8 +35,8 @@
       {   "PET":
         {  "properties": [
                  {
-                  "kev": 511,
-                  "BRatio": 0.99818,
+                  "keV": 511,
+                  "branching_ratio": 0.99818,
                   "half_life": 598.02
                   }      ]
          }
@@ -49,8 +49,8 @@
       {   "PET":
         {  "properties": [
                  {
-                  "kev": 511,
-                  "BRatio": 0.99885,
+                  "keV": 511,
+                  "branching_ratio": 0.99885,
                   "half_life": 122.46
                   }      ]
         }
@@ -63,8 +63,8 @@
        {   "PET":
          {  "properties": [
                   {
-                   "kev": 511,
-                   "BRatio": 0.1752,
+                   "keV": 511,
+                   "branching_ratio": 0.1752,
                    "half_life": 45721.144
                    }      ]
          }
@@ -77,8 +77,8 @@
       {   "PET":
         {  "properties": [
                  {
-                  "kev": 511,
-                  "BRatio": 0.8768,
+                  "keV": 511,
+                  "branching_ratio": 0.8768,
                   "half_life": 4069.8
                   }      ]
         }
@@ -91,8 +91,8 @@
     {   "nucmed":
       {  "properties": [
                {
-                "kev": 140.511,
-                "BRatio": 0.885,
+                "keV": 140.511,
+                "branching_ratio": 0.885,
                 "half_life": 21624.12
                 }       ]
       }  
@@ -105,8 +105,8 @@
      {   "nucmed":
        {  "properties": [
                 {
-                 "kev": 364.489,
-                     "BRatio": 0.812,
+                 "keV": 364.489,
+                     "branching_ratio": 0.812,
                      "half_life": 693446.4
                      }       ]
        }  
@@ -119,8 +119,8 @@
      {   "nucmed":
       {  "properties": [
                {
-               "kev": 184.577,
-               "BRatio": 0.213,
+               "keV": 184.577,
+               "branching_ratio": 0.213,
                 "half_life": 281776.32
                }       ]
       }  
@@ -133,8 +133,8 @@
       {   "nucmed":
         {  "properties": [
                  {
-                  "kev": 208.3662,
-                  "BRatio": 0.1109,
+                  "keV": 208.3662,
+                  "branching_ratio": 0.1109,
                   "half_life": 574300.8
                  }       ]
         }  
@@ -148,16 +148,16 @@
       {   "nucmed":
         {  "properties": [
                  {
-                  "kev": 150,
-                  "BRatio": 0.99983,
+                  "keV": 150,
+                  "branching_ratio": 0.99983,
                   "half_life": 230549.76
                  }       ]
         }, 
          "PET":
         {  "properties": [
                  {
-                  "kev": 511,
-                  "BRatio": 0.0000319,
+                  "keV": 511,
+                  "branching_ratio": 0.0000319,
                   "half_life": 230549.76
                   }       ]
         }

--- a/src/config/radionuclide_info.json
+++ b/src/config/radionuclide_info.json
@@ -1,167 +1,123 @@
 {
-    "nuclide": 
+    "nuclides": [
 
- {  "^18^Fluorine":
-
-  {  "modality": 
-    {   "PET":
-      {  "properties": [
-               {
-                "keV": 511,
-                "branching_ratio": 0.9686,
-                "half_life": 6584.04
-                }      ]
-      }
-    }
- },  
-        
-    "^11^Carbon":
-       
-    {  "modality": 
-     {   "PET":
-      {  "properties": [
-               {
-               "keV": 511,
-               "branching_ratio": 0.9975,
-               "half_life": 1221.66
-               }      ]
-     }
-   }
-},  
-    
-    "^13^Nitrogen":
-   
-    {  "modality": 
-      {   "PET":
-        {  "properties": [
-                 {
-                  "keV": 511,
-                  "branching_ratio": 0.99818,
-                  "half_life": 598.02
-                  }      ]
-         }
-       }
-    },  
-
-    "^15^Oxygen":
-       
-    {  "modality": 
-      {   "PET":
-        {  "properties": [
-                 {
-                  "keV": 511,
-                  "branching_ratio": 0.99885,
-                  "half_life": 122.46
-                  }      ]
-        }
-      }
-   },  
-       
-    "^64^Copper":
-     
-     {  "modality": 
-       {   "PET":
-         {  "properties": [
-                  {
+        {
+            "name":  "^18^Fluorine",
+            "decays": [                
+                {  "modality": "PET",
                    "keV": 511,
+                   "branching_ratio": 0.9686,
+                   "half_life": 6584.04
+                }
+            ]
+        },
+        {
+            "name": "^11^Carbon",
+            "decays": [
+                {  "modality": "PET",
+                   "keV": 511,
+                   "branching_ratio": 0.9975,
+                   "half_life": 1221.66
+                }
+            ]
+        },
+        {
+            "name": "^13^Nitrogen",
+            "decays": [
+                {  "modality": "PET",
+                   "keV": 511,
+                   "branching_ratio": 0.99818,
+                   "half_life": 598.02
+                }
+            ]
+        },
+        {
+            "name": "^15^Oxygen",
+            "decays": [
+                {  "modality": "PET",
+                   "keV": 511,
+                   "branching_ratio": 0.99885,
+                   "half_life": 122.46
+                }
+            ]
+        },
+        {
+            "name": "^64^Copper",
+            "decays": [
+                {  "modality": "PET",
+                   
                    "branching_ratio": 0.1752,
                    "half_life": 45721.144
-                   }      ]
-         }
-       }
-    },  
-        
-    "^68^Gallium":
-  
-    {  "modality": 
-      {   "PET":
-        {  "properties": [
-                 {
-                  "keV": 511,
-                  "branching_ratio": 0.8768,
-                  "half_life": 4069.8
-                  }      ]
-        }
-      }
-   },  
-
-   "^99m^Technetium":
-
-  {  "modality": 
-    {   "nucmed":
-      {  "properties": [
-               {
-                "keV": 140.511,
-                "branching_ratio": 0.885,
-                "half_life": 21624.12
-                }       ]
-      }  
-    }
-  },
-        
-    "^131^Iodine":
- 
-   {  "modality": 
-     {   "nucmed":
-       {  "properties": [
+                }      ]
+            
+        },
+        {
+            "name": "^68^Gallium",
+            "decays": [
+                {  "modality": "PET",
+                   "keV": 511,
+                   "branching_ratio": 0.8768,
+                   "half_life": 4069.8
+                }
+            ]
+        },
+        {
+            "name": "^99m^Technetium",
+            "decays": [
+                {  "modality": "nucmed",
+                   "keV": 140.511,
+                   "branching_ratio": 0.885,
+                   "half_life": 21624.12
+                }
+            ]            
+        },
+        {
+            "name": "^131^Iodine",
+            "decays": [
+                {  "modality": "nucmed",
+                   "kev": 364.489,
+                   "branching_ratio": 0.812,
+                   "half_life": 693446.4
+                }
+            ]
+            
+        },
+        {
+            "name": "^67^Gallium",
+            "decays": [
+                {  "modality": "nucmed",
+                   "keV": 184.577,
+                   "branching_ratio": 0.213,
+                   "half_life": 281776.32
+                }
+            ]
+            
+        },
+        {
+            "name": "^177^Lutetium",
+            "decays": [
+                {  "modality": "nucmed",
+                   "keV": 208.3662,
+                   "branching_ratio": 0.1109,
+                   "half_life": 574300.8
+                }
+            ]
+        },
+        {
+            "name": "^90^Yttrium",
+            "decays": [
+                {  "modality": "nucmed",
+                   "keV": 150,
+                   "branching_ratio": 0.99983,
+                   "half_life": 230549.76
+                },
                 {
-                 "keV": 364.489,
-                     "branching_ratio": 0.812,
-                     "half_life": 693446.4
-                     }       ]
-       }  
-     }
-   },
-
-    "^67^Gallium":
-                          
-    {  "modality": 
-     {   "nucmed":
-      {  "properties": [
-               {
-               "keV": 184.577,
-               "branching_ratio": 0.213,
-                "half_life": 281776.32
-               }       ]
-      }  
-     }
-    },
-                                
-    "^177^Lutetium":
-     
-    {  "modality": 
-      {   "nucmed":
-        {  "properties": [
-                 {
-                  "keV": 208.3662,
-                  "branching_ratio": 0.1109,
-                  "half_life": 574300.8
-                 }       ]
-        }  
-      }
-    },
-                                
-    "^90^Yttrium":
-
-    {  "modality": 
-                
-      {   "nucmed":
-        {  "properties": [
-                 {
-                  "keV": 150,
-                  "branching_ratio": 0.99983,
-                  "half_life": 230549.76
-                 }       ]
-        }, 
-         "PET":
-        {  "properties": [
-                 {
-                  "keV": 511,
-                  "branching_ratio": 0.0000319,
-                  "half_life": 230549.76
-                  }       ]
+                    "modality": "PET",
+                    "keV": 511,
+                    "branching_ratio": 0.0000319,
+                    "half_life": 230549.76
+                }
+            ]
         }
-      }
-    }
- }
+    ]
 }

--- a/src/include/stir/Radionuclide.h
+++ b/src/include/stir/Radionuclide.h
@@ -1,12 +1,8 @@
-//
-//
-
 /*!
   \file
-  \ingroup projdata
+  \ingroup ancillary
 
   \brief Declaration of class stir::Radionuclide
-  
 
   \author Daniel Deidda
   \author Kris Thielemans
@@ -28,31 +24,33 @@
 
 
 START_NAMESPACE_STIR
-/*!   \ingroup projdata
+/*!   \ingroup ancillary
  \brief
  A class for storing radionuclide information.
 
+ \sa RadionuclideDB
 */
 
 class Radionuclide
 {
 public: 
   //! default constructor
+  /*! Set name to "Unknown" and other values to invalid numbers (e.g. -1) */
   Radionuclide();
 
-  //!  A constructor : constructs a radionuclide with all it's information
+  //!  A constructor : constructs a radionuclide with all its information
   Radionuclide(const std::string& name, float energy, float branching_ratio, float half_life,
     ImagingModality modality);
   
-  //!get name
+  //! get name (normally in DICOM format)
   std::string get_name()const;
-  //! get energy
+  //! get energy (in keV)
   /*! if \a check=\c true, calls error() if value not set (i.e. is negative)*/
   float get_energy(bool check=true) const;
   //! get branching_ratio
   /*! if \a check=\c true, calls error() if value not set (i.e. is negative)*/
   float get_branching_ratio(bool check=true)  const;
-  //! get half_life
+  //! get half_life (in seconds)
   /*! if \a check=\c true, calls error() if value not set (i.e. is negative)*/
   float get_half_life(bool check=true) const;
   //! get modality

--- a/src/include/stir/RadionuclideDB.h
+++ b/src/include/stir/RadionuclideDB.h
@@ -43,42 +43,37 @@
 
   This file is in JSON format. An example is distributed with STIR, a brief extract follows
   \verbatim
-{   "nuclide": 
+{
+    "nuclides": [
 
- {  "^18^Fluorine":
-
-  {  "modality": 
-    {   "PET":
-      {  "properties": [
-               {
-                "kev": 511,
-                "BRatio": 0.9686,
-                "half_life": 6584.04
-                }      ]
-      }
-    }
- },  
-
-   "^99m^Technetium":
-
-  {  "modality": 
-    {   "NM":
-      {  "properties": [
-               {
-                "kev": 140.511,
-                "BRatio": 0.885,
-                "half_life": 21624.12,
-                }       ]
-      }  
-    }
-  },
+        {
+            "name":  "^18^Fluorine",
+            "decays": [                
+                {  "modality": "PET",
+                   "keV": 511,
+                   "branching_ratio": 0.9686,
+                   "half_life": 6584.04
+                }
+            ]
+        },
+        {
+            "name": "^99m^Technetium",
+            "decays": [
+                {  "modality": "nucmed",
+                   "keV": 140.511,
+                   "branching_ratio": 0.885,
+                   "half_life": 21624.12
+                }
+            ]
+            
+        },
       # more entries like the above
-   }
+   ]
 }
 
 \endverbatim
 
-  \par Format of the radionuclide database
+  \par Format of the radionuclide name look-up database
 
   This file is in JSON format. An example is distributed with STIR, a brief extract follows
   \verbatim
@@ -87,6 +82,7 @@
      [ "^11^Carbon", "11C", "C-11" ]
 ]
   \endverbatim
+  The first name is the one that will be used to find an entry in the radionuclide database.
 
   Note that both files need to have the same number of radionuclides..
 */

--- a/src/include/stir/RadionuclideDB.h
+++ b/src/include/stir/RadionuclideDB.h
@@ -117,9 +117,11 @@ public:
   /*!
     If \a rname is \c "default" or empty, use ^18F^Fluorine" for PET and "^99m^Technetium" for NM.
     Otherwise, first looks-up \a rname to translate to standard naming convention, then finds it in the database.
-    If not found in the database, this function calls error().
+    If not found in the database, this function uses warning() and returns
+    a default constructed Radionuclide() object (i.e. unknown).
 
-    If STIR is compiled without nlohmann_json support, this function calls error().
+    If STIR is compiled without nlohmann_json support, a hard-coded database is
+    used (currently only containing values for the above default radionuclides).
   */
   Radionuclide get_radionuclide(ImagingModality rmodality, const std::string& rname);
   
@@ -137,6 +139,9 @@ private:
   //! Finds the radionuclide info in the database
   /*!
     \a rname should have been standardised already.
+
+    If not found in the database, this function uses warning() and returns
+    a default constructed Radionuclide() object (i.e. unknown).
   */
   Radionuclide get_radionuclide_from_json(ImagingModality rmodality, const std::string& rname) const;
   

--- a/src/include/stir/RadionuclideDB.h
+++ b/src/include/stir/RadionuclideDB.h
@@ -3,29 +3,45 @@
   \file
   \ingroup ancillary
   \brief Declaration of class stir::RadionuclideDB
-    
+
   \author Daniel Deidda
   \author Kris Thielemans
       
 */
 /*
     Copyright (C) 2021, National Physical Laboratory
-    Copyright (C) 2021, University College London
+    Copyright (C) 2021, 2022, University College London
     See STIR/LICENSE.txt for details
 */
 
 #ifndef __stir_RADIONUCLIDEDB_H
 #define __stir_RADIONUCLIDEDB_H
 
+
+#include "stir/Radionuclide.h"
+#include "stir/ImagingModality.h"
+
+#ifdef nlohmann_json_FOUND
+#include <nlohmann/json.hpp>
+#endif
+
 /*!
+  \ingroup ancillary
   \brief A class in that reads the radionuclide information from a Json file
 
   Values for half life branching ratio are taken from: 
   http://www.lnhb.fr/donnees-nucleaires/donnees-nucleaires-tableau/
 
-  \par Format of the radionuclide data base
+  The class also supports using "aliases" for radionuclide names. This is useful
+  as different manufacturers use different conventions.
 
-  This file is in JSON format. An example is distributed with STIR.
+  STIR comes with a default database and lookup table. The database uses DICOM
+  conventions for the names. The lookup table provides alternatives for GE and Siemens
+  (in STIR 5.0).
+
+  \par Format of the radionuclide database
+
+  This file is in JSON format. An example is distributed with STIR, a brief extract follows
   \verbatim
 {   "nuclide": 
 
@@ -61,49 +77,74 @@
 }
 
 \endverbatim
+
+  \par Format of the radionuclide database
+
+  This file is in JSON format. An example is distributed with STIR, a brief extract follows
+  \verbatim
+[
+     [ "^18^Fluorine", "18F", "F-18" ],
+     [ "^11^Carbon", "11C", "C-11" ]
+]
+  \endverbatim
+
+  Note that both files need to have the same number of radionuclides..
 */
-
-#include "stir/RegisteredParsingObject.h"
-#include "stir/Radionuclide.h"
-#include "stir/ImagingModality.h"
-
-#ifdef nlohmann_json_FOUND
-#include <nlohmann/json.hpp>
-#endif
 
 START_NAMESPACE_STIR
 
 class RadionuclideDB
 {
 public:
-//  static constexpr const char * const registered_name = "nuclideDB"; 
   
   //! Default constructor
+  /*! Reads the database from radionuclide_info.json and lookup table from radionuclide_names.json,
+      with their locations found via find_STIR_config_file().
+
+      If STIR is compiled without nlohmann_json support, this constructor does nothing.
+  */
   RadionuclideDB();
   
-  //! set the JSON filename with the radionuclides
+  //! set the radionuclide database from a JSON file
+  /*!
+    This function could be used to override the default database information.
+
+    If STIR is compiled without nlohmann_json support, this function calls error().
+  */
   void read_from_file(const std::string& filename);
-  //! get the radionuclide 
+
+  //! Finds the radionuclide in the database
+  /*!
+    If \a rname is \c "default" or empty, use ^18F^Fluorine" for PET and "^99m^Technetium" for NM.
+    Otherwise, first looks-up \a rname to translate to standard naming convention, then finds it in the database.
+    If not found in the database, this function calls error().
+
+    If STIR is compiled without nlohmann_json support, this function calls error().
+  */
   Radionuclide get_radionuclide(ImagingModality rmodality, const std::string& rname);
   
 protected:
 
 
 private:
-  std::string filename;
-  Radionuclide radionuclide;
-  
-//  std::string nuclide_name;
-  std::string radionuclide_lookup_table_str;
+  std::string database_filename;
+  std::string radionuclide_lookup_table_filename;
   
 #ifdef nlohmann_json_FOUND
-nlohmann::json radionuclide_json;
+  nlohmann::json radionuclide_json;
 #endif
 
-//! the following extracts the radionuclide information from the JSON file and returns a radionculide object 
+  //! Finds the radionuclide info in the database
+  /*!
+    \a rname should have been standardised already.
+  */
   Radionuclide get_radionuclide_from_json(ImagingModality rmodality, const std::string& rname) const;
   
-//! the following looks at the radionuclide name in input and converts it if necessary to the Dicom format
+  //! Convert the radionuclide name using the lookup table
+  /*!
+    If \a rname is empty, return \c "default". Otherwise, attempt to find it in the lookup table and translate it.
+    If not found (or if STIR is compiled without nlohmann_json support), return \a rname.
+  */
   std::string get_radionuclide_name_from_lookup_table(const std::string& rname) const;
 };
 

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Copyright (C) 2011-2012, Kris Thielemans
-# Copyright (C) 2013, University College London
+# Copyright (C) 2013-2022 University College London
 # This file is part of STIR.
 #
 # SPDX-License-Identifier: Apache-2.0
@@ -24,6 +24,7 @@ set(${dir_SIMPLE_TEST_EXE_SOURCES}
 
 set(${dir_SIMPLE_TEST_EXE_SOURCES_NO_REGISTRIES}
         test_DateTime.cxx
+        test_radionuclide.cxx
 )
 
 Set(${dir_INVOLVED_TEST_EXE_SOURCES}

--- a/src/test/test_radionuclide.cxx
+++ b/src/test/test_radionuclide.cxx
@@ -1,0 +1,114 @@
+//
+//
+/*
+    Copyright (C) 2022, University College London
+    This file is part of STIR.
+
+    SPDX-License-Identifier: Apache-2.0
+
+    See STIR/LICENSE.txt for details
+*/
+
+/*!
+  \file 
+  \ingroup test
+  \ingroup ancillary
+  \brief A simple program to test stir::RadionuclideDB and stir::Radionuclide
+
+  \author Kris Thielemans
+*/
+#include "stir/RunTests.h"
+#include "stir/RadionuclideDB.h"
+#include "stir/Radionuclide.h"
+
+#include <iostream>
+
+
+START_NAMESPACE_STIR
+
+/*!
+  \brief Class with tests for stir::RadionuclideDB and stir::Radionuclide
+  \ingroup test
+  \ingroup ancillary
+*/
+class RadionuclideTest : public RunTests
+{
+public:
+  void run_tests();
+};
+
+
+void
+RadionuclideTest::run_tests()
+{
+  const ImagingModality pt_mod(ImagingModality::PT);
+  const ImagingModality nm_mod(ImagingModality::NM);
+
+  std::cerr << "Constructing database\n";
+  RadionuclideDB db;
+
+  std::cerr << "Testing F-18 and Tc99-m\n";
+
+  const auto F18_rnuclide = db.get_radionuclide(pt_mod, "^18^Fluorine");
+  std::cerr << "F18 radionuclide: " << F18_rnuclide.parameter_info();
+  check_if_equal(F18_rnuclide.get_half_life(), 6584.04F, "check on F18 half-life");
+  check_if_equal(F18_rnuclide.get_energy(), 511.F, "check on F18 energy");
+  check_if_equal(F18_rnuclide.get_branching_ratio(), 0.9686F, "check on F-18 branching ratio");
+  check(F18_rnuclide.get_modality() == pt_mod, "check on F-18 modality");
+    
+  const auto Tc99m_rnuclide = db.get_radionuclide(nm_mod, "^99m^Technetium");
+  std::cerr << "Tc-99m radionuclide: " << Tc99m_rnuclide.parameter_info();
+  check_if_equal(Tc99m_rnuclide.get_half_life(), 21624.12, "check on Tc-99m half-life");
+  check_if_equal(Tc99m_rnuclide.get_energy(), 140.511F, "check on Tc-99m energy");
+  check_if_equal(Tc99m_rnuclide.get_branching_ratio(), 0.885F, "check on Tc-99m branching ratio");
+  check(Tc99m_rnuclide.get_modality() == nm_mod, "check on Tc-99m modality");
+  
+  std::cerr << "Testing defaults\n";
+  {
+    // PET
+    {
+      const auto rnuclide = db.get_radionuclide(pt_mod, "");
+      check(rnuclide == F18_rnuclide, "check \"empty\" radionuclide for PET is F-18");
+
+      const auto def_rnuclide = db.get_radionuclide(pt_mod, "default");
+      check(rnuclide == def_rnuclide, "check equality of \"empty\" and \"default\" radionuclide for PET");
+    }
+    // NM
+    {
+      const auto rnuclide = db.get_radionuclide(nm_mod, "");
+      check(rnuclide == Tc99m_rnuclide, "check \"empty\" radionuclide for NM is Tc-99m");
+
+      const auto def_rnuclide = db.get_radionuclide(nm_mod, "default");
+      check(rnuclide == def_rnuclide, "check equality of \"empty\" and \"default\" radionuclide for NM");
+    }
+  }
+
+#ifdef nlohmann_json_FOUND
+  std::cerr << "Testing lookup-table and database\n";
+  {
+    check(F18_rnuclide == db.get_radionuclide(pt_mod, "F-18"), "alias F-18");
+    check(F18_rnuclide == db.get_radionuclide(pt_mod, "F-18"), "alias 18F");
+    check(Tc99m_rnuclide == db.get_radionuclide(nm_mod, "Tc-99m"), "alias Tc-99m");
+    check(Tc99m_rnuclide == db.get_radionuclide(nm_mod, "99mTc"), "alias 99mTc");
+    check_if_equal(db.get_radionuclide(pt_mod, "^11^Carbon").get_half_life(), 1221.66F,
+                   "C11 half-life");
+  }
+#endif    
+
+}
+
+
+END_NAMESPACE_STIR
+
+
+
+USING_NAMESPACE_STIR
+
+
+
+int main()
+{
+  RadionuclideTest tests;
+  tests.run_tests();
+  return tests.main_return_value();
+}

--- a/src/test/test_radionuclide.cxx
+++ b/src/test/test_radionuclide.cxx
@@ -105,7 +105,7 @@ RadionuclideTest::run_tests()
   std::cerr << "Testing lookup-table and database\n";
   {
     check(F18_rnuclide == db.get_radionuclide(pt_mod, "F-18"), "alias F-18");
-    check(F18_rnuclide == db.get_radionuclide(pt_mod, "F-18"), "alias 18F");
+    check(F18_rnuclide == db.get_radionuclide(pt_mod, "18F"), "alias 18F");
     check(Tc99m_rnuclide == db.get_radionuclide(nm_mod, "Tc-99m"), "alias Tc-99m");
     check(Tc99m_rnuclide == db.get_radionuclide(nm_mod, "99mTc"), "alias 99mTc");
     check_if_equal(db.get_radionuclide(pt_mod, "^11^Carbon").get_half_life(), 1221.66F,

--- a/src/test/test_radionuclide.cxx
+++ b/src/test/test_radionuclide.cxx
@@ -84,6 +84,24 @@ RadionuclideTest::run_tests()
   }
 
 #ifdef nlohmann_json_FOUND
+  std::cerr << "Testing Yttrium-90\n";
+  {
+    const auto Y90_rnuclide_SPECT = db.get_radionuclide(nm_mod, "^90^Yttrium");
+    std::cerr << "Y90 (SPECT) radionuclide: " << Y90_rnuclide_SPECT.parameter_info();
+    check_if_equal(Y90_rnuclide_SPECT.get_half_life(), 230549.76, "check on Y90 (SPECT) half-life");
+    check_if_equal(Y90_rnuclide_SPECT.get_energy(), 150.F, "check on Y90 (SPECT) energy");
+    check_if_equal(Y90_rnuclide_SPECT.get_branching_ratio(), 0.99983F, "check on Y90 (SPECT) branching ratio");
+    check(Y90_rnuclide_SPECT.get_modality() == nm_mod, "check on Y90 (SPECT) modality");
+
+    const auto Y90_rnuclide_PET = db.get_radionuclide(pt_mod, "^90^Yttrium");
+    std::cerr << "Y90 (PET) radionuclide: " << Y90_rnuclide_PET.parameter_info();
+    check_if_equal(Y90_rnuclide_PET.get_half_life(), 230549.76, "check on Y90 (PET) half-life");
+    check_if_equal(Y90_rnuclide_PET.get_energy(), 511.F, "check on Y90 (PET) energy");
+    check_if_equal(Y90_rnuclide_PET.get_branching_ratio(), 0.0000319F, "check on Y90 (PET) branching ratio");
+    check(Y90_rnuclide_PET.get_modality() == pt_mod, "check on Y90 (PET) modality");
+
+  }
+  
   std::cerr << "Testing lookup-table and database\n";
   {
     check(F18_rnuclide == db.get_radionuclide(pt_mod, "F-18"), "alias F-18");


### PR DESCRIPTION
I created a test for Radionuclide code and then had to fix various things to get it to work/understand.

The test fails locally because the JSON file has `PET` and `nucmed` but `ImagingModality` uses `PT` and `NM` as strings. We could fix this in the code or the JSON file. Not sure what the best option is. @danieldeidda ?

In addition, I think this will fail on Github Actions etc as the test code is run before install, so it won't find the JSON files.

