### PR TITLE
Fix OpenMP problem in ProjDataInfoCylindrical

### DIFF
--- a/documentation/release_5.1.htm
+++ b/documentation/release_5.1.htm
@@ -71,8 +71,8 @@ See <a href=https://github.com/UCL/STIR/labels/bug>our issue tracker</a>.
 
 <h3>Minor bug fixes</h3>
 <ul>
-<li>
-</li>
+  <li>made <code>ProjDataInfo*::get_all_det_pos_pairs_for_bin</code> thread-safe.
+   See <a href="https://github.com/UCL/STIR/pull/1084/">PR #1084</a>.</li></li>
 </ul>
 
 <h3>Documentation changes</h3>

--- a/src/include/stir/ProjDataInfoCylindrical.h
+++ b/src/include/stir/ProjDataInfoCylindrical.h
@@ -1,7 +1,7 @@
 /*
     Copyright (C) 2000 PARAPET partners
     Copyright (C) 2000-2009, Hammersmith Imanet Ltd
-    Copyright (C) 2013, University College London
+    Copyright (C) 2013, 2022 University College London
     Copyright (C) 2013, Institute for Bioengineering of Catalonia
     This file is part of STIR.
 
@@ -305,8 +305,6 @@ private:
 
   inline int get_num_axial_poss_per_ring_inc(const int segment_num) const;
 
-  //! This member will signal if the array below contain sensible info or not
-  mutable bool segment_axial_pos_to_ring_pair_allocated;
   //! This member stores a table used by get_all_ring_pairs_for_segment_axial_pos_num()
   mutable VectorWithOffset< VectorWithOffset < shared_ptr<RingNumPairs> > > 
     segment_axial_pos_to_ring_pair;
@@ -315,6 +313,7 @@ private:
   void allocate_segment_axial_pos_to_ring_pair() const;
 
   //! initialise one element of the above table
+  /*! Not thread-safe! Use  initialise_ring_diff_arrays_if_not_done_yet() instead. */
   void compute_segment_axial_pos_to_ring_pair(const int segment_num, const int axial_pos_num) const;
 
 };

--- a/src/include/stir/ProjDataInfoCylindrical.inl
+++ b/src/include/stir/ProjDataInfoCylindrical.inl
@@ -266,9 +266,7 @@ get_all_ring_pairs_for_segment_axial_pos_num(const int segment_num,
 					     const int axial_pos_num) const
 {
   this->initialise_ring_diff_arrays_if_not_done_yet();
-  if (is_null_ptr(segment_axial_pos_to_ring_pair[segment_num][axial_pos_num]))
-    compute_segment_axial_pos_to_ring_pair(segment_num, axial_pos_num);
-  return *segment_axial_pos_to_ring_pair[segment_num][axial_pos_num];
+  return *this->segment_axial_pos_to_ring_pair[segment_num][axial_pos_num];
 }
 
 unsigned


### PR DESCRIPTION
An internal array was not initialised in a thread-safe manner. `ProjDataInfo*::get_all_det_pos_pairs_for_bin` was therefore not thread-safe.

It turns out that the relevant function was not tested with OpenMP in `test_proj_data_info`, so I've put that in now.

Fixes #1083