### PR TITLE
Issue/1070 Making BlocksOnCylindrical projection tests faster

### DIFF
--- a/src/recon_test/test_blocks_on_cylindrical_projectors.cxx
+++ b/src/recon_test/test_blocks_on_cylindrical_projectors.cxx
@@ -38,7 +38,6 @@
 #include "stir/ProjDataInfoBlocksOnCylindricalNoArcCorr.h"
 #include "stir/ProjDataInfoGenericNoArcCorr.h"
 #include "stir/ProjDataInfoCylindricalNoArcCorr.h"
-#include "stir/ProjDataInfoCylindrical.h"
 #include "stir/recon_buildblock/ProjMatrixByBinUsingRayTracing.h"
 #include "stir/Sinogram.h"
 #include "stir/Viewgram.h"
@@ -54,8 +53,10 @@
 #include "stir/VoxelsOnCartesianGrid.h"
 #include "stir/recon_buildblock/ForwardProjectorByBin.h"
 #include "stir/recon_buildblock/ForwardProjectorByBinUsingProjMatrixByBin.h"
+#ifdef STIR_WITH_Parallelproj_PROJECTOR
 #include "stir/recon_buildblock/Parallelproj_projector/ForwardProjectorByBinParallelproj.h"
 #include "stir/recon_buildblock/Parallelproj_projector/BackProjectorByBinParallelproj.h"
+#endif
 #include "stir/recon_buildblock/BackProjectorByBinUsingProjMatrixByBin.h"
 #include "stir/IO/write_to_file.h"
 #include "stir/VoxelsOnCartesianGrid.h"

--- a/src/recon_test/test_blocks_on_cylindrical_projectors.cxx
+++ b/src/recon_test/test_blocks_on_cylindrical_projectors.cxx
@@ -38,6 +38,7 @@
 #include "stir/ProjDataInfoBlocksOnCylindricalNoArcCorr.h"
 #include "stir/ProjDataInfoGenericNoArcCorr.h"
 #include "stir/ProjDataInfoCylindricalNoArcCorr.h"
+#include "stir/ProjDataInfoCylindrical.h"
 #include "stir/recon_buildblock/ProjMatrixByBinUsingRayTracing.h"
 #include "stir/Sinogram.h"
 #include "stir/Viewgram.h"
@@ -53,6 +54,8 @@
 #include "stir/VoxelsOnCartesianGrid.h"
 #include "stir/recon_buildblock/ForwardProjectorByBin.h"
 #include "stir/recon_buildblock/ForwardProjectorByBinUsingProjMatrixByBin.h"
+#include "stir/recon_buildblock/Parallelproj_projector/ForwardProjectorByBinParallelproj.h"
+#include "stir/recon_buildblock/Parallelproj_projector/BackProjectorByBinParallelproj.h"
 #include "stir/recon_buildblock/BackProjectorByBinUsingProjMatrixByBin.h"
 #include "stir/IO/write_to_file.h"
 #include "stir/VoxelsOnCartesianGrid.h"
@@ -71,14 +74,27 @@ public:
   void run_tests();
 
 private:
-  void run_symmetry_test();
-  void run_plane_symmetry_test();
-  void run_map_orientation_test();
-  void run_axial_projection_test();
-  void run_voxelOnCartesianGrid_with_negative_offset();
-  void run_intersection_with_cylinder_test();
   template <class TProjDataInfo>
   shared_ptr<TProjDataInfo> set_blocks_projdata_info(shared_ptr<Scanner> scanner_sptr);
+
+  template <typename T>
+  void run_symmetry_test(shared_ptr<T> forw_projector1_sptr, shared_ptr<T> forw_projector2_sptr);
+
+  template <typename T>
+  void run_plane_symmetry_test(shared_ptr<T> forw_projector1_sptr, shared_ptr<T> forw_projector2_sptr);
+
+  void run_voxelOnCartesianGrid_with_negative_offset();
+
+  template <typename FORW, typename BACK>
+  void run_axial_projection_test(shared_ptr<FORW> forw_projector_sptr, shared_ptr<BACK> bck_projector_sptr);
+
+  template <typename T>
+  void run_map_orientation_test(shared_ptr<T> forw_projector1_sptr, shared_ptr<T> forw_projector2_sptr);
+
+  template<typename T>
+  void run_projection_test(shared_ptr<T> forw_projector1_sptr, shared_ptr<T> forw_projector2_sptr);
+
+  void run_intersection_with_cylinder_test();
 };
 /*! The following is a function to allow a projdata_info blocksONCylindrical to be created from the scanner.
  */
@@ -104,293 +120,15 @@ BlocksTests::set_blocks_projdata_info(shared_ptr<Scanner> scanner_sptr)
   return proj_data_info_blocks_sptr;
 }
 
-/*! The following is a test for the view offset with voxelOnCartesianGrid: ascanner is created and its relative
- * projdata info using a negative offset is set. When calling the voxelOnCartesianGrid constructor if everything ok
- * a variable called is_OK is set to true and false otherwise. If false the test will fail.
- */
-void
-BlocksTests::run_voxelOnCartesianGrid_with_negative_offset()
-{
-  //    create projadata info
-
-  auto scannerBlocks_sptr = std::make_shared<Scanner>(Scanner::SAFIRDualRingPrototype);
-
-  scannerBlocks_sptr->set_intrinsic_azimuthal_tilt(-30);
-  scannerBlocks_sptr->set_scanner_geometry("BlocksOnCylindrical");
-  scannerBlocks_sptr->set_up();
-
-  auto proj_data_info_blocks_sptr = std::make_shared<ProjDataInfoBlocksOnCylindricalNoArcCorr>();
-  proj_data_info_blocks_sptr = set_blocks_projdata_info<ProjDataInfoBlocksOnCylindricalNoArcCorr>(scannerBlocks_sptr);
-
-  bool is_ok = true;
-
-  try
-    {
-      auto grid = std::make_shared<VoxelsOnCartesianGrid<float>>(
-          *proj_data_info_blocks_sptr, 1, CartesianCoordinate3D<float>(0.F, 0.F, 0.F), CartesianCoordinate3D<int>(-1, -1, -1));
-    }
-  catch (...)
-    {
-      is_ok = false;
-    }
-
-  check_if_equal(is_ok, true);
-}
-
-/*! The following is a test for axial symmetries: a simulated image is created with a line along the z direction.
- *  The image is forward projected to a sinogram and the sinogram back projected to an image. This image should
- *  be symmetrical along z
- */
-void
-BlocksTests::run_axial_projection_test()
-{
-
-  //-- ExamInfo
-  auto exam_info_sptr = std::make_shared<ExamInfo>();
-  exam_info_sptr->imaging_modality = ImagingModality::PT;
-
-  CartesianCoordinate3D<float> origin(0, 0, 0);
-  CartesianCoordinate3D<float> grid_spacing(1.1, 2.2, 2.2);
-
-  const IndexRange<3> range(Coordinate3D<int>(0, -45, -45), Coordinate3D<int>(24, 44, 44));
-  VoxelsOnCartesianGrid<float> image(exam_info_sptr, range, origin, grid_spacing);
-
-  //    60 degrees
-  float phi1 = 0 * _PI / 180;
-  const Array<2, float> direction_vectors
-      = make_array(make_1d_array(1.F, 0.F, 0.F), make_1d_array(0.F, cos(float(_PI) - phi1), sin(float(_PI) - phi1)),
-                   make_1d_array(0.F, -sin(float(_PI) - phi1), cos(float(_PI) - phi1)));
-
-  Ellipsoid plane(CartesianCoordinate3D<float>(/*edge_z*/ 50 * grid_spacing.z(),
-                                               /*edge_y*/ 2 * grid_spacing.y(),
-                                               /*edge_x*/ 2 * grid_spacing.x()),
-                  /*centre*/
-                  CartesianCoordinate3D<float>((image.get_min_index() + image.get_max_index()) / 2 * grid_spacing.z(),
-                                               0 * grid_spacing.y(), 0),
-                  direction_vectors);
-
-  plane.construct_volume(image, make_coordinate(3, 3, 3));
-
-  //    create projadata info
-
-  auto scannerBlocks_sptr = std::make_shared<Scanner>(Scanner::SAFIRDualRingPrototype);
-  scannerBlocks_sptr->set_scanner_geometry("BlocksOnCylindrical");
-  scannerBlocks_sptr->set_up();
-
-  auto proj_data_info_blocks_sptr = std::make_shared<ProjDataInfoBlocksOnCylindricalNoArcCorr>();
-  proj_data_info_blocks_sptr
-      = set_blocks_projdata_info<ProjDataInfoBlocksOnCylindricalNoArcCorr>(scannerBlocks_sptr); //    now forward-project image
-
-  shared_ptr<DiscretisedDensity<3, float>> image_sptr(image.clone());
-  shared_ptr<DiscretisedDensity<3, float>> bck_proj_image_sptr(image.clone());
-  write_to_file("axial_test", *image_sptr);
-
-  auto PM = std::make_shared<ProjMatrixByBinUsingRayTracing>();
-  PM->enable_cache(false);
-  //    PM->set_do_symmetry_90degrees_min_phi(false);
-  //    PM->set_do_symmetry_shift_z(false);
-  //    PM->set_do_symmetry_swap_segment(false);
-
-  auto forw_projector_sptr = std::make_shared<ForwardProjectorByBinUsingProjMatrixByBin>(PM);
-  auto bck_projector_sptr = std::make_shared<BackProjectorByBinUsingProjMatrixByBin>(PM);
-  info(boost::format("Test blocks on Cylindrical: Forward projector used: %1%") % forw_projector_sptr->parameter_info());
-
-  forw_projector_sptr->set_up(proj_data_info_blocks_sptr, image_sptr);
-  bck_projector_sptr->set_up(proj_data_info_blocks_sptr, bck_proj_image_sptr);
-
-  auto projdata = std::make_shared<ProjDataInterfile>(exam_info_sptr, proj_data_info_blocks_sptr, "test_axial.hs",
-                                                      std::ios::out | std::ios::trunc | std::ios::in);
-
-  forw_projector_sptr->forward_project(*projdata, *image_sptr);
-
-  bck_projector_sptr->back_project(*bck_proj_image_sptr, *projdata, 0, 1);
-  write_to_file("back_proj_axial_test", *bck_proj_image_sptr);
-
-  int min_z = bck_proj_image_sptr->get_min_index();
-  int max_z = bck_proj_image_sptr->get_max_index();
-  int min_y = (*bck_proj_image_sptr)[min_z].get_min_index();
-  int max_y = (*bck_proj_image_sptr)[min_z].get_max_index();
-  int min_x = (*bck_proj_image_sptr)[min_z][min_y].get_min_index();
-  int max_x = (*bck_proj_image_sptr)[min_z][min_y].get_max_index();
-
-  // get two planes in the image that are equidistant from the z center
-  int centre_z = (max_z - min_z) / 2;
-  int plane_idA = centre_z - 5;
-  int plane_idB = centre_z + 5;
-
-  for (int y = min_y; y < max_y; y++)
-    for (int x = min_x; x < max_x; x++)
-      {
-        check_if_equal((*bck_proj_image_sptr)[plane_idA][y][x], (*bck_proj_image_sptr)[plane_idB][y][x],
-                       "checking the symmetry along the axial direction");
-      }
-}
-
-/*! The following is a test for symmetries: a simulated image is created with a plane at known angles,
- *  the forward projected sinogram should show the maximum value at the bin corresponding to the angle phi
- *  equal to the orientation of the plane
- */
-void
-BlocksTests::run_plane_symmetry_test()
-{
-
-  //-- ExamInfo
-  auto exam_info_sptr = std::make_shared<ExamInfo>();
-  exam_info_sptr->imaging_modality = ImagingModality::PT;
-
-  CartesianCoordinate3D<float> origin(0, 0, 0);
-  CartesianCoordinate3D<float> grid_spacing(1.1, 2.2, 2.2);
-  float phi1;
-  float phi2;
-  const IndexRange<3> range(Coordinate3D<int>(0, -45, -44), Coordinate3D<int>(24, 44, 45));
-  VoxelsOnCartesianGrid<float> image(exam_info_sptr, range, origin, grid_spacing);
-
-  //    60 degrees
-  phi1 = 60 * _PI / 180;
-  const Array<2, float> direction_vectors
-      = make_array(make_1d_array(1.F, 0.F, 0.F), make_1d_array(0.F, cos(float(_PI) - phi1), sin(float(_PI) - phi1)),
-                   make_1d_array(0.F, -sin(float(_PI) - phi1), cos(float(_PI) - phi1)));
-
-  Ellipsoid plane(CartesianCoordinate3D<float>(/*edge_z*/ 25 * grid_spacing.z(),
-                                               /*edge_y*/ 91 * grid_spacing.y(),
-                                               /*edge_x*/ 5 * grid_spacing.x()),
-                  /*centre*/
-                  CartesianCoordinate3D<float>((image.get_min_index() + image.get_max_index()) / 2 * grid_spacing.z(),
-                                               0 * grid_spacing.y(), 0),
-                  direction_vectors);
-
-  plane.construct_volume(image, make_coordinate(3, 3, 3));
-
-  //    rotate by 30 degrees
-  phi2 = 30 * _PI / 180;
-  VoxelsOnCartesianGrid<float> image2 = *image.get_empty_copy();
-  const Array<2, float> direction2
-      = make_array(make_1d_array(1.F, 0.F, 0.F), make_1d_array(0.F, cos(float(_PI) - phi2), sin(float(_PI) - phi2)),
-                   make_1d_array(0.F, -sin(float(_PI) - phi2), cos(float(_PI) - phi2)));
-
-  Ellipsoid plane2(CartesianCoordinate3D<float>(/*edge_z*/ 25 * grid_spacing.z(),
-                                                /*edge_y*/ 91 * grid_spacing.y(),
-                                                /*edge_x*/ 5 * grid_spacing.x()),
-                   /*centre*/
-                   CartesianCoordinate3D<float>((image.get_min_index() + image.get_max_index()) / 2 * grid_spacing.z(),
-                                                0 * grid_spacing.y(), 0),
-                   direction2);
-  //    plane.set_direction_vectors(direction2);
-
-  plane2.construct_volume(image2, make_coordinate(3, 3, 3));
-
-  //    create projadata info
-
-  auto scannerBlocks_sptr = std::make_shared<Scanner>(Scanner::SAFIRDualRingPrototype);
-  scannerBlocks_sptr->set_num_axial_crystals_per_block(1);
-  scannerBlocks_sptr->set_axial_block_spacing(scannerBlocks_sptr->get_axial_crystal_spacing()
-                                              * scannerBlocks_sptr->get_num_axial_crystals_per_block());
-  scannerBlocks_sptr->set_transaxial_block_spacing(scannerBlocks_sptr->get_transaxial_crystal_spacing()
-                                                   * scannerBlocks_sptr->get_num_transaxial_crystals_per_block());
-  //    scannerBlocks_sptr->set_num_transaxial_crystals_per_block(1);
-  scannerBlocks_sptr->set_num_axial_blocks_per_bucket(2);
-  //    scannerBlocks_sptr->set_num_transaxial_blocks_per_bucket(1);
-  scannerBlocks_sptr->set_num_rings(2);
-
-  scannerBlocks_sptr->set_scanner_geometry("BlocksOnCylindrical");
-  scannerBlocks_sptr->set_up();
-
-  auto proj_data_info_blocks_sptr = std::make_shared<ProjDataInfoBlocksOnCylindricalNoArcCorr>();
-  proj_data_info_blocks_sptr = set_blocks_projdata_info<ProjDataInfoBlocksOnCylindricalNoArcCorr>(scannerBlocks_sptr);
-
-  //    now forward-project image
-
-  shared_ptr<DiscretisedDensity<3, float>> image_sptr(image.clone());
-  write_to_file("plane60", *image_sptr);
-
-  shared_ptr<DiscretisedDensity<3, float>> image2_sptr(image2.clone());
-  write_to_file("plane30", *image2_sptr);
-
-  auto PM = std::make_shared<ProjMatrixByBinUsingRayTracing>();
-  PM->enable_cache(false);
-  auto forw_projector_sptr = std::make_shared<ForwardProjectorByBinUsingProjMatrixByBin>(PM);
-  info(boost::format("Test blocks on Cylindrical: Forward projector used: %1%") % forw_projector_sptr->parameter_info());
-
-  forw_projector_sptr->set_up(proj_data_info_blocks_sptr, image_sptr);
-
-  auto forw_projector2_sptr = std::make_shared<ForwardProjectorByBinUsingProjMatrixByBin>(PM);
-  forw_projector2_sptr->set_up(proj_data_info_blocks_sptr, image2_sptr);
-
-  auto projdata = std::make_shared<ProjDataInterfile>(exam_info_sptr, proj_data_info_blocks_sptr, "sino1_from_plane.hs",
-                                                      std::ios::out | std::ios::trunc | std::ios::in);
-
-  forw_projector_sptr->forward_project(*projdata, *image_sptr);
-
-  auto projdata2 = std::make_shared<ProjDataInterfile>(exam_info_sptr, proj_data_info_blocks_sptr, "sino2_from_plane.hs",
-                                                       std::ios::out | std::ios::trunc | std::ios::in);
-
-  forw_projector2_sptr->forward_project(*projdata2, *image2_sptr);
-
-  int view1_num = 0, view2_num = 0;
-  LORInAxialAndNoArcCorrSinogramCoordinates<float> lorB1;
-  for (int i = 0; i < projdata->get_max_view_num(); i++)
-    {
-      Bin bin(0, i, 0, 0);
-      proj_data_info_blocks_sptr->get_LOR(lorB1, bin);
-      if (abs(lorB1.phi() - phi1) / phi1 <= 1E-2)
-        {
-          view1_num = i;
-          break;
-        }
-    }
-
-  LORInAxialAndNoArcCorrSinogramCoordinates<float> lorB2;
-  for (int i = 0; i < projdata2->get_max_view_num(); i++)
-    {
-      Bin bin(0, i, 0, 0);
-      proj_data_info_blocks_sptr->get_LOR(lorB2, bin);
-      if (abs(lorB2.phi() - phi2) / phi2 <= 1E-2)
-        {
-          view2_num = i;
-          break;
-        }
-    }
-
-  float max1 = projdata->get_sinogram(0, 0).find_max();
-  float max2 = projdata2->get_sinogram(0, 0).find_max();
-
-  //    find the tang position with the max value
-  int tang1_num = 0, tang2_num = 0;
-  for (int tang = projdata->get_min_tangential_pos_num(); tang < projdata->get_max_tangential_pos_num(); tang++)
-    {
-
-      if ((max1 - projdata->get_sinogram(0, 0).at(view1_num).at(tang)) / max1 < 1E-3)
-        {
-          tang1_num = tang;
-          break;
-        }
-    }
-
-  for (int tang = projdata2->get_min_tangential_pos_num(); tang < projdata2->get_max_tangential_pos_num(); tang++)
-    {
-
-      if ((max2 - projdata2->get_sinogram(0, 0).at(view2_num).at(tang)) / max2 < 1E-3)
-        {
-          tang2_num = tang;
-          break;
-        }
-    }
-
-  float bin1 = projdata->get_sinogram(0, 0).at(view1_num).at(tang1_num);
-  float bin2 = projdata2->get_sinogram(0, 0).at(view2_num).at(tang2_num);
-  set_tolerance(10E-2);
-  check_if_equal(bin1, max1, "the value seen in the block at 60 degrees should be the same as the max value of the sinogram");
-  check_if_equal(bin2, max2, "the value seen in the block at 30 degrees should be the same as the max value of the sinogram");
-}
-
 /*! The following is a test for symmetries: a simulated image is created with spherical source in front of each detector block,
  *  the forward projected sinogram should show the same bin values in symmetric places (in this test a dodecagon scanner is
  * used so we have symmetry every 30 degrees. The above is repeated for an image with sources in front of the dodecagon corners.
  * The sinogram should have now different values at fixed bin compared the previous image. In this test we are also testing a
  * projdata_info with a negative view offset.
  */
+template <typename T>
 void
-BlocksTests::run_symmetry_test()
+BlocksTests::run_symmetry_test(shared_ptr<T> forw_projector1_sptr, shared_ptr<T> forw_projector2_sptr)
 {
 
   //-- ExamInfo
@@ -470,14 +208,10 @@ BlocksTests::run_symmetry_test()
   proj_data_info_blocks_sptr = set_blocks_projdata_info<ProjDataInfoBlocksOnCylindricalNoArcCorr>(scannerBlocks_sptr);
   //    now forward-project images
 
-  auto PM = std::make_shared<ProjMatrixByBinUsingRayTracing>();
-  PM->enable_cache(false);
-  auto forw_projector1_sptr = std::make_shared<ForwardProjectorByBinUsingProjMatrixByBin>(PM);
   info(boost::format("Test blocks on Cylindrical: Forward projector used: %1%") % forw_projector1_sptr->parameter_info());
 
   forw_projector1_sptr->set_up(proj_data_info_blocks_sptr, image1_sptr);
 
-  auto forw_projector2_sptr = std::make_shared<ForwardProjectorByBinUsingProjMatrixByBin>(PM);
   forw_projector2_sptr->set_up(proj_data_info_blocks_sptr, image2_sptr);
 
   auto projdata1 = std::make_shared<ProjDataInterfile>(exam_info_sptr, proj_data_info_blocks_sptr, "sino1_from_image.hs",
@@ -515,14 +249,284 @@ BlocksTests::run_symmetry_test()
   check(bin1_150 != bin2_150, "the two data have different symmetries, the values should be different");
 }
 
+/*! The following is a test for symmetries: a simulated image is created with a plane at known angles,
+ *  the forward projected sinogram should show the maximum value at the bin corresponding to the angle phi
+ *  equal to the orientation of the plane
+ */
+template <typename T>
+void
+BlocksTests::run_plane_symmetry_test(shared_ptr<T> forw_projector1_sptr, shared_ptr<T> forw_projector2_sptr)
+{
+
+  //-- ExamInfo
+  auto exam_info_sptr = std::make_shared<ExamInfo>();
+  exam_info_sptr->imaging_modality = ImagingModality::PT;
+
+  CartesianCoordinate3D<float> origin(0, 0, 0);
+  CartesianCoordinate3D<float> grid_spacing(1.1, 2.2, 2.2);
+  float phi1;
+  float phi2;
+  const IndexRange<3> range(Coordinate3D<int>(0, -45, -44), Coordinate3D<int>(24, 44, 45));
+  VoxelsOnCartesianGrid<float> image(exam_info_sptr, range, origin, grid_spacing);
+
+  //    60 degrees
+  phi1 = 60 * _PI / 180;
+  const Array<2, float> direction_vectors
+      = make_array(make_1d_array(1.F, 0.F, 0.F), make_1d_array(0.F, cos(float(_PI) - phi1), sin(float(_PI) - phi1)),
+                   make_1d_array(0.F, -sin(float(_PI) - phi1), cos(float(_PI) - phi1)));
+
+  Ellipsoid plane(CartesianCoordinate3D<float>(/*edge_z*/ 25 * grid_spacing.z(),
+                                               /*edge_y*/ 91 * grid_spacing.y(),
+                                               /*edge_x*/ 5 * grid_spacing.x()),
+                  /*centre*/
+                  CartesianCoordinate3D<float>((image.get_min_index() + image.get_max_index()) / 2 * grid_spacing.z(),
+                                               0 * grid_spacing.y(), 0),
+                  direction_vectors);
+
+  plane.construct_volume(image, make_coordinate(3, 3, 3));
+
+  //    rotate by 30 degrees
+  phi2 = 30 * _PI / 180;
+  VoxelsOnCartesianGrid<float> image2 = *image.get_empty_copy();
+  const Array<2, float> direction2
+      = make_array(make_1d_array(1.F, 0.F, 0.F), make_1d_array(0.F, cos(float(_PI) - phi2), sin(float(_PI) - phi2)),
+                   make_1d_array(0.F, -sin(float(_PI) - phi2), cos(float(_PI) - phi2)));
+
+  Ellipsoid plane2(CartesianCoordinate3D<float>(/*edge_z*/ 25 * grid_spacing.z(),
+                                                /*edge_y*/ 91 * grid_spacing.y(),
+                                                /*edge_x*/ 5 * grid_spacing.x()),
+                   /*centre*/
+                   CartesianCoordinate3D<float>((image.get_min_index() + image.get_max_index()) / 2 * grid_spacing.z(),
+                                                0 * grid_spacing.y(), 0),
+                   direction2);
+  //    plane.set_direction_vectors(direction2);
+
+  plane2.construct_volume(image2, make_coordinate(3, 3, 3));
+
+  //    create projadata info
+
+  auto scannerBlocks_sptr = std::make_shared<Scanner>(Scanner::SAFIRDualRingPrototype);
+  scannerBlocks_sptr->set_num_axial_crystals_per_block(1);
+  scannerBlocks_sptr->set_axial_block_spacing(scannerBlocks_sptr->get_axial_crystal_spacing()
+                                              * scannerBlocks_sptr->get_num_axial_crystals_per_block());
+  scannerBlocks_sptr->set_transaxial_block_spacing(scannerBlocks_sptr->get_transaxial_crystal_spacing()
+                                                   * scannerBlocks_sptr->get_num_transaxial_crystals_per_block());
+  //    scannerBlocks_sptr->set_num_transaxial_crystals_per_block(1);
+  scannerBlocks_sptr->set_num_axial_blocks_per_bucket(2);
+  //    scannerBlocks_sptr->set_num_transaxial_blocks_per_bucket(1);
+  scannerBlocks_sptr->set_num_rings(2);
+
+  scannerBlocks_sptr->set_scanner_geometry("BlocksOnCylindrical");
+  scannerBlocks_sptr->set_up();
+
+  auto proj_data_info_blocks_sptr = std::make_shared<ProjDataInfoBlocksOnCylindricalNoArcCorr>();
+  proj_data_info_blocks_sptr = set_blocks_projdata_info<ProjDataInfoBlocksOnCylindricalNoArcCorr>(scannerBlocks_sptr);
+
+  //    now forward-project image
+
+  shared_ptr<DiscretisedDensity<3, float>> image_sptr(image.clone());
+  write_to_file("plane60", *image_sptr);
+
+  shared_ptr<DiscretisedDensity<3, float>> image2_sptr(image2.clone());
+  write_to_file("plane30", *image2_sptr);
+
+  info(boost::format("Test blocks on Cylindrical: Forward projector used: %1%") % forw_projector1_sptr->parameter_info());
+
+  forw_projector1_sptr->set_up(proj_data_info_blocks_sptr, image_sptr);
+
+  forw_projector2_sptr->set_up(proj_data_info_blocks_sptr, image2_sptr);
+
+  auto projdata = std::make_shared<ProjDataInterfile>(exam_info_sptr, proj_data_info_blocks_sptr, "sino1_from_plane.hs",
+                                                      std::ios::out | std::ios::trunc | std::ios::in);
+
+  forw_projector1_sptr->forward_project(*projdata, *image_sptr);
+
+  auto projdata2 = std::make_shared<ProjDataInterfile>(exam_info_sptr, proj_data_info_blocks_sptr, "sino2_from_plane.hs",
+                                                       std::ios::out | std::ios::trunc | std::ios::in);
+
+  forw_projector2_sptr->forward_project(*projdata2, *image2_sptr);
+
+  int view1_num = 0, view2_num = 0;
+  LORInAxialAndNoArcCorrSinogramCoordinates<float> lorB1;
+  for (int i = 0; i < projdata->get_max_view_num(); i++)
+    {
+      Bin bin(0, i, 0, 0);
+      proj_data_info_blocks_sptr->get_LOR(lorB1, bin);
+      if (abs(lorB1.phi() - phi1) / phi1 <= 1E-2)
+        {
+          view1_num = i;
+          break;
+        }
+    }
+
+  LORInAxialAndNoArcCorrSinogramCoordinates<float> lorB2;
+  for (int i = 0; i < projdata2->get_max_view_num(); i++)
+    {
+      Bin bin(0, i, 0, 0);
+      proj_data_info_blocks_sptr->get_LOR(lorB2, bin);
+      if (abs(lorB2.phi() - phi2) / phi2 <= 1E-2)
+        {
+          view2_num = i;
+          break;
+        }
+    }
+
+  float max1 = projdata->get_sinogram(0, 0).find_max();
+  float max2 = projdata2->get_sinogram(0, 0).find_max();
+
+  //    find the tang position with the max value
+  int tang1_num = 0, tang2_num = 0;
+  for (int tang = projdata->get_min_tangential_pos_num(); tang < projdata->get_max_tangential_pos_num(); tang++)
+    {
+
+      if ((max1 - projdata->get_sinogram(0, 0).at(view1_num).at(tang)) / max1 < 1E-3)
+        {
+          tang1_num = tang;
+          break;
+        }
+    }
+
+  for (int tang = projdata2->get_min_tangential_pos_num(); tang < projdata2->get_max_tangential_pos_num(); tang++)
+    {
+
+      if ((max2 - projdata2->get_sinogram(0, 0).at(view2_num).at(tang)) / max2 < 1E-3)
+        {
+          tang2_num = tang;
+          break;
+        }
+    }
+
+  float bin1 = projdata->get_sinogram(0, 0).at(view1_num).at(tang1_num);
+  float bin2 = projdata2->get_sinogram(0, 0).at(view2_num).at(tang2_num);
+  set_tolerance(10E-2);
+  check_if_equal(bin1, max1, "the value seen in the block at 60 degrees should be the same as the max value of the sinogram");
+  check_if_equal(bin2, max2, "the value seen in the block at 30 degrees should be the same as the max value of the sinogram");
+}
+
+/*! The following is a test for the view offset with voxelOnCartesianGrid: ascanner is created and its relative
+ * projdata info using a negative offset is set. When calling the voxelOnCartesianGrid constructor if everything ok
+ * a variable called is_OK is set to true and false otherwise. If false the test will fail.
+ */
+void
+BlocksTests::run_voxelOnCartesianGrid_with_negative_offset()
+{
+  //    create projadata info
+
+  auto scannerBlocks_sptr = std::make_shared<Scanner>(Scanner::SAFIRDualRingPrototype);
+
+  scannerBlocks_sptr->set_intrinsic_azimuthal_tilt(-30);
+  scannerBlocks_sptr->set_scanner_geometry("BlocksOnCylindrical");
+  scannerBlocks_sptr->set_up();
+
+  auto proj_data_info_blocks_sptr = std::make_shared<ProjDataInfoBlocksOnCylindricalNoArcCorr>();
+  proj_data_info_blocks_sptr = set_blocks_projdata_info<ProjDataInfoBlocksOnCylindricalNoArcCorr>(scannerBlocks_sptr);
+
+  bool is_ok = true;
+
+  try
+    {
+      auto grid = std::make_shared<VoxelsOnCartesianGrid<float>>(
+          *proj_data_info_blocks_sptr, 1, CartesianCoordinate3D<float>(0.F, 0.F, 0.F), CartesianCoordinate3D<int>(-1, -1, -1));
+    }
+  catch (...)
+    {
+      is_ok = false;
+    }
+
+  check_if_equal(is_ok, true);
+}
+
+/*! The following is a test for axial symmetries: a simulated image is created with a line along the z direction.
+ *  The image is forward projected to a sinogram and the sinogram back projected to an image. This image should
+ *  be symmetrical along z
+ */
+template <typename FORW, typename BACK>
+void
+BlocksTests::run_axial_projection_test(shared_ptr<FORW> forw_projector_sptr, shared_ptr<BACK> bck_projector_sptr)
+{
+
+  //-- ExamInfo
+  auto exam_info_sptr = std::make_shared<ExamInfo>();
+  exam_info_sptr->imaging_modality = ImagingModality::PT;
+
+  CartesianCoordinate3D<float> origin(0, 0, 0);
+  CartesianCoordinate3D<float> grid_spacing(1.1, 2.2, 2.2);
+
+  const IndexRange<3> range(Coordinate3D<int>(0, -45, -45), Coordinate3D<int>(24, 44, 44));
+  VoxelsOnCartesianGrid<float> image(exam_info_sptr, range, origin, grid_spacing);
+
+  //    60 degrees
+  float phi1 = 0 * _PI / 180;
+  const Array<2, float> direction_vectors
+      = make_array(make_1d_array(1.F, 0.F, 0.F), make_1d_array(0.F, cos(float(_PI) - phi1), sin(float(_PI) - phi1)),
+                   make_1d_array(0.F, -sin(float(_PI) - phi1), cos(float(_PI) - phi1)));
+
+  Ellipsoid plane(CartesianCoordinate3D<float>(/*edge_z*/ 50 * grid_spacing.z(),
+                                               /*edge_y*/ 2 * grid_spacing.y(),
+                                               /*edge_x*/ 2 * grid_spacing.x()),
+                  /*centre*/
+                  CartesianCoordinate3D<float>((image.get_min_index() + image.get_max_index()) / 2 * grid_spacing.z(),
+                                               0 * grid_spacing.y(), 0),
+                  direction_vectors);
+
+  plane.construct_volume(image, make_coordinate(3, 3, 3));
+
+  //    create projadata info
+
+  auto scannerBlocks_sptr = std::make_shared<Scanner>(Scanner::SAFIRDualRingPrototype);
+  scannerBlocks_sptr->set_scanner_geometry("BlocksOnCylindrical");
+  scannerBlocks_sptr->set_up();
+
+  auto proj_data_info_blocks_sptr = std::make_shared<ProjDataInfoBlocksOnCylindricalNoArcCorr>();
+  proj_data_info_blocks_sptr
+      = set_blocks_projdata_info<ProjDataInfoBlocksOnCylindricalNoArcCorr>(scannerBlocks_sptr); //    now forward-project image
+
+  shared_ptr<DiscretisedDensity<3, float>> image_sptr(image.clone());
+  shared_ptr<DiscretisedDensity<3, float>> bck_proj_image_sptr(image.clone());
+  write_to_file("axial_test", *image_sptr);
+
+  info(boost::format("Test blocks on Cylindrical: Forward projector used: %1%") % forw_projector_sptr->parameter_info());
+
+  forw_projector_sptr->set_up(proj_data_info_blocks_sptr, image_sptr);
+  bck_projector_sptr->set_up(proj_data_info_blocks_sptr, bck_proj_image_sptr);
+
+  auto projdata = std::make_shared<ProjDataInterfile>(exam_info_sptr, proj_data_info_blocks_sptr, "test_axial.hs",
+                                                      std::ios::out | std::ios::trunc | std::ios::in);
+
+  forw_projector_sptr->forward_project(*projdata, *image_sptr);
+
+  bck_projector_sptr->back_project(*bck_proj_image_sptr, *projdata, 0, 1);
+  write_to_file("back_proj_axial_test", *bck_proj_image_sptr);
+
+  int min_z = bck_proj_image_sptr->get_min_index();
+  int max_z = bck_proj_image_sptr->get_max_index();
+  int min_y = (*bck_proj_image_sptr)[min_z].get_min_index();
+  int max_y = (*bck_proj_image_sptr)[min_z].get_max_index();
+  int min_x = (*bck_proj_image_sptr)[min_z][min_y].get_min_index();
+  int max_x = (*bck_proj_image_sptr)[min_z][min_y].get_max_index();
+
+  // get two planes in the image that are equidistant from the z center
+  int centre_z = (max_z - min_z) / 2;
+  int plane_idA = centre_z - 5;
+  int plane_idB = centre_z + 5;
+
+  for (int y = min_y; y < max_y; y++)
+    for (int x = min_x; x < max_x; x++)
+      {
+        check_if_equal((*bck_proj_image_sptr)[plane_idA][y][x], (*bck_proj_image_sptr)[plane_idB][y][x],
+                       "checking the symmetry along the axial direction");
+      }
+}
+
 /*!The following is a test for the crystal maps. Two scanners and ProjDataInfo are created, one with the standard map orientation
  * and the other with an orientation along the view which is opposite to the first one.  A simulated sphere was forward projected
  * to look at bin values in the two cases. The bin obtained from the two different projdata will have different coordinates but
  * the same value.
  */
 
+template<typename T>
 void
-BlocksTests::run_map_orientation_test()
+BlocksTests::run_map_orientation_test(shared_ptr<T> forw_projector1_sptr, shared_ptr<T> forw_projector2_sptr)
 {
   CPUTimer timer;
   //-- ExamInfo
@@ -619,25 +623,12 @@ BlocksTests::run_map_orientation_test()
   timer.start();
 
   //    now forward-project images
-
-  auto PM = std::make_shared<ProjMatrixByBinUsingRayTracing>();
-  PM->enable_cache(false);
-  auto forw_projector1_sptr = std::make_shared<ForwardProjectorByBinUsingProjMatrixByBin>(PM);
   info(boost::format("Test blocks on Cylindrical: Forward projector used: %1%") % forw_projector1_sptr->parameter_info());
+  auto projdata1 = std::make_shared<ProjDataInMemory>(exam_info_sptr, proj_data_info_blocks_sptr);
   forw_projector1_sptr->set_up(proj_data_info_blocks_sptr, image1_sptr);
-
-  auto forw_projector2_sptr = std::make_shared<ForwardProjectorByBinUsingProjMatrixByBin>(PM);
-  forw_projector2_sptr->set_up(proj_data_info_blocks_reord_sptr, image1_sptr);
-
-  auto projdata1 = std::make_shared<ProjDataInMemory>(exam_info_sptr,
-                                                      proj_data_info_blocks_sptr); //,
-  //                                             "sino1_map.hs",std::ios::out | std::ios::trunc | std::ios::in));
-
-  auto projdata2 = std::make_shared<ProjDataInMemory>(exam_info_sptr,
-                                                      proj_data_info_blocks_reord_sptr); //,
-  //                                             "sino2_map.hs",std::ios::out | std::ios::trunc | std::ios::in));
-
   forw_projector1_sptr->forward_project(*projdata1, *image1_sptr);
+  auto projdata2 = std::make_shared<ProjDataInMemory>(exam_info_sptr, proj_data_info_blocks_reord_sptr);
+  forw_projector2_sptr->set_up(proj_data_info_blocks_reord_sptr, image1_sptr);
   forw_projector2_sptr->forward_project(*projdata2, *image1_sptr);
 
   for (int view = 0; view <= proj_data_info_blocks_reord_sptr->get_max_view_num(); view++)
@@ -671,6 +662,82 @@ BlocksTests::run_map_orientation_test()
     }
   timer.stop();
   std::cerr << "-- CPU Time " << timer.value() << '\n';
+}
+
+template<typename T>
+void
+BlocksTests::run_projection_test(shared_ptr<T> forw_projector1_sptr, shared_ptr<T> forw_projector2_sptr)
+{
+  //-- ExamInfo
+  auto exam_info_sptr = std::make_shared<ExamInfo>();
+  exam_info_sptr->imaging_modality = ImagingModality::PT;
+
+  CartesianCoordinate3D<float> origin(0, 0, 0);
+  CartesianCoordinate3D<float> grid_spacing(1.1, 2.2, 2.2);
+
+  const IndexRange<3> range(Coordinate3D<int>(0, -45, -44), Coordinate3D<int>(24, 44, 45));
+  VoxelsOnCartesianGrid<float> image(exam_info_sptr, range, origin, grid_spacing);
+
+  const Array<2, float> direction_vectors
+      = make_array(make_1d_array(1.F, 0.F, 0.F), make_1d_array(0.F, 1.F, 0.F), make_1d_array(0.F, 0.F, 1.F));
+
+  Ellipsoid ellipsoid(CartesianCoordinate3D<float>(/*radius_z*/ 6 * grid_spacing.z(),
+                                                   /*radius_y*/ 6 * grid_spacing.y(),
+                                                   /*radius_x*/ 6 * grid_spacing.x()),
+                      /*centre*/
+                      CartesianCoordinate3D<float>((image.get_min_index() + image.get_max_index()) / 2 * grid_spacing.z(), 0,
+                                                   -30 * grid_spacing.y()),
+                      direction_vectors);
+  // ellipsoid.construct_volume(image, make_coordinate(3, 3, 3));
+  image[(image.get_min_index() + image.get_max_index()) / 2 * grid_spacing.z()][0][-30] = 1;
+
+  shared_ptr<DiscretisedDensity<3, float>> image1_sptr(image.clone());
+  write_to_file("image_with_phantom_at_30_0", *image1_sptr);
+
+  image = *image.get_empty_copy();
+  CartesianCoordinate3D<float> origin2((image.get_min_index() + image.get_max_index()) / 2 * grid_spacing.z(), 0, 0);
+  ellipsoid.set_origin(origin2);
+  // ellipsoid.construct_volume(image, make_coordinate(3, 3, 3));
+  image[(image.get_min_index() + image.get_max_index()) / 2 * grid_spacing.z()][0][-25] = 1;
+
+  shared_ptr<DiscretisedDensity<3, float>> image2_sptr(image.clone());
+  write_to_file("image_with_phantom_in_middle", *image2_sptr);
+
+  //    create projadata info
+  auto scannerBlocks_sptr = std::make_shared<Scanner>(Scanner::SAFIRDualRingPrototype);
+  scannerBlocks_sptr->set_average_depth_of_interaction(5);
+  scannerBlocks_sptr->set_num_axial_crystals_per_block(1);
+  scannerBlocks_sptr->set_axial_block_spacing(scannerBlocks_sptr->get_axial_crystal_spacing()
+                                              * scannerBlocks_sptr->get_num_axial_crystals_per_block());
+  scannerBlocks_sptr->set_transaxial_block_spacing(scannerBlocks_sptr->get_transaxial_crystal_spacing()
+                                                   * scannerBlocks_sptr->get_num_transaxial_crystals_per_block());
+  //  scannerBlocks_sptr->set_num_transaxial_crystals_per_block(1);
+  scannerBlocks_sptr->set_num_axial_blocks_per_bucket(2);
+  //  scannerBlocks_sptr->set_num_transaxial_blocks_per_bucket(1);
+  scannerBlocks_sptr->set_num_rings(2);
+  // scannerBlocks_sptr->set_intrinsic_azimuthal_tilt(-30);
+  scannerBlocks_sptr->set_scanner_geometry("BlocksOnCylindrical");
+  scannerBlocks_sptr->set_up();
+
+  auto proj_data_info_blocks_sptr = std::make_shared<ProjDataInfoBlocksOnCylindricalNoArcCorr>();
+  proj_data_info_blocks_sptr = set_blocks_projdata_info<ProjDataInfoBlocksOnCylindricalNoArcCorr>(scannerBlocks_sptr);
+
+  //    now forward-project images
+  info(boost::format("Test blocks on Cylindrical: Forward projector used: %1%") % forw_projector1_sptr->parameter_info());
+
+  forw_projector1_sptr->set_up(proj_data_info_blocks_sptr, image1_sptr);
+
+  forw_projector2_sptr->set_up(proj_data_info_blocks_sptr, image2_sptr);
+
+  auto projdata1 = std::make_shared<ProjDataInterfile>(exam_info_sptr, proj_data_info_blocks_sptr, "sino_with_phantom_at_30_0.hs",
+                                                       std::ios::out | std::ios::trunc | std::ios::in);
+
+  auto projdata2
+      = std::make_shared<ProjDataInterfile>(exam_info_sptr, proj_data_info_blocks_sptr, "sino_with_phantom_in_middle.hs",
+                                            std::ios::out | std::ios::trunc | std::ios::in);
+
+  forw_projector1_sptr->forward_project(*projdata1, *image1_sptr);
+  forw_projector2_sptr->forward_project(*projdata2, *image2_sptr);
 }
 
 void
@@ -756,12 +823,35 @@ BlocksTests::run_tests()
 {
 
   std::cerr << "-------- Testing Blocks Geometry --------\n";
+  auto PM = std::make_shared<ProjMatrixByBinUsingRayTracing>();
+  PM->enable_cache(false);
+  PM->set_use_actual_detector_boundaries(true);
+  PM->set_num_tangential_LORs(5);
+  auto forw_projector1_sptr = std::make_shared<ForwardProjectorByBinUsingProjMatrixByBin>(PM);
+  auto forw_projector2_sptr = std::make_shared<ForwardProjectorByBinUsingProjMatrixByBin>(PM);
+  auto back_projector_sptr = std::make_shared<BackProjectorByBinUsingProjMatrixByBin>(PM);
+
+  run_symmetry_test(forw_projector1_sptr, forw_projector2_sptr);
+  run_plane_symmetry_test(forw_projector1_sptr, forw_projector2_sptr);
   run_voxelOnCartesianGrid_with_negative_offset();
-  run_axial_projection_test();
-  run_map_orientation_test();
-  run_symmetry_test();
-  run_plane_symmetry_test();
+  run_map_orientation_test(forw_projector1_sptr, forw_projector2_sptr);
+  run_axial_projection_test(forw_projector1_sptr, back_projector_sptr);
+  run_projection_test(forw_projector1_sptr, forw_projector2_sptr);
   run_intersection_with_cylinder_test();
+
+#ifdef STIR_WITH_Parallelproj_PROJECTOR
+  // run the same tests with parallelproj, if available
+  auto forw_projector1_parallelproj_sptr = std::make_shared<ForwardProjectorByBinParallelproj>();
+  auto forw_projector2_parallelproj_sptr = std::make_shared<ForwardProjectorByBinParallelproj>();
+  auto back_projector_parallelproj_sptr = std::make_shared<BackProjectorByBinParallelproj>();
+
+  run_symmetry_test(forw_projector1_parallelproj_sptr, forw_projector2_parallelproj_sptr);
+  run_plane_symmetry_test(forw_projector1_parallelproj_sptr, forw_projector2_parallelproj_sptr);
+  run_map_orientation_test(forw_projector1_parallelproj_sptr, forw_projector2_parallelproj_sptr);
+  run_axial_projection_test(forw_projector1_parallelproj_sptr, back_projector_parallelproj_sptr);
+  run_projection_test(forw_projector1_parallelproj_sptr, forw_projector2_parallelproj_sptr);
+#endif
+
 }
 END_NAMESPACE_STIR
 

--- a/src/recon_test/test_blocks_on_cylindrical_projectors.cxx
+++ b/src/recon_test/test_blocks_on_cylindrical_projectors.cxx
@@ -77,7 +77,8 @@ public:
 
 private:
   template <class TProjDataInfo>
-  shared_ptr<TProjDataInfo> set_blocks_projdata_info(shared_ptr<Scanner> scanner_sptr);
+  shared_ptr<TProjDataInfo> set_blocks_projdata_info(shared_ptr<Scanner> scanner_sptr, int view_fraction = 1,
+                                                     int bin_fraction = 1);
   template <class TProjDataInfo>
   shared_ptr<TProjDataInfo> set_direct_projdata_info(shared_ptr<Scanner> scanner_sptr, int view_fraction = 4,
                                                      int bin_fraction = 4);
@@ -94,7 +95,7 @@ private:
 /*! The following is a function to allow a projdata_info BlocksOnCylindrical to be created from the scanner. */
 template <class TProjDataInfo>
 shared_ptr<TProjDataInfo>
-BlocksTests::set_blocks_projdata_info(shared_ptr<Scanner> scanner_sptr)
+BlocksTests::set_blocks_projdata_info(shared_ptr<Scanner> scanner_sptr, int view_fraction, int bin_fraction)
 {
   auto segments = scanner_sptr->get_num_rings() - 1;
   VectorWithOffset<int> num_axial_pos_per_segment(-segments, segments);
@@ -107,9 +108,9 @@ BlocksTests::set_blocks_projdata_info(shared_ptr<Scanner> scanner_sptr)
       num_axial_pos_per_segment[i] = scanner_sptr->get_num_rings() - abs(i);
     }
 
-  auto proj_data_info_blocks_sptr
-      = std::make_shared<TProjDataInfo>(scanner_sptr, num_axial_pos_per_segment, min_ring_diff_v, max_ring_diff_v,
-                                        scanner_sptr->get_max_num_views(), scanner_sptr->get_max_num_non_arccorrected_bins());
+  auto proj_data_info_blocks_sptr = std::make_shared<TProjDataInfo>(
+      scanner_sptr, num_axial_pos_per_segment, min_ring_diff_v, max_ring_diff_v,
+      scanner_sptr->get_max_num_views() / view_fraction, scanner_sptr->get_max_num_non_arccorrected_bins() / bin_fraction);
 
   return proj_data_info_blocks_sptr;
 }
@@ -493,7 +494,7 @@ BlocksTests::run_axial_projection_test(ForwardProjectorByBin& forw_projector, Ba
 
   auto proj_data_info_blocks_sptr = std::make_shared<ProjDataInfoBlocksOnCylindricalNoArcCorr>();
   proj_data_info_blocks_sptr
-      = set_blocks_projdata_info<ProjDataInfoBlocksOnCylindricalNoArcCorr>(scannerBlocks_sptr); //    now forward-project image
+      = set_blocks_projdata_info<ProjDataInfoBlocksOnCylindricalNoArcCorr>(scannerBlocks_sptr, 4); //    now forward-project image
 
   shared_ptr<DiscretisedDensity<3, float>> image_sptr(image.clone());
   shared_ptr<DiscretisedDensity<3, float>> bck_proj_image_sptr(image.clone());

--- a/src/swig/stir_projectors.i
+++ b/src/swig/stir_projectors.i
@@ -95,7 +95,7 @@
     stir::ProjectorByBinPairUsingSeparateProjectors, stir::ProjectorByBinPair, stir::ProjectorByBinPair>;
 %include "stir/recon_buildblock/ProjectorByBinPairUsingSeparateProjectors.h"
 
-#ifdef STIR_WITH_Parallelproj_PROJECTOR
+#ifdef HAVE_parallelproj // STIR_WITH_Parallelproj_PROJECTOR
 %shared_ptr(stir::RegisteredParsingObject<stir::ForwardProjectorByBinParallelproj,
     stir::ForwardProjectorByBin>);
 %shared_ptr(stir::ForwardProjectorByBinParallelproj);
@@ -117,7 +117,7 @@
     stir::ProjectorByBinPair, stir::ProjectorByBinPair>);
 %shared_ptr(stir::ProjectorByBinPairUsingParallelproj);
 %template(internalRPProjectorByBinPairUsingParallelproj)
-  stir::RegisteredParsingObject<stir::ProjectorByBinPairUsingeParallelproj,
+  stir::RegisteredParsingObject<stir::ProjectorByBinPairUsingParallelproj,
     stir::ProjectorByBinPair, stir::ProjectorByBinPair>;
 %include "stir/recon_buildblock/Parallelproj_projector/ProjectorByBinPairUsingParallelproj.h"
 #endif

--- a/src/swig/stir_projectors.i
+++ b/src/swig/stir_projectors.i
@@ -95,7 +95,7 @@
     stir::ProjectorByBinPairUsingSeparateProjectors, stir::ProjectorByBinPair, stir::ProjectorByBinPair>;
 %include "stir/recon_buildblock/ProjectorByBinPairUsingSeparateProjectors.h"
 
-#ifdef HAVE_parallelproj // STIR_WITH_Parallelproj_PROJECTOR
+#ifdef HAVE_parallelproj
 %shared_ptr(stir::RegisteredParsingObject<stir::ForwardProjectorByBinParallelproj,
     stir::ForwardProjectorByBin>);
 %shared_ptr(stir::ForwardProjectorByBinParallelproj);


### PR DESCRIPTION
This PR is about making the BlocksOnCylindrical projection tests faster to avoid AppVeyor timeouts. Current timings with latest commit are below.

-------- Testing Blocks Geometry --------
symmetry test took: 0.947663 seconds
plane symmetry test took: 1.74959 seconds
voxelOnCartesianGrid test took: 0.009056 seconds
axial projection test took: 7.87713 seconds
map orientation test took: 1.40988 seconds
intersection with cylinder test took: 0.122833 seconds

-------- Testing Parallelproj --------
symmetry test took: 1.02611 seconds
plane symmetry test took: 2.07785 seconds
map orientation test took: 0.629038 seconds
axial projection test took: 2.79315 seconds
projection cpu vs. gpu comparison test took: 8.15366 seconds