### PR TITLE
Issue/1070 parallelproj support issues linked to scanner fov radius

### DIFF
--- a/documentation/release_5.1.htm
+++ b/documentation/release_5.1.htm
@@ -39,7 +39,9 @@ improvements to the documentation.
 <h2> Summary for end users (also to be read by developers)</h2>
 
 <h3>Bug fixes</h3>
-none
+<ul>
+  <li>Fix of find_LOR_intersections_with_cylinder function, see <a href="https://github.com/UCL/STIR/pull/1072/">PR #1072</a>.
+</ul>
 
 <h3>New functionality</h3>
 <li>Improvements to listmode reconstruction by Nikos Efthimiou, see <a href="https://github.com/UCL/STIR/pull/1030/">PR #1030</a>. 

--- a/documentation/release_5.1.htm
+++ b/documentation/release_5.1.htm
@@ -40,7 +40,7 @@ improvements to the documentation.
 
 <h3>Bug fixes</h3>
 <ul>
-  <li>Fix of find_LOR_intersections_with_cylinder function, see <a href="https://github.com/UCL/STIR/pull/1072/">PR #1072</a>.
+  <li>Fix of <code>find_LOR_intersections_with_cylinder</code> functions in the LOR hierarchy. This fixes the use of the <tt>parallelproj<tt> projector for non-cylindrical geometries. See <a href="https://github.com/UCL/STIR/pull/1072/">PR #1072</a>.</li>
 </ul>
 
 <h3>New functionality</h3>

--- a/src/buildblock/Scanner.cxx
+++ b/src/buildblock/Scanner.cxx
@@ -910,6 +910,7 @@ void Scanner::set_up()
             error("Scanner::scanner_geometry needs to be one of Cylindrical, BlocksOnCylindrical, Generic");
         }
     }
+  set_outer_FOV_radius();
   _already_setup = true;
 }
 
@@ -922,6 +923,29 @@ set_detector_map( const DetectorCoordinateMap::det_pos_to_coord_type& coord_map 
       (unsigned)num_rings != detector_map_sptr->get_num_axial_coords() ||
       (unsigned)num_detector_layers != detector_map_sptr->get_num_radial_coords())
       error("Scanner:set_detector_map: inconsistent number of detectors");
+}
+
+void
+Scanner::
+set_outer_FOV_radius() {
+  if (!this->detector_map_sptr)
+  {
+    // for cylindrical scanners, all detectors have the same distance from the rotational axis
+    outer_FOV_radius = inner_ring_radius;
+  }
+  else
+  {
+    // for other geometries, loop through all detectors and set the radius to the largest found distance
+    outer_FOV_radius = inner_ring_radius;
+    for (auto tangential_pos = 0; tangential_pos < detector_map_sptr->get_num_tangential_coords(); tangential_pos++)
+      for (auto axial_pos = 0; axial_pos < detector_map_sptr->get_num_axial_coords(); axial_pos++)
+        for (auto radial_pos = 0; radial_pos < detector_map_sptr->get_num_radial_coords(); radial_pos++)
+    {
+      auto coord = detector_map_sptr->get_coordinate_for_det_pos(stir::DetectionPosition<>(tangential_pos, axial_pos, radial_pos));
+      const auto detector_radius = sqrt(coord.x() * coord.x() + coord.y() * coord.y()) - average_depth_of_interaction;
+      outer_FOV_radius = fmax(outer_FOV_radius, detector_radius);
+    }
+  }
 }
 
 void

--- a/src/include/stir/LORCoordinates.h
+++ b/src/include/stir/LORCoordinates.h
@@ -143,8 +143,9 @@ class LORCylindricalCoordinates_z_and_radius
     {
       check_state();
       assert(new_radius>0);
-      _z1 *= new_radius/_radius;
-      _z2 *= new_radius/_radius;
+      const auto mid_point = 0.5 * (_z1 + _z2);
+      _z1 = mid_point + (_z1 - mid_point) * new_radius / _radius;
+      _z2 = mid_point + (_z2 - mid_point) * new_radius / _radius;
       _radius = new_radius;
     }
   coordT _radius;
@@ -192,8 +193,9 @@ class LORInCylinderCoordinates : public LOR<coordT>
       _radius*fabs(cos((_p1.psi()-_p2.psi())/2));
     if (new_radius >= min_radius)
       return Succeeded::no;
-    _p1.z() *= new_radius/_radius;
-    _p2.z() *= new_radius/_radius;
+    const auto mid_point = 0.5 * (_p1.z() + _p2.z());
+    _p1.z() = mid_point + (_p1.z() - mid_point) * new_radius / _radius;
+    _p2.z() = mid_point + (_p2.z() - mid_point) * new_radius / _radius;
     _radius = new_radius;
     return Succeeded::yes;
   }

--- a/src/include/stir/LORCoordinates.h
+++ b/src/include/stir/LORCoordinates.h
@@ -143,9 +143,8 @@ class LORCylindricalCoordinates_z_and_radius
     {
       check_state();
       assert(new_radius>0);
-      const auto mid_point = 0.5 * (_z1 + _z2);
-      _z1 = mid_point + (_z1 - mid_point) * new_radius / _radius;
-      _z2 = mid_point + (_z2 - mid_point) * new_radius / _radius;
+      _z1 *= new_radius/_radius;
+      _z2 *= new_radius/_radius;
       _radius = new_radius;
     }
   coordT _radius;
@@ -180,6 +179,10 @@ class LORInCylinderCoordinates : public LOR<coordT>
     }
   coordT radius() const { check_state(); return _radius; }
 
+  /*! \ingroup LOR
+    \brief Changes the radius of the LOR
+    \warning This does *not* preserve the LOR. Instead, it scales the LOR radially.
+  */
   inline 
     Succeeded
     set_radius(coordT new_radius)
@@ -193,9 +196,8 @@ class LORInCylinderCoordinates : public LOR<coordT>
       _radius*fabs(cos((_p1.psi()-_p2.psi())/2));
     if (new_radius >= min_radius)
       return Succeeded::no;
-    const auto mid_point = 0.5 * (_p1.z() + _p2.z());
-    _p1.z() = mid_point + (_p1.z() - mid_point) * new_radius / _radius;
-    _p2.z() = mid_point + (_p2.z() - mid_point) * new_radius / _radius;
+    _p1.z() *= new_radius/_radius;
+    _p2.z() *= new_radius/_radius;
     _radius = new_radius;
     return Succeeded::yes;
   }

--- a/src/include/stir/LORCoordinates.inl
+++ b/src/include/stir/LORCoordinates.inl
@@ -333,15 +333,18 @@ find_LOR_intersections_with_cylinder(LORAs2Points<coordT1>& intersection_coords,
      argument of sqrt simplifies to
      R^2*(d.x^2+d.y^2)-(d.x*c1.y-d.y*c1.x)^2
   */
-  const double dxy2 = (square(d.x())+square(d.y()));
-  const double argsqrt=
-    (square(radius)*dxy2-square(d.x()*c1.y()-d.y()*c1.x()));
-  if (argsqrt<=0)
+  const double a = square(d.x()) + square(d.y());
+  const double b = d.x() * c1.x() + d.y() * c1.y();
+  const double e = square(c1.x()) + square(c1.y()) - square(radius);
+  double argsqrt = square(b) - a * e;
+  if (argsqrt<=0) {
     return Succeeded::no; // LOR is outside detector radius
+  }
   const coordT2 root = static_cast<coordT2>(sqrt(argsqrt));
 
-  const coordT2 l1 = static_cast<coordT2>((- (d.x()*c1.x() + d.y()*c1.y())+root)/dxy2);
-  const coordT2 l2 = static_cast<coordT2>((- (d.x()*c1.x() + d.y()*c1.y())-root)/dxy2);
+  auto l1 = static_cast<coordT2>((-b + root) / a);
+  auto l2 = static_cast<coordT2>((-b - root) / a);
+  
   // TODO won't work when coordT1!=coordT2
   intersection_coords.p1() = d*l1 + c1;
   intersection_coords.p2() = d*l2 + c1;
@@ -518,10 +521,9 @@ TYPE<coordT>::								     \
 get_intersections_with_cylinder(LORAs2Points<coordT>& lor,              \
                                 const double radius) const		     \
 {									     \
-  self_type tmp = *this;							     \
-  if (tmp.set_radius(static_cast<coordT>(radius)) == Succeeded::no)			             \
+  LORAs2Points<coordT> actual_lor = *this;							     \
+  if (find_LOR_intersections_with_cylinder(lor, actual_lor, radius) == Succeeded::no)  \
     return Succeeded::no;						     \
-  lor = tmp;                                                                 \
   return Succeeded::yes;								     \
 }
 									    

--- a/src/include/stir/Scanner.h
+++ b/src/include/stir/Scanner.h
@@ -250,6 +250,8 @@ class Scanner
   inline int get_max_num_views() const;
   //! get inner ring radius
   inline float get_inner_ring_radius() const;
+  //! get outer field of view radius
+  inline float get_outer_FOV_radius() const;
   //! get effective ring radius
   inline float get_effective_ring_radius() const;
   //! get average depth of interaction
@@ -464,6 +466,7 @@ private:
 
   float inner_ring_radius;      /*! detector inner radius in mm*/
   float average_depth_of_interaction; /*! Average interaction depth in detector crystal */
+  float outer_FOV_radius;       /*! detector outer radius in mm - for cylindrical scanner identical to inner radius */
   float ring_spacing;   /*! ring separation in mm*/
   float bin_size;               /*! arc-corrected bin size in mm (spacing of transaxial elements) */
   float intrinsic_tilt;         /*! intrinsic tilt in radians*/
@@ -506,6 +509,7 @@ private:
   shared_ptr<DetectorCoordinateMap> detector_map_sptr;
 
   void set_detector_map( const DetectorCoordinateMap::det_pos_to_coord_type& coord_map );
+  void set_outer_FOV_radius();
 
   // function to create the maps
   void read_detectormap_from_file( const std::string& filename );

--- a/src/include/stir/Scanner.inl
+++ b/src/include/stir/Scanner.inl
@@ -68,6 +68,12 @@ Scanner::get_inner_ring_radius() const
 }
 
 float
+Scanner::get_outer_FOV_radius() const
+{
+  return outer_FOV_radius;
+}
+
+float
 Scanner::get_average_depth_of_interaction() const
 {
   return average_depth_of_interaction;

--- a/src/recon_buildblock/Parallelproj_projector/ParallelprojHelper.cxx
+++ b/src/recon_buildblock/Parallelproj_projector/ParallelprojHelper.cxx
@@ -73,7 +73,7 @@ detail::ParallelprojHelper::ParallelprojHelper(const ProjDataInfo& p_info, const
   Bin bin;
   LORInAxialAndNoArcCorrSinogramCoordinates<float> lor;
   LORAs2Points<float> lor_points;
-  const float radius = p_info.get_scanner_sptr()->get_inner_ring_radius();
+  const float radius = p_info.get_scanner_sptr()->get_outer_FOV_radius() + p_info.get_scanner_sptr()->get_average_depth_of_interaction();
 
   // warning: next loop needs to be the same as how ProjDataInMemory stores its data. There is no guarantee that this will remain the case in the future.
   const auto segment_sequence = ProjData::standard_segment_sequence(p_info);


### PR DESCRIPTION
Added a call to get the outer_FOV_radius of the scanner, to fix the parallelproj interface for non-cylindrical scanners. This is just the first suggestion for this implementation - we might want to rename the get_inner_radius to get_inner_FOV_radius as well. And I'm open to other suggestions.