### PR TITLE
Projdata visualisation PyQt5 fix for older python and PyQt5 versions

### DIFF
--- a/examples/python/projdata_visualisation/BackendTools/STIRInterface.py
+++ b/examples/python/projdata_visualisation/BackendTools/STIRInterface.py
@@ -102,7 +102,7 @@ class ProjDataVisualisationBackend:
         """Converts a STIR data object to a numpy array."""
         return stirextra.to_numpy(data)
 
-    def get_limits(self, dimension: ProjDataDims, segment_number: int) -> tuple[int, int]:
+    def get_limits(self, dimension: ProjDataDims, segment_number: int) -> tuple:
         """
         Returns the limits of the projection data in the indicated dimension.
         :param dimension: The dimension to get the limits for, type SinogramDimensions.

--- a/examples/python/projdata_visualisation/BackendTools/UIGroupboxProjdataDimensions.py
+++ b/examples/python/projdata_visualisation/BackendTools/UIGroupboxProjdataDimensions.py
@@ -58,7 +58,7 @@ class UIGroupboxProjDataDimensions:
         layout.setRowStretch(5, 1)
         self.groupbox.setLayout(layout)
 
-    def set_UI_connect_methods(self, methods: [list[callable], callable]) -> None:
+    def set_UI_connect_methods(self, methods: list or callable) -> None:
         """
         Sets the external connect methods for the UI.
         Pass methods in a list of callable objects. These methods will be called when the UI is changed in order.
@@ -169,7 +169,7 @@ class UIGroupboxProjDataDimensions:
         """Disables the slider and spinbox for the given dimension."""
         self.UI_slider_spinboxes[dimension].disable()
 
-    def get_limits(self, dimension: ProjDataDims) -> tuple[int, int]:
+    def get_limits(self, dimension: ProjDataDims) -> tuple:
         """Returns the limits of the slider and spinbox for the given dimension."""
         return self.UI_slider_spinboxes[dimension].get_limits()
 
@@ -250,7 +250,7 @@ class UISliderSpinboxItem:
         self.__spinbox.setValue(value)
         self.__slider.setValue(value)
 
-    def get_limits(self) -> (int, int):
+    def get_limits(self) -> tuple:
         """Returns the range (min, max) of the spinbox and slider."""
         return self.__spinbox.minimum(), self.__spinbox.maximum()
 
@@ -258,7 +258,7 @@ class UISliderSpinboxItem:
         """Returns the value of the spinbox. Expected to be equal to slider value."""
         return self.__spinbox.value()
 
-    def create_label_str(self, limits: tuple[int, int]) -> str:
+    def create_label_str(self, limits: tuple) -> str:
         """Returns the label string."""
         return f"{self.__label_str} {limits}"
 

--- a/examples/python/projdata_visualisation/BackendTools/UIGroupboxProjdataDimensions.py
+++ b/examples/python/projdata_visualisation/BackendTools/UIGroupboxProjdataDimensions.py
@@ -212,7 +212,10 @@ class UISliderSpinboxItem:
         self.__spinbox.valueChanged.connect(self.__spinbox_connect)
 
         # Slider
-        self.__slider = QSlider(Qt.Orientation.Horizontal, groupbox)
+        try: # Qt.Orientation.Horizontal required more recent versions of PyQt
+            self.__slider = QSlider(Qt.Orientation.Horizontal, groupbox)
+        except AttributeError: # Qt.Horizontal required for PyQt version <= v5.10.1
+            self.__slider = QSlider(Qt.Horizontal, groupbox)
         self.__slider.setRange(lower_limit, upper_limit)
         self.__slider.setValue(self.__spinbox.value())
         self.__slider.setTickPosition(QSlider.TicksBelow)

--- a/examples/python/projdata_visualisation/ProjDataVisualisation.py
+++ b/examples/python/projdata_visualisation/ProjDataVisualisation.py
@@ -45,7 +45,10 @@ class ProjDataVisualisationWidgetGallery(QDialog):
         styleLabel.setBuddy(styleComboBox)
         self.useStylePaletteCheckBox = QCheckBox("&Use style's standard palette")
         self.useStylePaletteCheckBox.setChecked(True)
-        styleComboBox.textActivated.connect(self.change_UI_style)
+        try: # Required for PyQt version >= v5.14
+            styleComboBox.textActivated.connect(self.change_UI_style)
+        except AttributeError: 
+            styleComboBox.activated.connect(self.change_UI_style)
         self.useStylePaletteCheckBox.toggled.connect(self.change_UI_palette)
 
 


### PR DESCRIPTION
Fixes #1170

Removes the complex typehints (e.g. `tuple[int, int]`) and adds a `try`-`except`. This resolves the issue on my machine.