### PR TITLE
Fix #1154 path to lowercase bug and update path error message

### DIFF
--- a/src/recon_buildblock/PinholeSPECTUB_Tools.cxx
+++ b/src/recon_buildblock/PinholeSPECTUB_Tools.cxx
@@ -1249,7 +1249,7 @@ void error_wmtools_SPECT_mph( int nerr, int ip, string txt )
 			
 		//... error: value of argv[]..........................
 		
-		case 122: printf("\n\nError wm_SPECT: File with variable collimator parameters: %s not found.\n",txt.c_str() ); break;
+		case 122: printf("\n\nError wm_SPECT: File with variable parameters: %s not found.\n",txt.c_str() ); break;
 		case 124: printf("\n\nError wm_SPECT: Cannot open attenuation map: %s for reading..\n", txt.c_str() ); break;
 		case 126: printf("\n\nError wm_SPECT: Cannot open file mask: %s for reading\n",txt.c_str() ); break;
         case 150: printf("\n\nError wm_SPECT: List of hole parameters has different length (%d) than number of holes.\n", ip); break;

--- a/src/recon_buildblock/ProjMatrixByBinPinholeSPECTUB.cxx
+++ b/src/recon_buildblock/ProjMatrixByBinPinholeSPECTUB.cxx
@@ -276,9 +276,9 @@ void
 ProjMatrixByBinPinholeSPECTUB::
 set_detector_file( const string& value )
 {
-    if (this->detector_file != boost::algorithm::to_lower_copy(value))
+    if (this->detector_file != value)
     {
-        this->detector_file = boost::algorithm::to_lower_copy(value);
+        this->detector_file = value;
         this->already_setup = false;
     }
 }
@@ -297,9 +297,9 @@ void
 ProjMatrixByBinPinholeSPECTUB::
 set_collimator_file( const string& value )
 {
-    if (this->collimator_file != boost::algorithm::to_lower_copy(value))
+    if (this->collimator_file != value)
     {
-        this->collimator_file = boost::algorithm::to_lower_copy(value);
+        this->collimator_file = value;
         this->already_setup = false;
     }
 }


### PR DESCRIPTION
Removed `boost::algorithm::to_lower_copy` when setting filename variables.

Updated path error message since functions to read detector and collimator files both use the same error case.