### PR TITLE
fix leaks when using SPECTUB matrix and openmp

### DIFF
--- a/src/recon_buildblock/BackProjectorByBinUsingProjMatrixByBin.cxx
+++ b/src/recon_buildblock/BackProjectorByBinUsingProjMatrixByBin.cxx
@@ -100,8 +100,8 @@ set_up(const shared_ptr<const ProjDataInfo>& proj_data_info_ptr,
        const shared_ptr<const DiscretisedDensity<3,float> >& image_info_ptr)
 
 {
-  BackProjectorByBin::set_up(proj_data_info_ptr, image_info_ptr);
   proj_matrix_ptr->set_up(proj_data_info_ptr, image_info_ptr);
+  BackProjectorByBin::set_up(proj_data_info_ptr, image_info_ptr);
 }
 
 const DataSymmetriesForViewSegmentNumbers *

--- a/src/recon_buildblock/ForwardProjectorByBinUsingProjMatrixByBin.cxx
+++ b/src/recon_buildblock/ForwardProjectorByBinUsingProjMatrixByBin.cxx
@@ -97,8 +97,8 @@ ForwardProjectorByBinUsingProjMatrixByBin::
 set_up(const shared_ptr<const ProjDataInfo>& proj_data_info_ptr,
        const shared_ptr<const DiscretisedDensity<3,float> >& image_info_ptr)
 {    	   
-  ForwardProjectorByBin::set_up(proj_data_info_ptr, image_info_ptr);
   proj_matrix_ptr->set_up(proj_data_info_ptr, image_info_ptr);
+  ForwardProjectorByBin::set_up(proj_data_info_ptr, image_info_ptr);
 }
 
 const DataSymmetriesForViewSegmentNumbers *


### PR DESCRIPTION
The SPECTUB matrix set_up() currently sets num_threads to 1 under certain conditions. However, the (base class) projectors create temp data depending on number of threads. Therefore, call set_up of the matrix before the one from the projector.

Might fix leak observed in https://github.com/SyneRBI/SIRF/issues/1101#issuecomment-1116006149