### PR TITLE
Add VSCode build directory to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,9 @@ install_manifest.txt
 *.manifest
 *.exp
 
+# Ignore Visual Studio Code User-specific files
+build/
+
 # MATLAB
 
 *.pdf


### PR DESCRIPTION
A generally useful change for Code users. VSCode builds into the source directory by default.