### PR TITLE
blocksoncylindrical: making scatter estimation work for segment different than 0

### DIFF
--- a/src/scatter_buildblock/upsample_and_fit_scatter_estimate.cxx
+++ b/src/scatter_buildblock/upsample_and_fit_scatter_estimate.cxx
@@ -60,7 +60,6 @@ upsample_and_fit_scatter_estimate(ProjData& scaled_scatter_proj_data,
   ProjDataInMemory interpolated_direct_scatter(emission_proj_data.get_exam_info_sptr(),
 					       interpolated_direct_scatter_proj_data_info_sptr);        
   
-      interpolated_direct_scatter_proj_data_info_sptr->reduce_segment_range(0,0);
       bool actual_remove_interleaving = remove_interleaving;
 
       if (remove_interleaving && emission_proj_data.get_proj_data_info_sptr()->get_scanner_sptr()->get_scanner_geometry()!="Cylindrical")
@@ -68,6 +67,9 @@ upsample_and_fit_scatter_estimate(ProjData& scaled_scatter_proj_data,
           warning("upsample_and_fit_scatter_estimate: forcing remove_interleaving to false as non-cylindrical projdata");
                actual_remove_interleaving = false;
       }
+      if (emission_proj_data.get_proj_data_info_sptr()->get_scanner_sptr()->get_scanner_geometry()=="Cylindrical")
+          interpolated_direct_scatter_proj_data_info_sptr->reduce_segment_range(0,0);
+
         interpolate_projdata(interpolated_direct_scatter, scatter_proj_data, spline_type, actual_remove_interleaving);
 
   const TimeFrameDefinitions& time_frame_defs =


### PR DESCRIPTION
the problem is that during the upsampling the reduce_segment was called. But for the BlocksOnCylindrical we need the full segments
