### PR TITLE
Remove distributable is_trivial() call

### DIFF
--- a/src/recon_buildblock/distributable.cxx
+++ b/src/recon_buildblock/distributable.cxx
@@ -212,7 +212,7 @@ void get_viewgrams(shared_ptr<RelatedViewgrams<float> >& y,
     }
 
   // multiplicative correction
-  if (!is_null_ptr(normalisation_sptr) && !normalisation_sptr->is_trivial())
+  if (!is_null_ptr(normalisation_sptr))
     {
       mult_viewgrams_sptr.reset(
 				new RelatedViewgrams<float>(proj_dat_ptr->get_empty_related_viewgrams(view_segment_num, symmetries_ptr)));


### PR DESCRIPTION
Fix for #1153 

Using the same script as discussed [here](https://github.com/UCL/STIR/issues/1153#issuecomment-1421500784) leads to the same timing results for a given projector whether 
```
config.mult_factors.fill(1)
obj_func.set_normalisation_sptr(stir.BinNormalisationFromProjData(config.mult_factors))
```
is called or not.