### PR TITLE
Parallelproj support: bugfix for computing LOR intersection with cylinder

### DIFF
--- a/documentation/release_5.1.htm
+++ b/documentation/release_5.1.htm
@@ -39,7 +39,9 @@ improvements to the documentation.
 <h2> Summary for end users (also to be read by developers)</h2>
 
 <h3>Bug fixes</h3>
-none
+<ul>
+  <li>Fix of find_LOR_intersections_with_cylinder function, see <a href="https://github.com/UCL/STIR/pull/1072/">PR #1072</a>.
+</ul>
 
 <h3>New functionality</h3>
 <li>Improvements to listmode reconstruction by Nikos Efthimiou, see <a href="https://github.com/UCL/STIR/pull/1030/">PR #1030</a>. 

--- a/documentation/release_5.1.htm
+++ b/documentation/release_5.1.htm
@@ -40,7 +40,7 @@ improvements to the documentation.
 
 <h3>Bug fixes</h3>
 <ul>
-  <li>Fix of find_LOR_intersections_with_cylinder function, see <a href="https://github.com/UCL/STIR/pull/1072/">PR #1072</a>.
+  <li>Fix of <code>find_LOR_intersections_with_cylinder</code> functions in the LOR hierarchy. This fixes the use of the <tt>parallelproj<tt> projector for non-cylindrical geometries. See <a href="https://github.com/UCL/STIR/pull/1072/">PR #1072</a>.</li>
 </ul>
 
 <h3>New functionality</h3>

--- a/src/include/stir/LORCoordinates.h
+++ b/src/include/stir/LORCoordinates.h
@@ -143,8 +143,9 @@ class LORCylindricalCoordinates_z_and_radius
     {
       check_state();
       assert(new_radius>0);
-      _z1 *= new_radius/_radius;
-      _z2 *= new_radius/_radius;
+      const auto mid_point = 0.5 * (_z1 + _z2);
+      _z1 = mid_point + (_z1 - mid_point) * new_radius / _radius;
+      _z2 = mid_point + (_z2 - mid_point) * new_radius / _radius;
       _radius = new_radius;
     }
   coordT _radius;
@@ -192,8 +193,9 @@ class LORInCylinderCoordinates : public LOR<coordT>
       _radius*fabs(cos((_p1.psi()-_p2.psi())/2));
     if (new_radius >= min_radius)
       return Succeeded::no;
-    _p1.z() *= new_radius/_radius;
-    _p2.z() *= new_radius/_radius;
+    const auto mid_point = 0.5 * (_p1.z() + _p2.z());
+    _p1.z() = mid_point + (_p1.z() - mid_point) * new_radius / _radius;
+    _p2.z() = mid_point + (_p2.z() - mid_point) * new_radius / _radius;
     _radius = new_radius;
     return Succeeded::yes;
   }

--- a/src/include/stir/LORCoordinates.h
+++ b/src/include/stir/LORCoordinates.h
@@ -143,9 +143,8 @@ class LORCylindricalCoordinates_z_and_radius
     {
       check_state();
       assert(new_radius>0);
-      const auto mid_point = 0.5 * (_z1 + _z2);
-      _z1 = mid_point + (_z1 - mid_point) * new_radius / _radius;
-      _z2 = mid_point + (_z2 - mid_point) * new_radius / _radius;
+      _z1 *= new_radius/_radius;
+      _z2 *= new_radius/_radius;
       _radius = new_radius;
     }
   coordT _radius;
@@ -180,6 +179,10 @@ class LORInCylinderCoordinates : public LOR<coordT>
     }
   coordT radius() const { check_state(); return _radius; }
 
+  /*! \ingroup LOR
+    \brief Changes the radius of the LOR
+    \warning This does *not* preserve the LOR. Instead, it scales the LOR radially.
+  */
   inline 
     Succeeded
     set_radius(coordT new_radius)
@@ -193,9 +196,8 @@ class LORInCylinderCoordinates : public LOR<coordT>
       _radius*fabs(cos((_p1.psi()-_p2.psi())/2));
     if (new_radius >= min_radius)
       return Succeeded::no;
-    const auto mid_point = 0.5 * (_p1.z() + _p2.z());
-    _p1.z() = mid_point + (_p1.z() - mid_point) * new_radius / _radius;
-    _p2.z() = mid_point + (_p2.z() - mid_point) * new_radius / _radius;
+    _p1.z() *= new_radius/_radius;
+    _p2.z() *= new_radius/_radius;
     _radius = new_radius;
     return Succeeded::yes;
   }

--- a/src/include/stir/LORCoordinates.inl
+++ b/src/include/stir/LORCoordinates.inl
@@ -333,15 +333,18 @@ find_LOR_intersections_with_cylinder(LORAs2Points<coordT1>& intersection_coords,
      argument of sqrt simplifies to
      R^2*(d.x^2+d.y^2)-(d.x*c1.y-d.y*c1.x)^2
   */
-  const double dxy2 = (square(d.x())+square(d.y()));
-  const double argsqrt=
-    (square(radius)*dxy2-square(d.x()*c1.y()-d.y()*c1.x()));
-  if (argsqrt<=0)
+  const double a = square(d.x()) + square(d.y());
+  const double b = d.x() * c1.x() + d.y() * c1.y();
+  const double e = square(c1.x()) + square(c1.y()) - square(radius);
+  double argsqrt = square(b) - a * e;
+  if (argsqrt<=0) {
     return Succeeded::no; // LOR is outside detector radius
+  }
   const coordT2 root = static_cast<coordT2>(sqrt(argsqrt));
 
-  const coordT2 l1 = static_cast<coordT2>((- (d.x()*c1.x() + d.y()*c1.y())+root)/dxy2);
-  const coordT2 l2 = static_cast<coordT2>((- (d.x()*c1.x() + d.y()*c1.y())-root)/dxy2);
+  auto l1 = static_cast<coordT2>((-b + root) / a);
+  auto l2 = static_cast<coordT2>((-b - root) / a);
+  
   // TODO won't work when coordT1!=coordT2
   intersection_coords.p1() = d*l1 + c1;
   intersection_coords.p2() = d*l2 + c1;
@@ -518,10 +521,9 @@ TYPE<coordT>::								     \
 get_intersections_with_cylinder(LORAs2Points<coordT>& lor,              \
                                 const double radius) const		     \
 {									     \
-  self_type tmp = *this;							     \
-  if (tmp.set_radius(static_cast<coordT>(radius)) == Succeeded::no)			             \
+  LORAs2Points<coordT> actual_lor = *this;							     \
+  if (find_LOR_intersections_with_cylinder(lor, actual_lor, radius) == Succeeded::no)  \
     return Succeeded::no;						     \
-  lor = tmp;                                                                 \
   return Succeeded::yes;								     \
 }
 									    


### PR DESCRIPTION
Fixes part of the issues mentioned in issue: https://github.com/UCL/STIR/issues/1070.

Previously, the LOR endpoints were radially projected outwards, instead of extended and intersected with cylinder. As part of this, the code computing the intersection was slightly modified to align with the equations in the comments.