### PR TITLE
Fix for scatter simulation with respect to how max_num_non_arccorrected bins are used

### DIFF
--- a/documentation/release_5.2.htm
+++ b/documentation/release_5.2.htm
@@ -63,6 +63,9 @@
 
 <h3>Minor (?) bug fixes</h3>
 <ul>
+  <li>Small change in scatter simulation to how non-arccorrected bins are computed. Added a check in the construction of non-arccorrected projdata that the number of tangential bins is not larger than the maximum non-arccorrected bins.
+    <br /><a href="https://github.com/UCL/STIR/pull/1152/">PR #1152</a>.
+  </li>
 </ul>
 
 <h3>Documentation changes</h3>

--- a/src/buildblock/ProjDataInfoCylindricalNoArcCorr.cxx
+++ b/src/buildblock/ProjDataInfoCylindricalNoArcCorr.cxx
@@ -64,6 +64,9 @@ ProjDataInfoCylindricalNoArcCorr(const shared_ptr<Scanner> scanner_ptr,
   ring_radius(ring_radius_v),
   angular_increment(angular_increment_v)
 {
+  if (num_tangential_poss > scanner_ptr->get_max_num_non_arccorrected_bins())
+    error("Configured tangential positions exceed the maximum number of non arc-corrected bins set for the scanner.");
+    
   uncompressed_view_tangpos_to_det1det2_initialised = false;
   det1det2_to_uncompressed_view_tangpos_initialised = false;
   //this->initialise_uncompressed_view_tangpos_to_det1det2();

--- a/src/buildblock/ProjDataInfoGenericNoArcCorr.cxx
+++ b/src/buildblock/ProjDataInfoGenericNoArcCorr.cxx
@@ -61,6 +61,9 @@ ProjDataInfoGenericNoArcCorr(const shared_ptr<Scanner> scanner_ptr,
                           min_ring_diff_v, max_ring_diff_v,
                           num_views, num_tangential_poss)
 {
+  if (num_tangential_poss > scanner_ptr->get_max_num_non_arccorrected_bins())
+    error("Configured tangential positions exceed the maximum number of non arc-corrected bins set for the scanner.");
+
   assert(!is_null_ptr(scanner_ptr));
   uncompressed_view_tangpos_to_det1det2_initialised = false;
   det1det2_to_uncompressed_view_tangpos_initialised = false;

--- a/src/scatter_buildblock/ScatterSimulation.cxx
+++ b/src/scatter_buildblock/ScatterSimulation.cxx
@@ -903,7 +903,7 @@ ScatterSimulation::downsample_scanner(int new_num_rings, int new_num_dets)
     }
     
     const float approx_num_non_arccorrected_bins =
-      old_scanner_ptr->get_max_num_non_arccorrected_bins() * 
+      this->proj_data_info_sptr->get_num_tangential_poss() * 
       (float(new_num_dets) / old_scanner_ptr->get_num_detectors_per_ring())
       + 5; // add 5 to avoid strange edge-effects, certainly with B-splines
     new_scanner_sptr->set_max_num_non_arccorrected_bins(round(approx_num_non_arccorrected_bins+.5F));
@@ -919,7 +919,7 @@ ScatterSimulation::downsample_scanner(int new_num_rings, int new_num_dets)
                                                       ProjDataInfo::ProjDataInfoCTI(new_scanner_sptr,
                                                                                     1, delta_ring,
                                                                                     new_scanner_sptr->get_num_detectors_per_ring()/2,
-                                                                                    this->proj_data_info_sptr->get_num_tangential_poss(),
+                                                                                    new_scanner_sptr->get_max_num_non_arccorrected_bins(),
                                                                                     false));
 
     info(boost::format("ScatterSimulation: down-sampled scanner info:\n%1%")

--- a/src/scatter_buildblock/ScatterSimulation.cxx
+++ b/src/scatter_buildblock/ScatterSimulation.cxx
@@ -919,7 +919,7 @@ ScatterSimulation::downsample_scanner(int new_num_rings, int new_num_dets)
                                                       ProjDataInfo::ProjDataInfoCTI(new_scanner_sptr,
                                                                                     1, delta_ring,
                                                                                     new_scanner_sptr->get_num_detectors_per_ring()/2,
-                                                                                    new_scanner_sptr->get_max_num_non_arccorrected_bins(),
+                                                                                    this->proj_data_info_sptr->get_num_tangential_poss(),
                                                                                     false));
 
     info(boost::format("ScatterSimulation: down-sampled scanner info:\n%1%")


### PR DESCRIPTION
Fix for scatter simulation. The issue was that the arccorrected bin number was used to initialise the proj_data_info. Instead, the actual proj_data_info tangential bin number should be used.