### PR TITLE
Scatter simulation: extra set/get methods

### DIFF
--- a/src/include/stir/scatter/ScatterSimulation.h
+++ b/src/include/stir/scatter/ScatterSimulation.h
@@ -180,6 +180,25 @@ public:
     void downsample_density_image_for_scatter_points(float _zoom_xy, float _zoom_z,
                           int _size_xy = -1, int _size_z = -1);
 
+
+    //! Get and set methods for the downsample_scanner_bool
+    //@{
+    void set_downsample_scanner_bool(const bool arg);
+    bool get_downsample_scanner_bool() const;
+    //@}
+
+    //! Get and set methods for downsample_scanner_rings
+    //@{
+    int get_num_downsample_scanner_rings() const;
+    void set_num_downsample_scanner_rings(const int arg);
+    //@}
+
+    //! Get and set methods for downsample_scanner_dets
+    //@{
+    int get_num_downsample_scanner_dets() const;
+    void set_num_downsample_scanner_dets(const int arg);
+    //@}
+
     //! Downsample the scanner keeping the total axial length the same.
     /*! If \c new_num_rings<=0, use rings of approximately 2 cm thickness.
         If \c new_num_dets <=0, use the default set (currently set in set_defaults())

--- a/src/scatter_buildblock/ScatterSimulation.cxx
+++ b/src/scatter_buildblock/ScatterSimulation.cxx
@@ -828,6 +828,61 @@ set_exam_info_sptr(const shared_ptr<const ExamInfo> arg)
     this->template_exam_info_sptr = arg->create_shared_clone();
 }
 
+
+bool 
+ScatterSimulation::
+get_downsample_scanner_bool() const
+{
+    return this->downsample_scanner_bool;
+}
+
+void 
+ScatterSimulation::
+set_downsample_scanner_bool(const bool arg)
+{
+    if (arg != this->get_downsample_scanner_bool())
+    {
+        this->_already_set_up = false;
+        this->downsample_scanner_bool = arg;
+    }
+}
+
+int 
+ScatterSimulation::
+get_num_downsample_scanner_rings() const
+{
+    return this->downsample_scanner_rings;
+}
+
+void 
+ScatterSimulation::
+set_num_downsample_scanner_rings(const int arg)
+{
+    if (arg != this->get_num_downsample_scanner_rings())
+    {
+        this->_already_set_up = false;
+        this->downsample_scanner_rings = arg;
+    }
+}
+
+int 
+ScatterSimulation::
+get_num_downsample_scanner_dets() const
+{
+    return this->downsample_scanner_dets;
+}
+
+void 
+ScatterSimulation::
+set_num_downsample_scanner_dets(const int arg)
+{
+    if (arg != this->get_num_downsample_scanner_dets())
+    {
+        this->_already_set_up = false;
+        this->downsample_scanner_dets = arg;
+    }
+}
+
 Succeeded
 ScatterSimulation::downsample_scanner(int new_num_rings, int new_num_dets)
 {


### PR DESCRIPTION
As mentioned in #1173, does not currently fix that issue.

PR adds get/set method for protected/private members:
- `downsample_scanner_bool`, 
- `num_downsample_scanne…r_rings` and 
- `num_downsample_scanner_dets`

The set methods will set the `_already_set_up` to false (if change), requiring a new `set_up()` call.