### PR TITLE
fixing geometrical factors 

### DIFF
--- a/src/buildblock/ML_norm.cxx
+++ b/src/buildblock/ML_norm.cxx
@@ -378,14 +378,14 @@ void iterate_efficiencies(Array<1,float>& efficiencies,
   for (int a = 0; a < num_detectors; ++a)
     {
       if (data_fan_sums[a] == 0)
-	efficiencies[a] = 0;
+    efficiencies[a] = 0;
       else
 	{
           //const float denominator = inner_product(efficiencies,model[a]);
 	  float denominator = 0;
-           for (int b = model.get_min_index(a); b <= model.get_max_index(a); ++b)      
+           for (int b = model.get_min_index(a); b <= model.get_max_index(a); ++b)
   	    denominator += efficiencies[b%num_detectors]*model(a,b);
-	  efficiencies[a] = data_fan_sums[a] / denominator;
+      efficiencies[a] = data_fan_sums[a] / denominator;
 	}
     }
 }
@@ -1340,8 +1340,8 @@ void apply_geo_norm(FanProjData& fan_data, const GeoData3D& geo_data, const bool
     const int num_axial_detectors = fan_data.get_num_rings();
     const int num_transaxial_detectors = fan_data.get_num_detectors_per_ring();
     const int num_axial_crystals_per_block = geo_data.get_num_axial_crystals_per_block();
-    const int num_transaxial_crystals_per_block = geo_data.get_half_num_transaxial_crystals_per_block()*2;
-    
+    const int num_transaxial_crystals_per_block = geo_data.get_half_num_transaxial_crystals_per_block();
+
     const int num_transaxial_blocks = num_transaxial_detectors/num_transaxial_crystals_per_block;
     const int num_axial_blocks = num_axial_detectors/num_axial_crystals_per_block;
     
@@ -1350,7 +1350,7 @@ void apply_geo_norm(FanProjData& fan_data, const GeoData3D& geo_data, const bool
     
     
     for (int ra = 0; ra < num_axial_crystals_per_block; ++ra)
-        for (int a = 0; a < num_transaxial_crystals_per_block /2; ++a)
+        for (int a = 0; a < num_transaxial_crystals_per_block ; ++a)
             // loop rb from ra to avoid double counting
             for (int rb = max(ra,fan_data.get_min_rb(ra)); rb <= fan_data.get_max_rb(ra); ++rb)
                 for (int b = fan_data.get_min_b(a); b <= fan_data.get_max_b(a); ++b)
@@ -1358,7 +1358,7 @@ void apply_geo_norm(FanProjData& fan_data, const GeoData3D& geo_data, const bool
                     
                     
                     // rotation
-                    
+
                     for (int axial_block_num = 0; axial_block_num<num_axial_blocks; ++axial_block_num)
                     {
                         
@@ -1373,33 +1373,33 @@ void apply_geo_norm(FanProjData& fan_data, const GeoData3D& geo_data, const bool
                             const int new_ring_num_a = ra+axial_det_inc;
                             const int new_ring_num_b = rb+axial_det_inc;
                             
-                            const int ma = num_transaxial_detectors-1-new_det_num_a;
-                            const int mb = (2*num_transaxial_detectors-1-new_det_num_b)%num_transaxial_detectors;
-                            const int mra = num_axial_detectors-1-new_ring_num_a;
-                            const int mrb = num_axial_detectors-1-new_ring_num_b;
+//                            const int ma = num_transaxial_detectors-1-new_det_num_a;//mirror a
+//                            const int mb = (2*num_transaxial_detectors-1-new_det_num_b)%num_transaxial_detectors;
+//                            const int mra = num_axial_detectors-1-new_ring_num_a;
+//                            const int mrb = num_axial_detectors-1-new_ring_num_b;
                             
                             if (work.is_in_data(new_ring_num_a,new_det_num_a,new_ring_num_b,new_det_num_b))
                                 work(new_ring_num_a, new_det_num_a,new_ring_num_b, new_det_num_b) =
                                 geo_data(ra,a,rb,b%num_transaxial_detectors);
+
+//                            if (work.is_in_data(new_ring_num_a,ma,new_ring_num_b,mb))
+//                                work(new_ring_num_a,ma,new_ring_num_b,mb) = geo_data(ra,a,rb,b%num_transaxial_detectors);
                             
-                            if (work.is_in_data(new_ring_num_a,ma,new_ring_num_b,mb))
-                                work(new_ring_num_a,ma,new_ring_num_b,mb) = geo_data(ra,a,rb,b%num_transaxial_detectors);
-                            
-                            if (work.is_in_data(mra,new_det_num_a,mrb,new_det_num_b))
+//                            if (work.is_in_data(mra,new_det_num_a,mrb,new_det_num_b))
                                 
-                                work(mra,new_det_num_a,mrb,new_det_num_b) = geo_data(ra,a,rb,b%num_transaxial_detectors);
+//                                work(mra,new_det_num_a,mrb,new_det_num_b) = geo_data(ra,a,rb,b%num_transaxial_detectors);
                             
-                            if (work.is_in_data(mra,ma,mrb,mb))
+//                            if (work.is_in_data(mra,ma,mrb,mb))
                                 
-                                work(mra,ma,mrb,mb) = geo_data(ra,a,rb,b%num_transaxial_detectors);
-                            
+//                                work(mra,ma,mrb,mb) = geo_data(ra,a,rb,b%num_transaxial_detectors);
+
                             
                             
                         }
                         
                     }
                 }
-    
+
     for (int ra = fan_data.get_min_ra(); ra <= fan_data.get_max_ra(); ++ra)
         for (int a = fan_data.get_min_a(); a <= fan_data.get_max_a(); ++a)
         //    for (int rb = fan_data.get_min_ra(); rb <= fan_data.get_max_ra(); ++rb)
@@ -1539,8 +1539,10 @@ void make_geo_data(GeoData3D& geo_data, const FanProjData& fan_data)
     const int num_axial_detectors = fan_data.get_num_rings();
     const int num_transaxial_detectors = fan_data.get_num_detectors_per_ring();
     const int num_axial_crystals_per_block = geo_data.get_num_axial_crystals_per_block();
-    const int num_transaxial_crystals_per_block = geo_data.get_half_num_transaxial_crystals_per_block()*2;
-    const int num_transaxial_blocks = num_transaxial_detectors/num_transaxial_crystals_per_block;
+
+    const int num_transaxial_crystals_per_block = geo_data.get_half_num_transaxial_crystals_per_block();
+
+        const int num_transaxial_blocks = num_transaxial_detectors/num_transaxial_crystals_per_block;
     const int num_axial_blocks = num_axial_detectors/num_axial_crystals_per_block;
     
     
@@ -1575,7 +1577,7 @@ void make_geo_data(GeoData3D& geo_data, const FanProjData& fan_data)
     
     for (int ra = 0; ra < num_axial_crystals_per_block; ++ra)
       //  for (int a = 0; a <= num_transaxial_detectors/2; ++a)
-        for (int a = 0; a <num_transaxial_crystals_per_block/2; ++a)
+        for (int a = 0; a <num_transaxial_crystals_per_block; ++a)
             // loop rb from ra to avoid double counting
            // for (int rb = fan_data.get_min_ra(); rb <= fan_data.get_max_ra(); ++rb)
 	     for (int rb = max(ra,fan_data.get_min_rb(ra)); rb <= fan_data.get_max_rb(ra); ++rb)
@@ -1641,6 +1643,7 @@ void iterate_efficiencies(DetectorEfficiencies& efficiencies,
   assert(model.get_max_ra() == data_fan_sums.get_max_index());
   assert(model.get_min_a() == data_fan_sums[data_fan_sums.get_min_index()].get_min_index());
   assert(model.get_max_a() == data_fan_sums[data_fan_sums.get_min_index()].get_max_index());
+
   for (int ra = model.get_min_ra(); ra <= model.get_max_ra(); ++ra)
     for (int a = model.get_min_a(); a <= model.get_max_a(); ++a)
     {
@@ -1651,7 +1654,9 @@ void iterate_efficiencies(DetectorEfficiencies& efficiencies,
      	  float denominator = 0;
            for (int rb = model.get_min_rb(ra); rb <= model.get_max_rb(ra); ++rb)
              for (int b = model.get_min_b(a); b <= model.get_max_b(a); ++b)
-  	       denominator += efficiencies[rb][b%num_detectors_per_ring]*model(ra,a,rb,b);
+           denominator += efficiencies[rb][b%num_detectors_per_ring]*model(ra,a,rb,b);
+
+
 	  efficiencies[ra][a] = data_fan_sums[ra][a] / denominator;
 	}
     }
@@ -1708,14 +1713,20 @@ void iterate_geo_norm(GeoData3D& norm_geo_data,
 {
     make_geo_data(norm_geo_data, model);
     //norm_geo_data = measured_geo_data / norm_geo_data;
-    
+
+    const int num_transaxial_detectors = model.get_num_detectors_per_ring();
     const int num_axial_crystals_per_block = measured_geo_data.get_num_axial_crystals_per_block();
-    const int num_transaxial_crystals_per_block = measured_geo_data.get_half_num_transaxial_crystals_per_block()*2;
-    
+
+    int num_trans_crystals_per_block = measured_geo_data.get_half_num_transaxial_crystals_per_block();
+    if (num_transaxial_detectors % num_trans_crystals_per_block != 0)
+        num_trans_crystals_per_block+=1;
+
+    const int num_transaxial_crystals_per_block = num_trans_crystals_per_block;
+
     const float threshold = measured_geo_data.find_max()/10000.F;
     
     for (int ra = 0; ra < num_axial_crystals_per_block; ++ra)
-        for (int a = 0; a <num_transaxial_crystals_per_block/2; ++a)
+        for (int a = 0; a <num_transaxial_crystals_per_block; ++a)
             // loop rb from ra to avoid double counting
          //   for (int rb = model.get_min_ra(); rb <= model.get_max_ra(); ++rb)
 	     for (int rb = max(ra,model.get_min_rb(ra)); rb <= model.get_max_rb(ra); ++rb)

--- a/src/recon_buildblock/ML_estimate_component_based_normalisation.cxx
+++ b/src/recon_buildblock/ML_estimate_component_based_normalisation.cxx
@@ -80,10 +80,11 @@ ML_estimate_component_based_normalisation(const std::string& out_filename_prefix
   FanProjData fan_data;
   DetectorEfficiencies data_fan_sums(IndexRange2D(num_physical_rings, num_physical_detectors_per_ring));
   DetectorEfficiencies efficiencies(IndexRange2D(num_physical_rings, num_physical_detectors_per_ring));
-
-  GeoData3D measured_geo_data(num_physical_axial_crystals_per_basic_unit, num_physical_transaxial_crystals_per_basic_unit / 2,
+// if(num_physical_axial_crystals_per_basic_unit%2 ==0)
+//     num_physical_transaxial_crystals_per_basic_unit+=1;
+  GeoData3D measured_geo_data(num_physical_axial_crystals_per_basic_unit, num_physical_transaxial_crystals_per_basic_unit ,
                               num_physical_rings, num_physical_detectors_per_ring); // inputes have to be modified
-  GeoData3D norm_geo_data(num_physical_axial_crystals_per_basic_unit, num_physical_transaxial_crystals_per_basic_unit / 2,
+  GeoData3D norm_geo_data(num_physical_axial_crystals_per_basic_unit, num_physical_transaxial_crystals_per_basic_unit ,
                           num_physical_rings, num_physical_detectors_per_ring); // inputes have to be modified
 
   BlockData3D measured_block_data(num_axial_blocks, num_transaxial_blocks, num_axial_blocks - 1, num_transaxial_blocks - 1);
@@ -152,14 +153,27 @@ ML_estimate_component_based_normalisation(const std::string& out_filename_prefix
             efficiencies.fill(sqrt(data_fan_sums.sum() / model_fan_data.sum()));
             norm_geo_data.fill(1);
             norm_block_data.fill(1);
+          }              {
+            char* out_filename = new char[out_filename_prefix.size() + 30];
+            sprintf(out_filename, "initEff.out");
+            std::ofstream out(out_filename);
+            out << efficiencies;
+            delete[] out_filename;
           }
         // efficiencies
         {
+//            std::cerr << "Before0 model*norm min " << model_fan_data.find_min() << " ,max " << model_fan_data.find_max() << std::endl;
+//            std::cerr << "Geo model*norm min " << norm_geo_data.find_min() << " ,max " << norm_geo_data.find_max() << std::endl;
+//            std::cerr << "Block model*norm min " << norm_block_data.find_min() << " ,max " << norm_block_data.find_max() << std::endl;
+
           fan_data = model_fan_data;
+//          std::cerr << "Before1 model*norm min " << fan_data.find_min() << " ,max " << fan_data.find_max() << std::endl;
           apply_geo_norm(fan_data, norm_geo_data);
+//          std::cerr << "Before2 model*norm min " << fan_data.find_min() << " ,max " << fan_data.find_max() << std::endl;
           apply_block_norm(fan_data, norm_block_data);
           if (do_display)
             display(fan_data, "model*geo*block");
+//          std::cerr << "Before3 model*norm min " << fan_data.find_min() << " ,max " << fan_data.find_max() << std::endl;
           for (int eff_iter_num = 1; eff_iter_num <= num_eff_iterations; ++eff_iter_num)
             {
               iterate_efficiencies(efficiencies, data_fan_sums, fan_data);

--- a/src/utilities/apply_normfactors3D.cxx
+++ b/src/utilities/apply_normfactors3D.cxx
@@ -79,6 +79,7 @@ main(int argc, char** argv)
             do_eff = false;
           }
         delete[] in_filename;
+//        std::cout<<norm.crystal_efficiencies();
       }
 
     // geo norm


### PR DESCRIPTION
estimation of geometrical factors uses mirroring and symmetries and only saves half of the data. This does not work when the number of detectors per block is odd. The branch fixes this:

- save the whole data
- apply symmetries anyway to reduce noise
-