### PR TITLE
Projdata visualization UI: Fix a bug when loading new data did not refresh the segment data in memory

### DIFF
--- a/examples/python/projdata_visualisation/BackendTools/STIRInterface.py
+++ b/examples/python/projdata_visualisation/BackendTools/STIRInterface.py
@@ -90,11 +90,7 @@ class ProjDataVisualisationBackend:
             self.load_projdata()
 
         if self.projdata is not None:
-            if self.segment_data is None:
-                self.segment_data = self.projdata.get_segment_by_view(segment_number)
-
-            elif segment_number != self.get_current_segment_num():
-                self.segment_data = self.projdata.get_segment_by_view(segment_number)
+            self.segment_data = self.projdata.get_segment_by_view(segment_number)
             return self.segment_data
 
     @staticmethod


### PR DESCRIPTION
Fixes bug when clicking "Browse" or "Load" buttons, the image did not update in the display until the segment slider was adjusted.

Issue:
-----
The `segment_data` in memory was only updated when the segment number slider changed. This meant that, the only way to actually `refresh_segment_data` was to adjust the segment number slider.

If a new projdata was loaded (replacing a previously loaded), because the segment number did not change, the `segment_data` was not updated and the image displayed represented the previously loaded segment data. You could even adjust the axial position and view number sliders and display the wrong projdata.

Fix:
----
Remove the additional check on segment numbers from `refresh_segment_data`.