### PR TITLE
BinNormalisation*::is_trivial fixes

### DIFF
--- a/src/include/stir/recon_buildblock/BinNormalisationFromProjData.h
+++ b/src/include/stir/recon_buildblock/BinNormalisationFromProjData.h
@@ -10,6 +10,7 @@
 */
 /*
     Copyright (C) 2000- 2011, Hammersmith Imanet Ltd
+    Copyright (C) 2023, University College London
     This file is part of STIR.
 
     SPDX-License-Identifier: Apache-2.0
@@ -67,9 +68,11 @@ public:
   /*! The projdata object pointed to will \c not be modified. */
   BinNormalisationFromProjData(const shared_ptr<ProjData>& norm_proj_data_ptr);
 
-  //! check if we would be multiplying with 1 (i.e. do nothing)
-  /*! Checks if all data is equal to 1 (up to a tolerance of 1e-4). To do this, it uses ProjData::get_viewgram()
-      and loops over all viewgrams.
+  //! check if we could be multiplying with 1 (i.e. do nothing)
+  /*! 
+    always return \c false, as the case where the whole ProjData is set to 1
+    will never occur in "real life", so we save ourselves some time/complications
+    by returning \c false
   */
   virtual bool is_trivial() const override;
 

--- a/src/include/stir/recon_buildblock/BinNormalisationPETFromComponents.h
+++ b/src/include/stir/recon_buildblock/BinNormalisationPETFromComponents.h
@@ -148,6 +148,7 @@ private:
   static const char* const registered_name;
   shared_ptr<ProjDataInMemory> invnorm_proj_data_sptr;
   bool _already_allocated;
+  bool _is_trivial;
   void create_proj_data();
 };
 

--- a/src/recon_buildblock/BinNormalisationFromProjData.cxx
+++ b/src/recon_buildblock/BinNormalisationFromProjData.cxx
@@ -2,6 +2,7 @@
 //
 /*
     Copyright (C) 2000- 2013, Hammersmith Imanet Ltd
+    Copyright (C) 2023, University College London
     This file is part of STIR.
 
     SPDX-License-Identifier: Apache-2.0
@@ -117,23 +118,7 @@ bool
 BinNormalisationFromProjData::
 is_trivial() const
 {
-  // check if all data is 1 (up to a tolerance of 1e-4)
-  for (int segment_num = this->norm_proj_data_ptr->get_min_segment_num(); 
-       segment_num <= this->norm_proj_data_ptr->get_max_segment_num(); 
-       ++segment_num)
-    {
-      for (int view_num = this->norm_proj_data_ptr->get_min_view_num(); 
-           view_num <= this->norm_proj_data_ptr->get_max_view_num(); 
-           ++view_num)
-        {
-          const Viewgram<float> viewgram =
-            this->norm_proj_data_ptr->get_viewgram(view_num, segment_num);
-          if (fabs(viewgram.find_min()-1)>.0001 || fabs(viewgram.find_max()-1)>.0001)
-            return false; // return from function as we know not all data is 1
-        }
-    }
-  // if we get here. they were all 1
-  return true;
+  return false;
 }
 
 void 

--- a/src/recon_buildblock/BinNormalisationPETFromComponents.cxx
+++ b/src/recon_buildblock/BinNormalisationPETFromComponents.cxx
@@ -94,6 +94,12 @@ BinNormalisationPETFromComponents::set_up(const shared_ptr<const ExamInfo>& exam
       }
   }
 
+  this->_is_trivial =
+    (!has_crystal_efficiencies()
+     || (fabs(efficiencies.find_min() - 1) <= .0001 && fabs(efficiencies.find_max() - 1) <= .0001))
+    && (!has_geometric_factors() || (fabs(geo_data.find_min() - 1) <= .0001 && fabs(geo_data.find_max() - 1) <= .0001))
+    && (!has_block_factors() || (fabs(block_data.find_min() - 1) <= .0001 && fabs(block_data.find_max() - 1) <= .0001));
+
   this->create_proj_data();
   return Succeeded::yes;
 }
@@ -101,10 +107,9 @@ BinNormalisationPETFromComponents::set_up(const shared_ptr<const ExamInfo>& exam
 bool
 BinNormalisationPETFromComponents::is_trivial() const
 {
-  return (!has_crystal_efficiencies()
-          || (fabs(efficiencies.find_min() - 1) <= .0001 && fabs(efficiencies.find_max() - 1) <= .0001))
-         && (!has_geometric_factors() || (fabs(geo_data.find_min() - 1) <= .0001 && fabs(geo_data.find_max() - 1) <= .0001))
-         && (!has_block_factors() || (fabs(block_data.find_min() - 1) <= .0001 && fabs(block_data.find_max() - 1) <= .0001));
+  if (!this->_already_set_up)
+    error("BinNormalisationPETFromComponents: is_trivial called without set_up");
+  return this->_is_trivial;
 }
 
 void


### PR DESCRIPTION
make `is_trivial()` fast, as it's called multiple times in `distributable_computation` (for every `RelatedViewgrams`).

Fixes #1153 
