### PR TITLE
fix num bins in uncompressed proj-data-info construction

### DIFF
--- a/src/include/stir/listmode/CListEventCylindricalScannerWithDiscreteDetectors.inl
+++ b/src/include/stir/listmode/CListEventCylindricalScannerWithDiscreteDetectors.inl
@@ -31,7 +31,7 @@ CListEventCylindricalScannerWithDiscreteDetectors(const shared_ptr<Scanner>& sca
      ProjDataInfo::ProjDataInfoCTI(scanner_sptr, 
                                    1, scanner_sptr->get_num_rings()-1,
                                    scanner_sptr->get_num_detectors_per_ring()/2,
-                                   scanner_sptr->get_default_num_arccorrected_bins(), 
+                                   scanner_sptr->get_max_num_non_arccorrected_bins(), 
                                    false)));
 }
 

--- a/src/listmode_buildblock/LmToProjData.cxx
+++ b/src/listmode_buildblock/LmToProjData.cxx
@@ -399,7 +399,7 @@ Succeeded LmToProjData::set_up()
 							       ProjDataInfo::ProjDataInfoCTI(scanner_sptr, 
 											     1, scanner_sptr->get_num_rings()-1,
 											     scanner_sptr->get_num_detectors_per_ring()/2,
-											     scanner_sptr->get_default_num_arccorrected_bins(), 
+											     scanner_sptr->get_max_num_non_arccorrected_bins(), 
 											     false)));
       
       if ( normalisation_ptr->set_up(lm_data_ptr->get_exam_info_sptr(), proj_data_info_cyl_uncompressed_ptr)

--- a/src/utilities/list_detector_and_bin_info.cxx
+++ b/src/utilities/list_detector_and_bin_info.cxx
@@ -63,7 +63,7 @@ int main(int argc, char *argv[])
      ProjDataInfo::ProjDataInfoCTI(scanner_sptr, 
                                    1, scanner_sptr->get_num_rings()-1,
                                    scanner_sptr->get_num_detectors_per_ring()/2,
-                                   scanner_sptr->get_default_num_arccorrected_bins(), 
+                                   scanner_sptr->get_max_num_non_arccorrected_bins(), 
                                    false)
       ));
 


### PR DESCRIPTION
This fixes some lines that used `default_num_arc_corrected_bins` as opposed to `max_num_non_arccorrected_bins`. However, these have zero impact on performance.

Fixes #1134, see there for more detail.