### PR TITLE
Modified the inline error() function to also throw a runtime_error

### DIFF
--- a/documentation/release_5.2.htm
+++ b/documentation/release_5.2.htm
@@ -86,6 +86,9 @@
   <li>We now use CMake's <a href=https://gitlab.kitware.com/cmake/community/-/wikis/doc/tutorials/Object-Library>OBJECT library feature</a> for the registries. This avoids re-compilation of the registries for every executable and therefore speeds-up building time. Use of STIR in an external project is not affected as long as the recommended practice was followed. This is now documented in the User's Guide.
     <br /><a href="https://github.com/UCL/STIR/pull/1141/">PR #1141</a>.
   </li>
+  <li>The <code>error</code> and <code>warning</code> functions are now no longer included from <code>common.h</code> and need to be included manually when used (as was already the case for <code>#include "stir/info.h"</code>).
+    <br /><a href="https://github.com/UCL/STIR/pull/1192/">PR #1192</a>.
+  </li>
 </ul>
 
 

--- a/examples/C++/src/demo4_obj_fun.cxx
+++ b/examples/C++/src/demo4_obj_fun.cxx
@@ -35,6 +35,7 @@
 #include "stir/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMeanAndProjData.h"
 #include "stir/IO/read_from_file.h"
 #include "stir/is_null_ptr.h"
+#include "stir/error.h"
 
 namespace stir {
 

--- a/examples/C++/src/demo5_line_search.cxx
+++ b/examples/C++/src/demo5_line_search.cxx
@@ -37,7 +37,7 @@
 #include "stir/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMeanAndProjData.h"
 #include "stir/IO/read_from_file.h"
 #include "stir/is_null_ptr.h"
-
+#include "stir/error.h"
 
 std::vector<double>
 compute_linear_alphas(const float alpha_min, const float alpha_max, const float num_evaluations)

--- a/src/IO/ECAT7DynamicDiscretisedDensityInputFileFormat.cxx
+++ b/src/IO/ECAT7DynamicDiscretisedDensityInputFileFormat.cxx
@@ -23,6 +23,7 @@
 #include "stir/DynamicDiscretisedDensity.h"
 #include "stir/VoxelsOnCartesianGrid.h" // necessary as stir_ecat7 reading routine returns a VoxelsOnCartesianGrid
 #include "stir/is_null_ptr.h"
+#include "stir/error.h"
 #include <fstream>
 #include <string>
 

--- a/src/IO/GEHDF5Wrapper.cxx
+++ b/src/IO/GEHDF5Wrapper.cxx
@@ -27,6 +27,7 @@
 #include "stir/IndexRange3D.h"
 #include "stir/is_null_ptr.h"
 #include "stir/info.h"
+#include "stir/error.h"
 #include <sstream>
 
 

--- a/src/IO/ITKImageInputFileFormat.cxx
+++ b/src/IO/ITKImageInputFileFormat.cxx
@@ -35,6 +35,8 @@
 #include "itkImageSeriesReader.h"
 #include "itkOrientImageFilter.h"
 #include "stir/info.h"
+#include "stir/warning.h"
+#include "stir/error.h"
 #include "boost/format.hpp"
 #include <string> // for std::stod
 

--- a/src/IO/ITKOutputFileFormat.cxx
+++ b/src/IO/ITKOutputFileFormat.cxx
@@ -23,6 +23,7 @@
 #include "stir/IO/ITKOutputFileFormat.h"
 #include "stir/utilities.h"
 #include "stir/Succeeded.h"
+#include "stir/warning.h"
 #include "itkImage.h"
 #include "itkImageFileWriter.h"
 #include "itkImageRegionIterator.h"

--- a/src/IO/InputStreamFromROOTFile.cxx
+++ b/src/IO/InputStreamFromROOTFile.cxx
@@ -23,6 +23,7 @@
 #include "stir/error.h"
 #include "stir/FilePath.h"
 #include "stir/info.h"
+#include "stir/error.h"
 
 #include <TROOT.h>
 #include <TSystem.h>

--- a/src/IO/InputStreamFromROOTFileForCylindricalPET.cxx
+++ b/src/IO/InputStreamFromROOTFileForCylindricalPET.cxx
@@ -9,6 +9,8 @@
 */
 #include "stir/IO/InputStreamFromROOTFileForCylindricalPET.h"
 #include <TChain.h>
+#include "stir/warning.h"
+#include "stir/error.h"
 
 START_NAMESPACE_STIR
 

--- a/src/IO/InputStreamFromROOTFileForECATPET.cxx
+++ b/src/IO/InputStreamFromROOTFileForECATPET.cxx
@@ -10,6 +10,8 @@
 
 #include "stir/IO/InputStreamFromROOTFileForECATPET.h"
 #include <TChain.h>
+#include "stir/warning.h"
+#include "stir/error.h"
 
 START_NAMESPACE_STIR
 

--- a/src/IO/InputStreamWithRecordsFromUPENNbin.cxx
+++ b/src/IO/InputStreamWithRecordsFromUPENNbin.cxx
@@ -15,6 +15,7 @@
 */
 
 #include "stir/IO/InputStreamWithRecordsFromUPENNbin.h"
+#include "stir/error.h"
 
 START_NAMESPACE_STIR
 

--- a/src/IO/InputStreamWithRecordsFromUPENNtxt.cxx
+++ b/src/IO/InputStreamWithRecordsFromUPENNtxt.cxx
@@ -15,6 +15,8 @@
 */
 
 #include "stir/IO/InputStreamWithRecordsFromUPENNtxt.h"
+#include "stir/warning.h"
+#include "stir/error.h"
 
 START_NAMESPACE_STIR
 

--- a/src/IO/InterfileDynamicDiscretisedDensityOutputFileFormat.cxx
+++ b/src/IO/InterfileDynamicDiscretisedDensityOutputFileFormat.cxx
@@ -25,6 +25,7 @@
 #include "stir/NumericType.h"
 #include "stir/Succeeded.h"
 #include "stir/IO/interfile.h"
+#include "stir/warning.h"
 
 START_NAMESPACE_STIR
 

--- a/src/IO/InterfileHeader.cxx
+++ b/src/IO/InterfileHeader.cxx
@@ -30,6 +30,8 @@
 #include "stir/ProjDataInfoCylindricalNoArcCorr.h"
 #include "stir/RadionuclideDB.h"
 #include "stir/info.h"
+#include "stir/warning.h"
+#include "stir/error.h"
 #include <numeric>
 #include <functional>
 #include "stir/ProjDataInfoBlocksOnCylindricalNoArcCorr.h"

--- a/src/IO/InterfileHeaderSiemens.cxx
+++ b/src/IO/InterfileHeaderSiemens.cxx
@@ -29,6 +29,8 @@
 #include "stir/IO/stir_ecat_common.h"
 #include <numeric>
 #include <functional>
+#include "stir/warning.h"
+#include "stir/error.h"
 
 #ifndef STIR_NO_NAMESPACES
 using std::pair;

--- a/src/IO/InterfilePDFSHeaderSPECT.cxx
+++ b/src/IO/InterfilePDFSHeaderSPECT.cxx
@@ -21,6 +21,7 @@
 #include "stir/ProjDataInfoCylindricalNoArcCorr.h"
 #include <numeric>
 #include <functional>
+#include "stir/warning.h"
 
 #ifndef STIR_NO_NAMESPACES
 using std::pair;

--- a/src/IO/InterfileParametricDiscretisedDensityOutputFileFormat.cxx
+++ b/src/IO/InterfileParametricDiscretisedDensityOutputFileFormat.cxx
@@ -26,6 +26,7 @@
 #include "stir/NumericType.h"
 #include "stir/Succeeded.h"
 #include "stir/IO/interfile.h"
+#include "stir/warning.h"
 
 START_NAMESPACE_STIR
 

--- a/src/IO/MultiDynamicDiscretisedDensityOutputFileFormat.cxx
+++ b/src/IO/MultiDynamicDiscretisedDensityOutputFileFormat.cxx
@@ -26,6 +26,8 @@
 #include "stir/Succeeded.h"
 #include "stir/FilePath.h"
 #include "stir/MultipleDataSetHeader.h"
+#include "stir/warning.h"
+#include "stir/error.h"
 
 START_NAMESPACE_STIR
 

--- a/src/IO/MultiParametricDiscretisedDensityOutputFileFormat.cxx
+++ b/src/IO/MultiParametricDiscretisedDensityOutputFileFormat.cxx
@@ -28,6 +28,8 @@
 #include "stir/Succeeded.h"
 #include "stir/FilePath.h"
 #include "stir/MultipleDataSetHeader.h"
+#include "stir/warning.h"
+#include "stir/error.h"
 
 START_NAMESPACE_STIR
 

--- a/src/IO/ecat6_utils.cxx
+++ b/src/IO/ecat6_utils.cxx
@@ -64,6 +64,7 @@ extern "C" FILE *mat_create(char *fname, Main_header *mhead);
 
 #include "stir/ByteOrder.h"
 #include "stir/ByteOrderDefine.h"
+#include "stir/warning.h"
 #include "boost/static_assert.hpp"
 #include "boost/cstdint.hpp"
 #include <algorithm> // for std::swap

--- a/src/IO/interfile.cxx
+++ b/src/IO/interfile.cxx
@@ -47,6 +47,7 @@
 #include "stir/Bin.h"
 #include "stir/stream.h"
 #include "stir/error.h"
+#include "stir/warning.h"
 #include "stir/DynamicDiscretisedDensity.h"
 #include "stir/modelling/ParametricDiscretisedDensity.h"
 #include "stir/date_time_functions.h"

--- a/src/IO/stir_AVW.cxx
+++ b/src/IO/stir_AVW.cxx
@@ -23,7 +23,7 @@
 #include "stir/IndexRange3D.h"
 #include "stir/VoxelsOnCartesianGrid.h"
 #include "stir/CartesianCoordinate3D.h"
-
+#include "stir/warning.h"
 
 START_NAMESPACE_STIR
 

--- a/src/IO/stir_ecat6.cxx
+++ b/src/IO/stir_ecat6.cxx
@@ -34,6 +34,8 @@
 #include "stir/convert_array.h"
 #include "stir/IndexRange2D.h"
 #include "stir/utilities.h"
+#include "stir/warning.h"
+#include "stir/error.h"
 
 #include "stir/Scanner.h" 
 #include "stir/ExamInfo.h"

--- a/src/IO/stir_ecat7.cxx
+++ b/src/IO/stir_ecat7.cxx
@@ -55,6 +55,8 @@
 #include "stir/ExamInfo.h"
 #include "stir/TimeFrameDefinitions.h"
 #include "stir/unique_ptr.h"
+#include "stir/warning.h"
+#include "stir/error.h"
 #include <iostream>
 #include <fstream>
 #include <string>

--- a/src/IO/stir_ecat_common.cxx
+++ b/src/IO/stir_ecat_common.cxx
@@ -26,6 +26,8 @@
 #include "stir/Scanner.h" 
 #include "stir/ProjDataInfo.h"
 #include "stir/IO/stir_ecat_common.h"
+#include "stir/warning.h"
+#include "stir/error.h"
 
 START_NAMESPACE_STIR
 START_NAMESPACE_ECAT

--- a/src/Shape_buildblock/Box3D.cxx
+++ b/src/Shape_buildblock/Box3D.cxx
@@ -19,6 +19,8 @@
 */
 #include "stir/Shape/Box3D.h"
 #include "stir/Succeeded.h"
+#include "stir/warning.h"
+#include "stir/error.h"
 
 START_NAMESPACE_STIR
 

--- a/src/Shape_buildblock/DiscretisedShape3D.cxx
+++ b/src/Shape_buildblock/DiscretisedShape3D.cxx
@@ -20,6 +20,8 @@
 #include "stir/round.h"
 #include "stir/zoom.h"
 #include "stir/is_null_ptr.h"
+#include "stir/warning.h"
+#include "stir/error.h"
 #include "stir/IO/read_from_file.h"
 START_NAMESPACE_STIR
 

--- a/src/Shape_buildblock/Ellipsoid.cxx
+++ b/src/Shape_buildblock/Ellipsoid.cxx
@@ -19,6 +19,8 @@
 #include "stir/Shape/Ellipsoid.h"
 #include "stir/numerics/MatrixFunction.h"
 #include "stir/Succeeded.h"
+#include "stir/warning.h"
+#include "stir/error.h"
 #include <cmath>
 
 START_NAMESPACE_STIR

--- a/src/Shape_buildblock/EllipsoidalCylinder.cxx
+++ b/src/Shape_buildblock/EllipsoidalCylinder.cxx
@@ -24,6 +24,8 @@
 #include "stir/Shape/EllipsoidalCylinder.h"
 #include "stir/numerics/MatrixFunction.h"
 #include "stir/Succeeded.h"
+#include "stir/warning.h"
+#include "stir/error.h"
 #include <algorithm>
 #include <cmath>
 

--- a/src/Shape_buildblock/GenerateImage.cxx
+++ b/src/Shape_buildblock/GenerateImage.cxx
@@ -32,6 +32,8 @@
 #include "stir/Succeeded.h"
 #include "stir/IO/OutputFileFormat.h"
 #include "stir/VoxelsOnCartesianGrid.h"
+#include "stir/warning.h"
+#include "stir/error.h"
 #include <iostream>
 
 

--- a/src/Shape_buildblock/Shape3DWithOrientation.cxx
+++ b/src/Shape_buildblock/Shape3DWithOrientation.cxx
@@ -21,6 +21,8 @@
 #include "stir/numerics/determinant.h"
 #include "stir/numerics/norm.h"
 #include "stir/Succeeded.h"
+#include "stir/warning.h"
+#include "stir/error.h"
 #include <cmath>
 
 START_NAMESPACE_STIR

--- a/src/SimSET/conv_SimSET_projdata_to_STIR.cxx
+++ b/src/SimSET/conv_SimSET_projdata_to_STIR.cxx
@@ -28,6 +28,8 @@
 #include "stir/is_null_ptr.h"
 #include "stir/IO/read_data.h"
 #include "stir/Succeeded.h"
+#include "stir/warning.h"
+#include "stir/error.h"
 #include <iostream>
 #include <stdlib.h>
 #include <string.h>

--- a/src/analytic/FBP2D/FBP2DReconstruction.cxx
+++ b/src/analytic/FBP2D/FBP2DReconstruction.cxx
@@ -36,6 +36,8 @@
 #include "stir/IO/interfile.h"
 #include "stir/info.h"
 #include <boost/format.hpp>
+#include "stir/warning.h"
+#include "stir/error.h"
 
 #ifdef STIR_OPENMP
 #include <omp.h>

--- a/src/analytic/FBP2D/RampFilter.cxx
+++ b/src/analytic/FBP2D/RampFilter.cxx
@@ -26,6 +26,7 @@
 
 #include "stir/analytic/FBP2D/RampFilter.h"
 #include <math.h>
+#include "stir/error.h"
 #include <iostream>
 #ifdef BOOST_NO_STRINGSTREAM
 #include <strstream.h>

--- a/src/analytic/FBP3DRP/ColsherFilter.cxx
+++ b/src/analytic/FBP3DRP/ColsherFilter.cxx
@@ -28,6 +28,7 @@
 #include "stir/numerics/fourier.h"
 #include "stir/IndexRange2D.h"
 #include "stir/Succeeded.h"
+#include "stir/warning.h"
 
 #ifdef __DEBUG_COLSHER
 // for debugging...

--- a/src/analytic/FBP3DRP/FBP3DRPReconstruction.cxx
+++ b/src/analytic/FBP3DRP/FBP3DRPReconstruction.cxx
@@ -77,6 +77,8 @@
 #include "stir/IndexRange3D.h"
 #include "stir/Coordinate3D.h"
 #include "stir/Succeeded.h"
+#include "stir/warning.h"
+#include "stir/error.h"
 
 #include "stir/analytic/FBP3DRP/ColsherFilter.h" 
 #include "stir/display.h"

--- a/src/buildblock/ArcCorrection.cxx
+++ b/src/buildblock/ArcCorrection.cxx
@@ -30,6 +30,7 @@
 #include "stir/Succeeded.h"
 #include "stir/numerics/overlap_interpolate.h"
 #include <typeinfo>
+#include "stir/warning.h"
 
 START_NAMESPACE_STIR
 ArcCorrection::

--- a/src/buildblock/ArrayFilter1DUsingConvolution.cxx
+++ b/src/buildblock/ArrayFilter1DUsingConvolution.cxx
@@ -23,6 +23,7 @@
 #include "stir/IndexRange.h"
 #include "stir/VectorWithOffset.h"
 #include "stir/Array.h"
+#include "stir/error.h"
 
 #include <algorithm>
 using std::min;

--- a/src/buildblock/ArrayFilter3DUsingConvolution.cxx
+++ b/src/buildblock/ArrayFilter3DUsingConvolution.cxx
@@ -22,6 +22,7 @@
 #include "stir/Array.h"
 #include "stir/IndexRange3D.h"
 #include "stir/IndexRange2D.h"
+#include "stir/error.h"
 
 #include <iostream>
 #include <fstream>

--- a/src/buildblock/ArrayFilterUsingRealDFTWithPadding.cxx
+++ b/src/buildblock/ArrayFilterUsingRealDFTWithPadding.cxx
@@ -25,6 +25,7 @@
 #include "stir/array_index_functions.h"
 #include "stir/modulo.h"
 #include <algorithm>
+#include "stir/error.h"
 
 
 START_NAMESPACE_STIR

--- a/src/buildblock/DetectorCoordinateMap.cxx
+++ b/src/buildblock/DetectorCoordinateMap.cxx
@@ -23,6 +23,7 @@
 #include "stir/DetectorCoordinateMap.h"
 #include "stir/modulo.h"
 #include "stir/Succeeded.h"
+#include "stir/warning.h"
 
 START_NAMESPACE_STIR
 	

--- a/src/buildblock/DiscretisedDensity.cxx
+++ b/src/buildblock/DiscretisedDensity.cxx
@@ -42,6 +42,8 @@
 
 #include <typeinfo>
 #include <fstream>
+#include "stir/warning.h"
+#include "stir/error.h"
 
 #ifndef STIR_NO_NAMESPACES
 using std::fstream;

--- a/src/buildblock/DynamicDiscretisedDensity.cxx
+++ b/src/buildblock/DynamicDiscretisedDensity.cxx
@@ -29,6 +29,8 @@
 #include "stir/is_null_ptr.h"
 #include "stir/round.h"
 #include <boost/format.hpp>
+#include "stir/warning.h"
+#include "stir/error.h"
 
 #ifndef STIR_NO_NAMESPACES
 using std::string;

--- a/src/buildblock/DynamicProjData.cxx
+++ b/src/buildblock/DynamicProjData.cxx
@@ -39,6 +39,8 @@
 #include <boost/format.hpp>
 #include <fstream>
 #include <math.h>
+#include "stir/warning.h"
+#include "stir/error.h"
 
 using std::string;
 using std::istream;

--- a/src/buildblock/FilePath.cxx
+++ b/src/buildblock/FilePath.cxx
@@ -24,6 +24,9 @@
 #include "stir/FilePath.h"
 #include "stir/utilities.h"
 
+#include "stir/warning.h"
+#include "stir/error.h"
+
 #include <boost/format.hpp>
 
 #if defined(__OS_WIN__)

--- a/src/buildblock/GatedProjData.cxx
+++ b/src/buildblock/GatedProjData.cxx
@@ -27,6 +27,8 @@
 #include <fstream>
 #include <sstream>
 #include <boost/format.hpp>
+#include "stir/warning.h"
+#include "stir/error.h"
 
 using std::string;
 

--- a/src/buildblock/GeneralisedPoissonNoiseGenerator.cxx
+++ b/src/buildblock/GeneralisedPoissonNoiseGenerator.cxx
@@ -20,6 +20,7 @@
 #include "stir/SegmentByView.h"
 #include "stir/Succeeded.h"
 #include "stir/round.h"
+#include "stir/error.h"
 
 #include <boost/random/uniform_01.hpp>
 #include <boost/random/normal_distribution.hpp>

--- a/src/buildblock/HUToMuImageProcessor.cxx
+++ b/src/buildblock/HUToMuImageProcessor.cxx
@@ -19,6 +19,7 @@
 
 #include "stir/HUToMuImageProcessor.h"
 #include "stir/info.h"
+#include "stir/error.h"
 #include "stir/round.h"
 #ifdef HAVE_JSON
   #include <nlohmann/json.hpp>

--- a/src/buildblock/KeyParser.cxx
+++ b/src/buildblock/KeyParser.cxx
@@ -27,10 +27,12 @@
 #include "stir/stream.h"
 #include "stir/is_null_ptr.h"
 #include <boost/format.hpp>
+#include "stir/error.h"
 #include <typeinfo>
 #include <fstream>
 #include <cstring>
 #include <cstdlib>
+#include "stir/warning.h"
 # ifdef BOOST_NO_STDC_NAMESPACE
  namespace std { using ::getenv; }
 # endif

--- a/src/buildblock/ML_norm.cxx
+++ b/src/buildblock/ML_norm.cxx
@@ -27,6 +27,8 @@
 #include "stir/ML_norm.h"
 #include "stir/SegmentBySinogram.h"
 #include "stir/stream.h"
+#include "stir/warning.h"
+#include "stir/error.h"
 
 #ifdef STIR_OPENMP
 #  include <omp.h>

--- a/src/buildblock/MultipleDataSetHeader.cxx
+++ b/src/buildblock/MultipleDataSetHeader.cxx
@@ -19,6 +19,7 @@
 
 #include "stir/MultipleDataSetHeader.h"
 #include <boost/format.hpp>
+#include "stir/warning.h"
 
 START_NAMESPACE_STIR
 

--- a/src/buildblock/MultipleProjData.cxx
+++ b/src/buildblock/MultipleProjData.cxx
@@ -25,6 +25,7 @@
 #include <fstream>
 #include <boost/format.hpp>
 #include "stir/info.h"
+#include "stir/error.h"
 
 START_NAMESPACE_STIR
 

--- a/src/buildblock/NonseparableConvolutionUsingRealDFTImageFilter.cxx
+++ b/src/buildblock/NonseparableConvolutionUsingRealDFTImageFilter.cxx
@@ -23,7 +23,7 @@
 #include "stir/ArrayFunction.h"
 #include "stir/Array_complex_numbers.h"
 #include "stir/IO/read_from_file.h"
-
+#include "stir/warning.h"
 
 START_NAMESPACE_STIR
 

--- a/src/buildblock/ParsingObject.cxx
+++ b/src/buildblock/ParsingObject.cxx
@@ -20,6 +20,8 @@
 */
 #include "stir/ParsingObject.h"
 #include <fstream>
+#include "stir/warning.h"
+#include "stir/error.h"
 
 #ifndef STIR_NO_NAMESPACE
 using std::ifstream;

--- a/src/buildblock/ProjData.cxx
+++ b/src/buildblock/ProjData.cxx
@@ -63,6 +63,8 @@
 #include <cstring>
 #include <fstream>
 #include <algorithm>
+#include "stir/warning.h"
+#include "stir/error.h"
 
 #ifndef STIR_NO_NAMESPACES
 using std::istream;

--- a/src/buildblock/ProjDataFromStream.cxx
+++ b/src/buildblock/ProjDataFromStream.cxx
@@ -38,6 +38,8 @@
 #include <numeric>
 #include <iostream>
 #include <fstream>
+#include "stir/warning.h"
+#include "stir/error.h"
 
 #ifndef STIR_NO_NAMESPACES
 using std::find;

--- a/src/buildblock/ProjDataGEAdvance.cxx
+++ b/src/buildblock/ProjDataGEAdvance.cxx
@@ -29,6 +29,8 @@
 #include "stir/Scanner.h"
 #include "stir/Succeeded.h"
 #include "stir/IO/read_data.h"
+#include "stir/warning.h"
+#include "stir/error.h"
 
 #include <vector>
 #include <algorithm>

--- a/src/buildblock/ProjDataGEHDF5.cxx
+++ b/src/buildblock/ProjDataGEHDF5.cxx
@@ -28,6 +28,7 @@
 #include "stir/IndexRange4D.h"
 #include "stir/IO/GEHDF5Wrapper.h"
 #include "stir/display.h"
+#include "stir/error.h"
 #include "stir/CPUTimer.h"
 #include "stir/HighResWallClockTimer.h"
 #ifndef STIR_NO_NAMESPACES

--- a/src/buildblock/ProjDataInMemory.cxx
+++ b/src/buildblock/ProjDataInMemory.cxx
@@ -24,6 +24,7 @@
 #include "stir/SegmentByView.h"
 #include "stir/Bin.h"
 #include "stir/is_null_ptr.h"
+#include "stir/error.h"
 #include <fstream>
 #include <cstring>
 

--- a/src/buildblock/ProjDataInfo.cxx
+++ b/src/buildblock/ProjDataInfo.cxx
@@ -41,6 +41,8 @@
 #include "stir/Bin.h"
 // include for ask and ask_num
 #include "stir/utilities.h"
+#include "stir/warning.h"
+#include "stir/error.h"
 
 #include <iostream>
 #include <typeinfo>

--- a/src/buildblock/ProjDataInfoBlocksOnCylindricalNoArcCorr.cxx
+++ b/src/buildblock/ProjDataInfoBlocksOnCylindricalNoArcCorr.cxx
@@ -29,6 +29,7 @@
 #include "stir/LORCoordinates.h"
 #include "stir/round.h"
 #include "stir/DetectionPosition.h"
+#include "stir/error.h"
 #include <iostream>
 #include <fstream>
 

--- a/src/buildblock/ProjDataInfoCylindrical.cxx
+++ b/src/buildblock/ProjDataInfoCylindrical.cxx
@@ -38,6 +38,8 @@
 #include "stir/info.h"
 #include <boost/format.hpp>
 #include <math.h>
+#include "stir/warning.h"
+#include "stir/error.h"
 
 #ifndef STIR_NO_NAMESPACES
 using std::min_element;

--- a/src/buildblock/ProjDataInfoCylindricalNoArcCorr.cxx
+++ b/src/buildblock/ProjDataInfoCylindricalNoArcCorr.cxx
@@ -28,6 +28,7 @@
 #include "stir/CartesianCoordinate3D.h"
 #include "stir/LORCoordinates.h"
 #include "stir/round.h"
+#include "stir/error.h"
 
 #ifdef BOOST_NO_STRINGSTREAM
 #include <strstream.h>

--- a/src/buildblock/ProjDataInfoGeneric.cxx
+++ b/src/buildblock/ProjDataInfoGeneric.cxx
@@ -37,6 +37,7 @@
 #endif
 
 #include "stir/round.h"
+#include "stir/error.h"
 #include <math.h>
 
 #ifndef STIR_NO_NAMESPACES

--- a/src/buildblock/ProjDataInfoGenericNoArcCorr.cxx
+++ b/src/buildblock/ProjDataInfoGenericNoArcCorr.cxx
@@ -29,6 +29,7 @@
 #include "stir/round.h"
 #include "stir/DetectionPosition.h"
 #include "stir/is_null_ptr.h"
+#include "stir/error.h"
 #include <iostream>
 #include <fstream>
 

--- a/src/buildblock/ProjDataInfoSubsetByView.cxx
+++ b/src/buildblock/ProjDataInfoSubsetByView.cxx
@@ -20,6 +20,7 @@
 #include "stir/Bin.h"
 #include "stir/Array.h"
 #include <boost/format.hpp>
+#include "stir/error.h"
 
 START_NAMESPACE_STIR
 

--- a/src/buildblock/ProjDataInterfile.cxx
+++ b/src/buildblock/ProjDataInterfile.cxx
@@ -19,6 +19,7 @@
 #include "stir/ProjDataInterfile.h" 
 #include "stir/utilities.h"
 #include "stir/IO/interfile.h"
+#include "stir/error.h"
 
 #include <iostream>
 #include <fstream>

--- a/src/buildblock/Radionuclide.cxx
+++ b/src/buildblock/Radionuclide.cxx
@@ -20,6 +20,7 @@
 #include <sstream>
 #include <iomanip>
 #include "stir/Radionuclide.h"
+#include "stir/error.h"
 
 START_NAMESPACE_STIR
 

--- a/src/buildblock/RadionuclideDB.cxx
+++ b/src/buildblock/RadionuclideDB.cxx
@@ -23,6 +23,7 @@
 #include "stir/round.h"
 #include "stir/error.h"
 #include "stir/find_STIR_config.h"
+#include "stir/warning.h"
 
 START_NAMESPACE_STIR
 

--- a/src/buildblock/SSRB.cxx
+++ b/src/buildblock/SSRB.cxx
@@ -27,6 +27,8 @@
 #include "stir/round.h"
 #include <fstream>
 #include <algorithm>
+#include "stir/warning.h"
+#include "stir/error.h"
 
 #ifndef STIR_NO_NAMESPACES
 using std::fstream;

--- a/src/buildblock/Scanner.cxx
+++ b/src/buildblock/Scanner.cxx
@@ -44,7 +44,8 @@
 #else
 #include <sstream>
 #endif
-
+#include "stir/warning.h"
+#include "stir/error.h"
 
 #ifndef STIR_NO_NAMESPACES
 using std::cerr;

--- a/src/buildblock/SeparableCartesianMetzImageFilter.cxx
+++ b/src/buildblock/SeparableCartesianMetzImageFilter.cxx
@@ -20,7 +20,7 @@
 */
 #include "stir/SeparableCartesianMetzImageFilter.h"
 #include "stir/VoxelsOnCartesianGrid.h"
-
+#include "stir/warning.h"
 
 START_NAMESPACE_STIR
 

--- a/src/buildblock/SeparableConvolutionImageFilter.cxx
+++ b/src/buildblock/SeparableConvolutionImageFilter.cxx
@@ -20,6 +20,7 @@
 #include "stir/SeparableArrayFunctionObject.h"
 #include "stir/ArrayFilter1DUsingConvolution.h"
 #include "stir/DiscretisedDensity.h"
+#include "stir/warning.h"
 
 #include <algorithm>
 using std::vector;

--- a/src/buildblock/SeparableGaussianArrayFilter.cxx
+++ b/src/buildblock/SeparableGaussianArrayFilter.cxx
@@ -29,6 +29,7 @@
 #include "stir/ArrayFilter1DUsingConvolutionSymmetricKernel.h"
 #include "stir/VectorWithOffset.h"
 #include "stir/info.h"
+#include "stir/error.h"
 #include "stir/stream.h"
 #include <boost/format.hpp>
 

--- a/src/buildblock/SeparableGaussianImageFilter.cxx
+++ b/src/buildblock/SeparableGaussianImageFilter.cxx
@@ -24,6 +24,7 @@
 
 #include "stir/SeparableGaussianImageFilter.h"
 #include "stir/VoxelsOnCartesianGrid.h"
+#include "stir/warning.h"
 
 START_NAMESPACE_STIR
 

--- a/src/buildblock/Sinogram.cxx
+++ b/src/buildblock/Sinogram.cxx
@@ -24,6 +24,7 @@
 
 #include "stir/Sinogram.h"
 #include "boost/format.hpp"
+#include "stir/warning.h"
 
 #ifdef _MSC_VER
 // disable warning that not all functions have been implemented when instantiating

--- a/src/buildblock/TimeGateDefinitions.cxx
+++ b/src/buildblock/TimeGateDefinitions.cxx
@@ -17,6 +17,8 @@
 */
 
 #include "stir/TimeGateDefinitions.h"
+#include "stir/warning.h"
+#include "stir/error.h"
 #include <iostream>
 #include <fstream>
 

--- a/src/buildblock/VoxelsOnCartesianGrid.cxx
+++ b/src/buildblock/VoxelsOnCartesianGrid.cxx
@@ -41,6 +41,8 @@
 #include "stir/unique_ptr.h"
 #include "stir/ProjDataInfoBlocksOnCylindricalNoArcCorr.h"
 #include "stir/ProjDataInfoGenericNoArcCorr.h"
+#include "stir/warning.h"
+#include "stir/error.h"
 
 #ifndef STIR_NO_NAMESPACES
 using std::ifstream;

--- a/src/buildblock/centre_of_gravity.cxx
+++ b/src/buildblock/centre_of_gravity.cxx
@@ -22,6 +22,7 @@
 #include "stir/CartesianCoordinate3D.h"
 #include "stir/centre_of_gravity.h"
 #include "stir/assign.h"
+#include "stir/error.h"
 #include <algorithm>
 
 #ifndef STIR_NO_NAMESPACES

--- a/src/buildblock/date_time_functions.cxx
+++ b/src/buildblock/date_time_functions.cxx
@@ -19,6 +19,7 @@
 #include "stir/interfile_keyword_functions.h"
 #include "stir/info.h"
 #include "stir/warning.h"
+#include "stir/error.h"
 #include "stir/round.h"
 #include "boost/lexical_cast.hpp"
 #include "boost/format.hpp"

--- a/src/buildblock/extend_projdata.cxx
+++ b/src/buildblock/extend_projdata.cxx
@@ -25,6 +25,8 @@
 #include "stir/IndexRange.h"
 #include "stir/Bin.h"
 #include "stir/round.h"
+#include "stir/warning.h"
+#include "stir/error.h"
 
 START_NAMESPACE_STIR
 

--- a/src/buildblock/find_fwhm_in_image.cxx
+++ b/src/buildblock/find_fwhm_in_image.cxx
@@ -21,6 +21,7 @@
 #include "stir/round.h"
 #include "stir/assign_to_subregion.h"
 #include "stir/extract_line.h"
+#include "stir/error.h"
 #include <algorithm>  
 #include <list>
 

--- a/src/buildblock/interpolate_axial_position.cxx
+++ b/src/buildblock/interpolate_axial_position.cxx
@@ -37,6 +37,7 @@
 #include <omp.h>
 #endif
 #include "stir/num_threads.h"
+#include "stir/error.h"
 
 START_NAMESPACE_STIR
 

--- a/src/buildblock/interpolate_projdata.cxx
+++ b/src/buildblock/interpolate_projdata.cxx
@@ -34,6 +34,7 @@
 #include "stir/interpolate_axial_position.h"
 #include "stir/extend_projdata.h"
 #include "stir/numerics/sampling_functions.h"
+#include "stir/error.h"
 #include <typeinfo>
 
 START_NAMESPACE_STIR

--- a/src/buildblock/inverse_SSRB.cxx
+++ b/src/buildblock/inverse_SSRB.cxx
@@ -25,6 +25,8 @@
 #include "stir/Bin.h"
 #include "stir/Succeeded.h"
 #include <limits>
+#include "stir/warning.h"
+#include "stir/error.h"
 
 START_NAMESPACE_STIR
 

--- a/src/buildblock/line.cxx
+++ b/src/buildblock/line.cxx
@@ -22,7 +22,7 @@
     See STIR/LICENSE.txt for details
 */
 #include "stir/line.h"
-
+#include "stir/warning.h"
 
 START_NAMESPACE_STIR
 

--- a/src/buildblock/linear_regression.cxx
+++ b/src/buildblock/linear_regression.cxx
@@ -22,6 +22,7 @@
 */
 
 #include "stir/linear_regression.h"
+#include "stir/warning.h"
 
 START_NAMESPACE_STIR
 

--- a/src/buildblock/multiply_crystal_factors.cxx
+++ b/src/buildblock/multiply_crystal_factors.cxx
@@ -23,6 +23,7 @@
 #include "stir/ProjDataInfoBlocksOnCylindricalNoArcCorr.h"
 #include "stir/Bin.h"
 #include "stir/Sinogram.h"
+#include "stir/error.h"
 
 START_NAMESPACE_STIR
 

--- a/src/buildblock/num_threads.cxx
+++ b/src/buildblock/num_threads.cxx
@@ -20,6 +20,7 @@
 #include "stir/warning.h"
 #include "stir/info.h"
 #include <boost/format.hpp>
+#include "stir/warning.h"
 
 #include <stdlib.h>
 

--- a/src/buildblock/recon_array_functions.cxx
+++ b/src/buildblock/recon_array_functions.cxx
@@ -30,6 +30,7 @@
 #include "stir/Viewgram.h"
 #include "stir/SegmentByView.h"
 #include "stir/SegmentBySinogram.h"
+#include "stir/error.h"
 
 #include <numeric>
 

--- a/src/buildblock/scale_sinograms.cxx
+++ b/src/buildblock/scale_sinograms.cxx
@@ -22,6 +22,7 @@
 #include "stir/Bin.h"
 #include "stir/Sinogram.h"
 #include "stir/Succeeded.h"
+#include "stir/warning.h"
 
 START_NAMESPACE_STIR
 

--- a/src/buildblock/utilities.cxx
+++ b/src/buildblock/utilities.cxx
@@ -19,6 +19,7 @@
 */
 #include "stir/utilities.h"
 #include "stir/IndexRange3D.h"
+#include "stir/error.h"
 #include <iostream>
 #include <fstream>
 

--- a/src/buildblock/zoom.cxx
+++ b/src/buildblock/zoom.cxx
@@ -40,6 +40,7 @@
 #include "stir/ProjDataInfoCylindricalArcCorr.h"
 #include "stir/IndexRange3D.h"
 #include "stir/IndexRange2D.h"
+#include "stir/error.h"
 #include <cmath>
 
 START_NAMESPACE_STIR

--- a/src/data_buildblock/SinglesRatesFromECAT7.cxx
+++ b/src/data_buildblock/SinglesRatesFromECAT7.cxx
@@ -26,6 +26,8 @@
 #endif
 
 #include <fstream>
+#include "stir/warning.h"
+#include "stir/error.h"
 
 #ifndef STIR_NO_NAMESPACES
 using std::ofstream;

--- a/src/data_buildblock/SinglesRatesFromGEHDF5.cxx
+++ b/src/data_buildblock/SinglesRatesFromGEHDF5.cxx
@@ -23,6 +23,7 @@
 #include "stir/data/SinglesRatesFromGEHDF5.h"
 #include "stir/stream.h"
 #include "stir/IO/GEHDF5Wrapper.h"
+#include "stir/error.h"
 
 #include <vector>
 #include <fstream>

--- a/src/data_buildblock/SinglesRatesFromSglFile.cxx
+++ b/src/data_buildblock/SinglesRatesFromSglFile.cxx
@@ -19,6 +19,8 @@
 #include "stir/IndexRange.h"
 #include "stir/IndexRange2D.h"
 #include "stir/data/SinglesRatesFromSglFile.h"
+#include "stir/warning.h"
+#include "stir/error.h"
 
 #include <vector>
 #ifdef HAVE_LLN_MATRIX

--- a/src/display/display_array.cxx
+++ b/src/display/display_array.cxx
@@ -74,7 +74,7 @@
 #include "stir/info.h"
 #include <boost/format.hpp>
 #include <iostream>
-
+#include "stir/warning.h"
   
 // First we define the different implementations. 
 // See end of file for display() itself.

--- a/src/eval_buildblock/compute_ROI_values.cxx
+++ b/src/eval_buildblock/compute_ROI_values.cxx
@@ -23,6 +23,7 @@
 #include "stir/CartesianCoordinate3D.h"
 #include "stir/VoxelsOnCartesianGrid.h"
 #include "stir/shared_ptr.h"
+#include "stir/error.h"
 #include <numeric>
 #include <boost/limits.hpp> // <limits> but also for old compilers
 

--- a/src/experimental/IO/ECAT7DynamicDiscretisedDensityOutputFileFormat.cxx
+++ b/src/experimental/IO/ECAT7DynamicDiscretisedDensityOutputFileFormat.cxx
@@ -23,6 +23,7 @@
 #include "stir/IO/stir_ecat7.h"
 #include "stir/Scanner.h"
 #include "stir/Succeeded.h"
+#include "stir/warning.h"
 
 START_NAMESPACE_STIR
 START_NAMESPACE_ECAT

--- a/src/experimental/buildblock/AbsTimeIntervalFromDynamicData.cxx
+++ b/src/experimental/buildblock/AbsTimeIntervalFromDynamicData.cxx
@@ -22,6 +22,8 @@
 #include "stir/is_null_ptr.h"
 #include "stir/IO/read_from_file.h"
 #include "stir/Succeeded.h"
+#include "stir/warning.h"
+#include "stir/error.h"
 
 START_NAMESPACE_STIR
 

--- a/src/experimental/buildblock/AbsTimeIntervalFromECAT7ACF.cxx
+++ b/src/experimental/buildblock/AbsTimeIntervalFromECAT7ACF.cxx
@@ -18,6 +18,8 @@
 #include "stir_experimental/AbsTimeIntervalFromECAT7ACF.h"
 #include "stir/IO/stir_ecat7.h"
 #include "stir/Succeeded.h"
+#include "stir/warning.h"
+#include "stir/error.h"
 
 START_NAMESPACE_STIR
 

--- a/src/experimental/buildblock/AbsTimeIntervalWithParsing.cxx
+++ b/src/experimental/buildblock/AbsTimeIntervalWithParsing.cxx
@@ -17,6 +17,7 @@
 
 #include "stir_experimental/AbsTimeIntervalWithParsing.h"
 #include "stir/Succeeded.h"
+#include "stir/warning.h"
 
 START_NAMESPACE_STIR
 

--- a/src/experimental/buildblock/ModifiedInverseAveragingImageFilterAll.cxx
+++ b/src/experimental/buildblock/ModifiedInverseAveragingImageFilterAll.cxx
@@ -26,6 +26,8 @@
 #include "stir/CPUTimer.h"
 #include "stir/SegmentByView.h"
 #include "stir/info.h"
+#include "stir/warning.h"
+#include "stir/error.h"
 
 #include "stir/round.h"
 #include <iostream>

--- a/src/experimental/buildblock/ModifiedInverseAverigingArrayFilter.cxx
+++ b/src/experimental/buildblock/ModifiedInverseAverigingArrayFilter.cxx
@@ -8,6 +8,8 @@
 #include "stir/Array.h"
 #include "stir/IndexRange3D.h"
 #include "stir_experimental/fft.h"
+#include "stir/warning.h"
+#include "stir/error.h"
 
 #include "stir_experimental/local_helping_functions.h"
 #include <iostream>

--- a/src/experimental/buildblock/ModifiedInverseAverigingImageFilter.cxx
+++ b/src/experimental/buildblock/ModifiedInverseAverigingImageFilter.cxx
@@ -32,7 +32,8 @@
 #include "stir_experimental/ArrayFilter3DUsingConvolution.h"
 #include "stir_experimental/ArrayFilter2DUsingConvolution.h"
 #include "stir/info.h"
-
+#include "stir/warning.h"
+#include "stir/error.h"
 
 #include "stir/CPUTimer.h"
 

--- a/src/experimental/buildblock/NonseparableSpatiallyVaryingFilters.cxx
+++ b/src/experimental/buildblock/NonseparableSpatiallyVaryingFilters.cxx
@@ -26,6 +26,7 @@ See STIR/LICENSE.txt for details
 #include "stir/CPUTimer.h"
 #include "stir/SegmentByView.h"
 #include "stir/info.h"
+#include "stir/warning.h"
 
 #include "stir/round.h"
 #include <iostream>

--- a/src/experimental/buildblock/NonseparableSpatiallyVaryingFilters3D.cxx
+++ b/src/experimental/buildblock/NonseparableSpatiallyVaryingFilters3D.cxx
@@ -26,6 +26,8 @@ See STIR/LICENSE.txt for details
 #include "stir/CPUTimer.h"
 #include "stir/SegmentByView.h"
 #include "stir/include.h"
+#include "stir/warning.h"
+#include "stir/error.h"
 
 #include "stir/round.h"
 #include <iostream>

--- a/src/experimental/buildblock/multiply_plane_scale_factorsImageProcessor.cxx
+++ b/src/experimental/buildblock/multiply_plane_scale_factorsImageProcessor.cxx
@@ -19,6 +19,8 @@
 #include "stir/VectorWithOffset.h"
 #include "stir/Succeeded.h"
 #include <algorithm>
+#include "stir/warning.h"
+#include "stir/error.h"
 
 #ifndef STIR_NO_NAMESPACES
 using std::copy;

--- a/src/experimental/iterative/OSSPS/line_search.cxx
+++ b/src/experimental/iterative/OSSPS/line_search.cxx
@@ -17,6 +17,9 @@
   
 */
 
+#include "stir/warning.h"
+#include "stir/error.h"
+
 #error this code does not compile right now
 
 // only used in (disabled) line_search below

--- a/src/experimental/listmode/CListModeDataLMF.cxx
+++ b/src/experimental/listmode/CListModeDataLMF.cxx
@@ -22,6 +22,7 @@
 #include "stir_experimental/listmode/CListRecordLMF.h"
 #include "stir/Succeeded.h"
 #include "stir/is_null_ptr.h"
+#include "stir/error.h"
 #include <stdio.h>
 
 #ifndef STIR_NO_NAMESPACES

--- a/src/experimental/listmode/LmToProjDataWithMC.cxx
+++ b/src/experimental/listmode/LmToProjDataWithMC.cxx
@@ -14,6 +14,7 @@
 #include "stir/ProjDataInfoCylindricalNoArcCorr.h"
 #include "stir/listmode/CListRecord.h"
 #include "stir/Succeeded.h"
+#include "stir/error.h"
 #include <time.h>
 #include "stir/is_null_ptr.h"
 #include "stir/stream.h"

--- a/src/experimental/listmode_utilities/change_lm_time_tags.cxx
+++ b/src/experimental/listmode_utilities/change_lm_time_tags.cxx
@@ -22,6 +22,8 @@
 #include "stir/listmode/CListModeData.h"
 #include <fstream>
 #include <iostream>
+#include "stir/warning.h"
+#include "stir/error.h"
 
 static
 void open_next(std::fstream& s, const std::string& filename_prefix, int& num)

--- a/src/experimental/listmode_utilities/get_singles_info.cxx
+++ b/src/experimental/listmode_utilities/get_singles_info.cxx
@@ -18,6 +18,7 @@
 
 #include "stir/TimeFrameDefinitions.h"
 #include "stir/data/SinglesRatesFromSglFile.h"
+#include "stir/error.h"
 
 #include <string>
 #include <fstream>

--- a/src/experimental/motion/MatchTrackerAndScanner.cxx
+++ b/src/experimental/motion/MatchTrackerAndScanner.cxx
@@ -24,6 +24,8 @@
 #include "stir/centre_of_gravity.h"
 #include "stir/thresholding.h"
 #include <vector>
+#include "stir/warning.h"
+#include "stir/error.h"
 #include <algorithm>
 #include <iostream>
 #include <cmath>

--- a/src/experimental/motion/NonRigidObjectTransformationUsingBSplines.cxx
+++ b/src/experimental/motion/NonRigidObjectTransformationUsingBSplines.cxx
@@ -19,6 +19,8 @@
 #include "stir/numerics/determinant.h"
 #include "stir/IndexRange2D.h"
 #include "stir/info.h"
+#include "stir/warning.h"
+#include "stir/error.h"
 #include <iostream>
 
 // for ncat

--- a/src/experimental/motion/PoissonLogLikelihoodWithLinearModelForMeanAndGatedProjDataWithMotion.cxx
+++ b/src/experimental/motion/PoissonLogLikelihoodWithLinearModelForMeanAndGatedProjDataWithMotion.cxx
@@ -21,6 +21,8 @@
 #include "stir/recon_buildblock/TrivialBinNormalisation.h"
 #include "stir/Succeeded.h"
 #include "stir/is_null_ptr.h"
+#include "stir/warning.h"
+#include "stir/error.h"
 
 #include "stir/recon_buildblock/ProjectorByBinPairUsingSeparateProjectors.h"
 #include "stir_experimental/motion/Transform3DObjectImageProcessor.h"

--- a/src/experimental/motion/Polaris_MT_File.cxx
+++ b/src/experimental/motion/Polaris_MT_File.cxx
@@ -16,6 +16,7 @@
 */
 #include "stir_experimental/motion/Polaris_MT_File.h"
 #include "stir/Succeeded.h"
+#include "stir/warning.h"
 #include <fstream>
 #include <iostream>
 #ifndef STIR_NO_NAMESPACES

--- a/src/experimental/motion/RigidObject3DMotion.cxx
+++ b/src/experimental/motion/RigidObject3DMotion.cxx
@@ -18,6 +18,7 @@
 #include "stir_experimental/motion/RigidObject3DTransformation.h"
 #include "stir/stream.h"
 #include "stir_experimental/AbsTimeInterval.h"
+#include "stir/warning.h"
 
 #include <iostream>
 

--- a/src/experimental/motion/RigidObject3DMotionFromPolaris.cxx
+++ b/src/experimental/motion/RigidObject3DMotionFromPolaris.cxx
@@ -27,6 +27,8 @@
 #include "stir/IO/read_from_file.h"
 #include "stir/CartesianCoordinate3D.h"
 #include "stir/linear_regression.h"
+#include "stir/warning.h"
+#include "stir/error.h"
 #include <fstream>
 #include <ctime>
 

--- a/src/experimental/motion/RigidObject3DTransformation.cxx
+++ b/src/experimental/motion/RigidObject3DTransformation.cxx
@@ -23,6 +23,8 @@
 #include "stir/stream.h"
 #include "stir/more_algorithms.h"
 #include "stir/numerics/max_eigenvector.h"
+#include "stir/warning.h"
+#include "stir/error.h"
 #include <vector>
 #include <cmath>
 #ifndef NEW_ROT

--- a/src/experimental/motion/TimeFrameMotion.cxx
+++ b/src/experimental/motion/TimeFrameMotion.cxx
@@ -14,6 +14,7 @@
 
 #include "stir_experimental/motion/TimeFrameMotion.h"
 #include "stir/is_null_ptr.h"
+#include "stir/warning.h"
 
 START_NAMESPACE_STIR
 

--- a/src/experimental/motion/Transform3DObjectImageProcessor.cxx
+++ b/src/experimental/motion/Transform3DObjectImageProcessor.cxx
@@ -20,6 +20,8 @@
 #include "stir/stream.h"
 #include "stir/CPUTimer.h"
 #include "stir/info.h"
+#include "stir/warning.h"
+#include "stir/error.h"
 START_NAMESPACE_STIR
 
 template<>

--- a/src/experimental/motion/transform_3d_object.cxx
+++ b/src/experimental/motion/transform_3d_object.cxx
@@ -25,6 +25,7 @@
 #include "stir/round.h"
 #include "stir/Succeeded.h"
 #include "stir/info.h"
+#include "stir/warning.h"
 #include "stir_experimental/motion/ObjectTransformation.h"
 #include "stir_experimental/motion/RigidObject3DTransformation.h"
 #include "stir_experimental/numerics/more_interpolators.h"

--- a/src/experimental/motion_utilities/find_motion_corrected_norm_factors.cxx
+++ b/src/experimental/motion_utilities/find_motion_corrected_norm_factors.cxx
@@ -28,6 +28,8 @@
 #include "stir/IO/write_data.h"
 #include "stir/is_null_ptr.h"
 #include "stir/round.h"
+#include "stir/warning.h"
+#include "stir/error.h"
 
 // TODO currently necessary, but needs to be replaced by ProjDataInMemory
 #define USE_SegmentByView

--- a/src/experimental/motion_utilities/list_deformation_vectors.cxx
+++ b/src/experimental/motion_utilities/list_deformation_vectors.cxx
@@ -31,6 +31,7 @@
 #include "stir_experimental/motion/ObjectTransformation.h"
 #include "stir/Succeeded.h"
 #include "stir/is_null_ptr.h"
+#include "stir/warning.h"
 #include <iostream>
 
 START_NAMESPACE_STIR

--- a/src/experimental/motion_utilities/move_image.cxx
+++ b/src/experimental/motion_utilities/move_image.cxx
@@ -34,6 +34,7 @@
 #include "stir/is_null_ptr.h"
 #include "stir/info.h"
 #include "boost/format.hpp"
+#include "stir/warning.h"
 
 START_NAMESPACE_STIR
 

--- a/src/experimental/motion_utilities/move_projdata.cxx
+++ b/src/experimental/motion_utilities/move_projdata.cxx
@@ -28,6 +28,7 @@
 #include "stir_experimental/motion/transform_3d_object.h"
 #include "stir/Succeeded.h"
 #include "stir/is_null_ptr.h"
+#include "stir/warning.h"
 #include <iostream>
 
 START_NAMESPACE_STIR

--- a/src/experimental/motion_utilities/non_rigid_transform.cxx
+++ b/src/experimental/motion_utilities/non_rigid_transform.cxx
@@ -39,6 +39,7 @@
 #include "stir/VoxelsOnCartesianGrid.h"
 #include "stir/IO/OutputFileFormat.h"
 #include "stir/Succeeded.h"
+#include "stir/warning.h"
 #include "stir_experimental/motion/NonRigidObjectTransformationUsingBSplines.h"
 #include "stir_experimental/motion/Transform3DObjectImageProcessor.h"
 

--- a/src/experimental/motion_utilities/remove_corrupted_sinograms.cxx
+++ b/src/experimental/motion_utilities/remove_corrupted_sinograms.cxx
@@ -37,6 +37,8 @@
 #include "stir/SegmentBySinogram.h"
 #include "stir/VectorWithOffset.h"
 #include "stir/Bin.h"
+#include "stir/warning.h"
+#include "stir/error.h"
 
 #include <vector>
 #include <algorithm>

--- a/src/experimental/motion_utilities/report_movement.cxx
+++ b/src/experimental/motion_utilities/report_movement.cxx
@@ -28,6 +28,8 @@
 #include "stir/Succeeded.h"
 #include "stir/is_null_ptr.h"
 #include "stir/CartesianCoordinate3D.h"
+#include "stir/warning.h"
+#include "stir/error.h"
 #include <algorithm>
 #include <fstream>
 

--- a/src/experimental/motion_utilities/rigid_object_transform_image.cxx
+++ b/src/experimental/motion_utilities/rigid_object_transform_image.cxx
@@ -39,6 +39,8 @@ namespace stir { // for doxygen
 #include "stir_experimental/Quaternion.h"
 #include "stir/VoxelsOnCartesianGrid.h"
 #include "stir/CPUTimer.h"
+#include "stir/warning.h"
+#include "stir/error.h"
 #include <string>
 
 #ifndef STIR_NO_NAMESPACES

--- a/src/experimental/motion_utilities/rigid_object_transform_projdata.cxx
+++ b/src/experimental/motion_utilities/rigid_object_transform_projdata.cxx
@@ -31,6 +31,7 @@ namespace stir { // for doxygen
 #include "stir_experimental/motion/transform_3d_object.h"
 #include "stir_experimental/Quaternion.h"
 #include "stir/CPUTimer.h"
+#include "stir/error.h"
 #include <string>
 
 USING_NAMESPACE_STIR

--- a/src/experimental/recon_buildblock/BinNormalisationFromML2D.cxx
+++ b/src/experimental/recon_buildblock/BinNormalisationFromML2D.cxx
@@ -27,6 +27,7 @@
 #include "stir/Bin.h"
 #include "stir/stream.h"
 #include "stir/IndexRange2D.h"
+#include "stir/warning.h"
 
 START_NAMESPACE_STIR
 

--- a/src/experimental/recon_buildblock/BinNormalisationSinogramRescaling.cxx
+++ b/src/experimental/recon_buildblock/BinNormalisationSinogramRescaling.cxx
@@ -22,6 +22,7 @@
 #include "stir/Bin.h"
 #include "stir/stream.h"
 #include "stir/Succeeded.h"
+#include "stir/warning.h"
 #include <algorithm>
 #include <fstream>
 

--- a/src/experimental/recon_buildblock/BinNormalisationUsingProfile.cxx
+++ b/src/experimental/recon_buildblock/BinNormalisationUsingProfile.cxx
@@ -17,6 +17,8 @@
 #include "stir_experimental/recon_buildblock/BinNormalisationUsingProfile.h"
 #include "stir/RelatedViewgrams.h"
 #include "stir/stream.h"
+#include "stir/warning.h"
+#include "stir/error.h"
 
 START_NAMESPACE_STIR
 

--- a/src/experimental/recon_buildblock/DataSymmetriesForDensels_PET_CartesianGrid.cxx
+++ b/src/experimental/recon_buildblock/DataSymmetriesForDensels_PET_CartesianGrid.cxx
@@ -25,6 +25,7 @@
 #include "stir/Bin.h"
 #include "stir/shared_ptr.h"
 #include "stir/round.h"
+#include "stir/error.h"
 #include <typeinfo>
 
 START_NAMESPACE_STIR

--- a/src/experimental/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMeanAndDynamicProjData.cxx
+++ b/src/experimental/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMeanAndDynamicProjData.cxx
@@ -21,6 +21,8 @@
 #include "stir/recon_buildblock/TrivialBinNormalisation.h"
 #include "stir/Succeeded.h"
 #include "stir/stream.h"
+#include "stir/warning.h"
+#include "stir/error.h"
 
 #include "stir/recon_buildblock/ProjectorByBinPair.h"
 

--- a/src/experimental/recon_buildblock/PostsmoothingForwardProjectorByBin.cxx
+++ b/src/experimental/recon_buildblock/PostsmoothingForwardProjectorByBin.cxx
@@ -18,6 +18,7 @@
 #include "stir/Viewgram.h"
 #include "stir/RelatedViewgrams.h"
 #include "stir/is_null_ptr.h"
+#include "stir/warning.h"
 #include <algorithm>
 using std::min;
 using std::max;

--- a/src/experimental/recon_buildblock/ProjMatrixByBinSinglePhoton.cxx
+++ b/src/experimental/recon_buildblock/ProjMatrixByBinSinglePhoton.cxx
@@ -22,6 +22,7 @@
 #include "stir/VoxelsOnCartesianGrid.h"
 #include "stir/ProjDataInfoCylindricalNoArcCorr.h"
 #include "stir/Coordinate3D.h"
+#include "stir/error.h"
 #include <algorithm>
 #include <math.h>
 

--- a/src/experimental/recon_buildblock/ProjMatrixByBinUsingSolidAngle.cxx
+++ b/src/experimental/recon_buildblock/ProjMatrixByBinUsingSolidAngle.cxx
@@ -23,6 +23,7 @@
 #include "stir/VoxelsOnCartesianGrid.h"
 #include "stir/ProjDataInfo.h"
 #include "stir/round.h"
+#include "stir/error.h"
 #include <algorithm>
 #include <math.h>
 

--- a/src/experimental/recon_buildblock/ProjMatrixByBinWithPositronRange.cxx
+++ b/src/experimental/recon_buildblock/ProjMatrixByBinWithPositronRange.cxx
@@ -24,6 +24,8 @@
 #include "stir/round.h"
 #include "stir/is_null_ptr.h"
 #include "stir/IndexRange.h"
+#include "stir/warning.h"
+#include "stir/error.h"
 #include <algorithm>
 #include <math.h>
 #include <boost/static_assert.hpp>

--- a/src/experimental/recon_buildblock/ProjMatrixByDenselOnCartesianGridUsingElement.cxx
+++ b/src/experimental/recon_buildblock/ProjMatrixByDenselOnCartesianGridUsingElement.cxx
@@ -19,6 +19,7 @@
 #include "stir_experimental/recon_buildblock/ProjMatrixByDenselOnCartesianGridUsingElement.h"
 #include "stir/DiscretisedDensityOnCartesianGrid.h"
 #include "stir/Bin.h"
+#include "stir/error.h"
 #include <math.h>
 
 START_NAMESPACE_STIR

--- a/src/experimental/recon_buildblock/ProjMatrixByDenselUsingRayTracing.cxx
+++ b/src/experimental/recon_buildblock/ProjMatrixByDenselUsingRayTracing.cxx
@@ -22,6 +22,8 @@
 #include "stir/VoxelsOnCartesianGrid.h"
 #include "stir/ProjDataInfo.h"
 #include "stir/ProjDataInfoCylindricalNoArcCorr.h"
+#include "stir/warning.h"
+#include "stir/error.h"
 #include <algorithm>
 #include <math.h>
 

--- a/src/experimental/recon_test/fwdtestDensel.cxx
+++ b/src/experimental/recon_test/fwdtestDensel.cxx
@@ -40,6 +40,7 @@
 #include "stir/SegmentByView.h"
 #include "stir/VoxelsOnCartesianGrid.h"
 #include "stir/CPUTimer.h"
+#include "stir/error.h"
 #include <fstream>
 
 

--- a/src/experimental/test/test_proj_data_info_LOR.cxx
+++ b/src/experimental/test/test_proj_data_info_LOR.cxx
@@ -29,6 +29,8 @@
 #include "stir/VoxelsOnCartesianGrid.h"
 #include "stir/Bin.h"
 #include "stir/stream.h"
+#include "stir/warning.h"
+#include "stir/error.h"
 #ifndef STIR_NO_NAMESPACES
 using std::cout;
 using std::endl;

--- a/src/experimental/utilities/AVWROI.cxx
+++ b/src/experimental/utilities/AVWROI.cxx
@@ -25,6 +25,7 @@ x//
 #include "stir/is_null_ptr.h"
 #include "stir/Succeeded.h"
 #include "stir/shared_ptr.h"
+#include "stir/warning.h"
 #include <iostream>
 
 USING_NAMESPACE_STIR

--- a/src/experimental/utilities/Bland_Altman_plot.cxx
+++ b/src/experimental/utilities/Bland_Altman_plot.cxx
@@ -34,6 +34,7 @@
 #include "stir/VoxelsOnCartesianGrid.h"
 #include "stir/linear_regression.h"
 #include "stir/VectorWithOffset.h"
+#include "stir/warning.h"
 #include <iostream>
 #include <iomanip>
 #include <fstream>

--- a/src/experimental/utilities/CoG.cxx
+++ b/src/experimental/utilities/CoG.cxx
@@ -41,6 +41,7 @@
 #include "stir/shared_ptr.h"
 #include "stir/CartesianCoordinate3D.h"
 #include "stir/CartesianCoordinate2D.h"
+#include "stir/warning.h"
 #include "stir/centre_of_gravity.h"
 #include <iostream>
 #include <iomanip>

--- a/src/experimental/utilities/add_ecat7_header_to_sgl.cxx
+++ b/src/experimental/utilities/add_ecat7_header_to_sgl.cxx
@@ -16,6 +16,8 @@
 
 
 #include "stir/IO/stir_ecat7.h"
+#include "stir/warning.h"
+#include "stir/error.h"
 
 #include <string>
 #include <stdio.h>

--- a/src/experimental/utilities/add_side_shields.cxx
+++ b/src/experimental/utilities/add_side_shields.cxx
@@ -22,6 +22,7 @@
 #include "stir/CartesianCoordinate3D.h"
 #include "stir/IndexRange3D.h"
 #include "stir/Succeeded.h"
+#include "stir/error.h"
 #include "stir/IO/OutputFileFormat.h"
 #include "stir/VoxelsOnCartesianGrid.h"
 #include <iostream>

--- a/src/experimental/utilities/apply_plane_rescale_factors.cxx
+++ b/src/experimental/utilities/apply_plane_rescale_factors.cxx
@@ -23,6 +23,7 @@
 #include "stir/Succeeded.h"
 #include "stir/stream.h"
 #include "stir/IO/read_from_file.h"
+#include "stir/warning.h"
 #include <fstream>
 #include <vector>
 

--- a/src/experimental/utilities/change_mhead_file_type.cxx
+++ b/src/experimental/utilities/change_mhead_file_type.cxx
@@ -15,6 +15,7 @@
 
 #include "stir/Succeeded.h"
 #include "matrix.h"
+#include "stir/warning.h"
 
 #include <iostream>
 

--- a/src/experimental/utilities/compute_gradient.cxx
+++ b/src/experimental/utilities/compute_gradient.cxx
@@ -24,7 +24,7 @@
 #include "stir/KeyParser.h"
 #include "stir/recon_buildblock/GeneralisedObjectiveFunction.h"
 #include "stir/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMean.h"
-
+#include "stir/error.h"
 
 /*
 example

--- a/src/experimental/utilities/compute_plane_rescale_factors.cxx
+++ b/src/experimental/utilities/compute_plane_rescale_factors.cxx
@@ -22,6 +22,7 @@
 #include "stir/Array.h"
 #include "stir/IO/read_from_file.h"
 #include "stir/error.h"
+#include "stir/warning.h"
 #include <fstream>
 
 #ifndef STIR_NO_NAMESPACES

--- a/src/experimental/utilities/create_normfactors3D.cxx
+++ b/src/experimental/utilities/create_normfactors3D.cxx
@@ -21,6 +21,7 @@
 #include "stir/Scanner.h"
 #include "stir/Bin.h"
 #include "stir/stream.h"
+#include "stir/warning.h"
 #include "stir/Sinogram.h"
 #include "stir/IndexRange2D.h"
 #include "stir/display.h"

--- a/src/experimental/utilities/fillwith1.cxx
+++ b/src/experimental/utilities/fillwith1.cxx
@@ -18,7 +18,7 @@
 #include "stir/ProjData.h"
 #include "stir/SegmentByView.h"
 #include "stir/Succeeded.h"
-
+#include "stir/error.h"
 #include <iostream> 
 
 

--- a/src/experimental/utilities/fillwithotherprojdata.cxx
+++ b/src/experimental/utilities/fillwithotherprojdata.cxx
@@ -19,6 +19,7 @@
 #include "stir/ProjData.h"
 #include "stir/SegmentByView.h"
 #include "stir/Succeeded.h"
+#include "stir/error.h"
 
 #include <iostream> 
 #include <fstream>

--- a/src/experimental/utilities/find_sinogram_rescaling_factors.cxx
+++ b/src/experimental/utilities/find_sinogram_rescaling_factors.cxx
@@ -22,6 +22,7 @@
 #include "stir/Succeeded.h"
 #include "stir/Sinogram.h"
 #include "stir/stream.h"
+#include "stir/warning.h"
 
 #include <fstream>
 

--- a/src/experimental/utilities/fit_cylinder.cxx
+++ b/src/experimental/utilities/fit_cylinder.cxx
@@ -18,6 +18,7 @@
 #include "stir/linear_regression.h"
 #include "stir/cross_product.h"
 #include "stir/stream.h"
+#include "stir/warning.h"
 #include <iostream>
 #include <numeric>
 #include <fstream>

--- a/src/experimental/utilities/interpolate_projdata.cxx
+++ b/src/experimental/utilities/interpolate_projdata.cxx
@@ -37,6 +37,7 @@
 #include "stir/Succeeded.h"
 #include "stir/numerics/BSplines.h"
 #include "stir/interpolate_projdata.h"
+#include "stir/error.h"
 
 using namespace stir;
 using namespace stir::BSpline;

--- a/src/experimental/utilities/inverse_SSRB.cxx
+++ b/src/experimental/utilities/inverse_SSRB.cxx
@@ -28,6 +28,7 @@ This is a utility program which uses the stir::inverse_SSRB function , in order 
 #include "stir/ProjDataInterfile.h"
 #include "stir/inverse_SSRB.h"
 #include "stir/Succeeded.h"
+#include "stir/error.h"
 #include <iostream>
 #include <string>
 #ifndef STIR_NO_NAMESPACES

--- a/src/experimental/utilities/list_TAC_ROI_values.cxx
+++ b/src/experimental/utilities/list_TAC_ROI_values.cxx
@@ -63,6 +63,7 @@
 #include "stir/DataProcessor.h"
 #include "stir/KeyParser.h"
 #include "stir/is_null_ptr.h"
+#include "stir/warning.h"
 #include <iostream>
 #include <iomanip>
 #include <fstream>

--- a/src/experimental/utilities/precompute_denominator_SPS.cxx
+++ b/src/experimental/utilities/precompute_denominator_SPS.cxx
@@ -38,7 +38,7 @@
 #include "stir/Viewgram.h"
 #include "stir/ProjDataFromStream.h"
 #include "stir/SegmentByView.h"
-
+#include "stir/warning.h"
 
 #include <fstream>
 #include <list>

--- a/src/experimental/utilities/prepare_projdata.cxx
+++ b/src/experimental/utilities/prepare_projdata.cxx
@@ -24,6 +24,7 @@
 #include "stir/is_null_ptr.h"
 #include "stir/Succeeded.h"
 #include "stir/TimeFrameDefinitions.h"
+#include "stir/warning.h"
 
 #include "stir/recon_buildblock/TrivialBinNormalisation.h"
 

--- a/src/experimental/utilities/remove_sinograms.cxx
+++ b/src/experimental/utilities/remove_sinograms.cxx
@@ -18,6 +18,7 @@
 #include "stir/SegmentBySinogram.h"
 #include "stir/ProjDataInterfile.h"
 #include "stir/Succeeded.h"
+#include "stir/error.h"
 #include <string>
 #include <algorithm>
 

--- a/src/experimental/utilities/show_ecat7_header.cxx
+++ b/src/experimental/utilities/show_ecat7_header.cxx
@@ -17,6 +17,7 @@
 #include "stir/Succeeded.h"
 #include "stir/utilities.h"
 #include "stir/IO/stir_ecat7.h"
+#include "stir/error.h"
 
 #include <iostream>
 #include <string>

--- a/src/experimental/utilities/threshold_norm_data.cxx
+++ b/src/experimental/utilities/threshold_norm_data.cxx
@@ -23,6 +23,7 @@
 #include "stir/utilities.h"
 #include "stir/shared_ptr.h"
 #include "stir/Succeeded.h"
+#include "stir/warning.h"
 
 #include <numeric>
 #include <iostream> 

--- a/src/experimental/utilities/zero_projdata_from_norm.cxx
+++ b/src/experimental/utilities/zero_projdata_from_norm.cxx
@@ -20,6 +20,7 @@
 #include "stir/SegmentByView.h"
 #include "stir/shared_ptr.h"
 #include "stir/Succeeded.h"
+#include "stir/warning.h"
 
 #include <numeric>
 #include <iostream> 

--- a/src/include/stir/Array.inl
+++ b/src/include/stir/Array.inl
@@ -23,6 +23,7 @@
 // include for min,max definitions
 #include <algorithm>
 #include "stir/assign.h"
+#include "stir/error.h"
 
 START_NAMESPACE_STIR
 

--- a/src/include/stir/DataProcessor.inl
+++ b/src/include/stir/DataProcessor.inl
@@ -18,6 +18,8 @@
     See STIR/LICENSE.txt for details
 */
 
+#include "stir/warning.h"
+
 START_NAMESPACE_STIR
 
  

--- a/src/include/stir/DynamicProjData.h
+++ b/src/include/stir/DynamicProjData.h
@@ -20,6 +20,7 @@
 #include "stir/TimeFrameDefinitions.h"
 #include "stir/SegmentByView.h"
 #include "stir/Succeeded.h"
+#include "stir/error.h"
 #include <string>
 
 START_NAMESPACE_STIR

--- a/src/include/stir/FactoryRegistry.inl
+++ b/src/include/stir/FactoryRegistry.inl
@@ -20,6 +20,8 @@
 
 #include <utility>
 #include <boost/format.hpp>
+#include "stir/warning.h"
+#include "stir/error.h"
 
 START_NAMESPACE_STIR
 

--- a/src/include/stir/IO/InputFileFormatRegistry.txx
+++ b/src/include/stir/IO/InputFileFormatRegistry.txx
@@ -23,6 +23,7 @@
 #include "stir/IO/InputFileFormatRegistry.h"
 #include "stir/IO/FileSignature.h"
 #include "stir/utilities.h" // for open_read_binary
+#include "stir/error.h"
 #include <utility> // for make_pair
 #include <typeinfo>
 

--- a/src/include/stir/IO/InputStreamFromROOTFile.h
+++ b/src/include/stir/IO/InputStreamFromROOTFile.h
@@ -26,6 +26,7 @@
 #include "stir/Succeeded.h"
 #include "stir/listmode/CListRecordROOT.h"
 #include "stir/RegisteredObject.h"
+#include "stir/error.h"
 
 // forward declaration of ROOT's TChain
 class TChain;

--- a/src/include/stir/IO/InputStreamFromROOTFileForCylindricalPET.inl
+++ b/src/include/stir/IO/InputStreamFromROOTFileForCylindricalPET.inl
@@ -16,6 +16,7 @@
   \author Kris Thielemans
   \author Robbie Twyman
 */
+#include "stir/error.h"
 
 START_NAMESPACE_STIR
 

--- a/src/include/stir/IO/InputStreamWithRecords.inl
+++ b/src/include/stir/IO/InputStreamWithRecords.inl
@@ -21,6 +21,8 @@
 #include "stir/is_null_ptr.h"
 #include "stir/shared_ptr.h"
 #include "boost/shared_array.hpp"
+#include "stir/warning.h"
+#include "stir/error.h"
 #include <fstream>
 
 START_NAMESPACE_STIR

--- a/src/include/stir/IO/InputStreamWithRecordsFromUPENNbin.inl
+++ b/src/include/stir/IO/InputStreamWithRecordsFromUPENNbin.inl
@@ -16,7 +16,7 @@
 
 
 #include "liboption.h"
-
+#include "stir/error.h"
 
 START_NAMESPACE_STIR
 

--- a/src/include/stir/IO/InputStreamWithRecordsFromUPENNtxt.inl
+++ b/src/include/stir/IO/InputStreamWithRecordsFromUPENNtxt.inl
@@ -14,6 +14,7 @@
     See STIR/LICENSE.txt for details
 */
 
+#include "stir/error.h"
 
 START_NAMESPACE_STIR
 

--- a/src/include/stir/IO/OutputFileFormat.txx
+++ b/src/include/stir/IO/OutputFileFormat.txx
@@ -20,6 +20,7 @@
 
 #include "stir/IO/OutputFileFormat.h"
 #include "stir/Succeeded.h"
+#include "stir/warning.h"
 
 START_NAMESPACE_STIR
 

--- a/src/include/stir/IO/read_data.inl
+++ b/src/include/stir/IO/read_data.inl
@@ -22,6 +22,7 @@
 #include "stir/ByteOrder.h"
 #include "stir/detail/test_if_1d.h"
 #include "stir/IO/read_data_1d.h"
+#include "stir/warning.h"
 #include <typeinfo>
 
 START_NAMESPACE_STIR

--- a/src/include/stir/IO/read_data_1d.inl
+++ b/src/include/stir/IO/read_data_1d.inl
@@ -17,6 +17,7 @@
 #include "stir/Array.h"
 #include "stir/Succeeded.h"
 #include "stir/ByteOrder.h"
+#include "stir/warning.h"
 #include <fstream>
 
 START_NAMESPACE_STIR

--- a/src/include/stir/IO/write_data.inl
+++ b/src/include/stir/IO/write_data.inl
@@ -22,6 +22,7 @@
 #include "stir/Succeeded.h"
 #include "stir/detail/test_if_1d.h"
 #include "stir/IO/write_data_1d.h"
+#include "stir/warning.h"
 #include <typeinfo>
 
 START_NAMESPACE_STIR

--- a/src/include/stir/IO/write_data_1d.inl
+++ b/src/include/stir/IO/write_data_1d.inl
@@ -17,6 +17,7 @@
 #include "stir/Array.h"
 #include "stir/Succeeded.h"
 #include "stir/ByteOrder.h"
+#include "stir/warning.h"
 #include <fstream>
 
 START_NAMESPACE_STIR

--- a/src/include/stir/ImagingModality.h
+++ b/src/include/stir/ImagingModality.h
@@ -19,6 +19,7 @@
 #define __stir_ImagingModality_H__
 
 #include "stir/interfile_keyword_functions.h"
+#include "stir/warning.h"
 #include <string>
 
 namespace stir {

--- a/src/include/stir/ML_norm.h
+++ b/src/include/stir/ML_norm.h
@@ -49,6 +49,7 @@
 #include "stir/ProjDataInfoBlocksOnCylindricalNoArcCorr.h"
 #include "stir/IndexRange2D.h"
 #include "stir/Sinogram.h"
+#include "stir/warning.h"
 #include <iostream>
 
 START_NAMESPACE_STIR

--- a/src/include/stir/MultipleDataSetHeader.inl
+++ b/src/include/stir/MultipleDataSetHeader.inl
@@ -16,6 +16,7 @@
 */
 
 #include <fstream>
+#include "stir/error.h"
 
 START_NAMESPACE_STIR
 

--- a/src/include/stir/MultipleProjData.h
+++ b/src/include/stir/MultipleProjData.h
@@ -23,6 +23,7 @@
 #include "stir/Array.h"
 #include "stir/is_null_ptr.h"
 #include "stir/copy_fill.h"
+#include "stir/error.h"
 //#include "stir/Scanner.h"
 #include <vector>
 

--- a/src/include/stir/NumericVectorWithOffset.inl
+++ b/src/include/stir/NumericVectorWithOffset.inl
@@ -23,6 +23,7 @@
 
 // include for min,max definitions
 #include <algorithm>
+#include "stir/error.h"
 
 START_NAMESPACE_STIR
 

--- a/src/include/stir/ProjDataInfoCylindrical.inl
+++ b/src/include/stir/ProjDataInfoCylindrical.inl
@@ -30,6 +30,7 @@
 #include "stir/Bin.h"
 #include "stir/Succeeded.h"
 #include "stir/is_null_ptr.h"
+#include "stir/error.h"
 #include <algorithm>
 
 START_NAMESPACE_STIR

--- a/src/include/stir/ProjDataInfoGenericNoArcCorr.inl
+++ b/src/include/stir/ProjDataInfoGenericNoArcCorr.inl
@@ -26,6 +26,7 @@
 #include "stir/Bin.h"
 #include "stir/Succeeded.h"
 #include "stir/LORCoordinates.h"
+#include "stir/error.h"
 #include <math.h>
 
 START_NAMESPACE_STIR

--- a/src/include/stir/Shape/DiscretisedShape3D.h
+++ b/src/include/stir/Shape/DiscretisedShape3D.h
@@ -22,6 +22,7 @@
 #include "stir/RegisteredParsingObject.h"
 #include "stir/Shape/Shape3D.h"
 #include "stir/shared_ptr.h"
+#include "stir/error.h"
 
 START_NAMESPACE_STIR
 

--- a/src/include/stir/VectorWithOffset.inl
+++ b/src/include/stir/VectorWithOffset.inl
@@ -24,6 +24,7 @@
 #include <algorithm>
 #include <stdexcept>
 #include "thresholding.h"
+#include "stir/error.h"
 
 START_NAMESPACE_STIR
 

--- a/src/include/stir/common.h
+++ b/src/include/stir/common.h
@@ -289,11 +289,10 @@ START_NAMESPACE_STIR
 template <class NUMBER> 
 inline NUMBER square(const NUMBER &x) { return x*x; }
 
-
 END_NAMESPACE_STIR
 
-// include these such that we don't have to include them all over the place
-#include "stir/error.h"
-#include "stir/warning.h"
+// // include these such that we don't have to include them all over the place
+// #include "stir/error.h"
+// #include "stir/warning.h"
 
 #endif 

--- a/src/include/stir/common.h
+++ b/src/include/stir/common.h
@@ -291,8 +291,4 @@ inline NUMBER square(const NUMBER &x) { return x*x; }
 
 END_NAMESPACE_STIR
 
-// // include these such that we don't have to include them all over the place
-// #include "stir/error.h"
-// #include "stir/warning.h"
-
 #endif 

--- a/src/include/stir/error.h
+++ b/src/include/stir/error.h
@@ -23,6 +23,8 @@
 #include <iostream>
 #include <sstream>
 
+#include "TextWriter.h"
+
 START_NAMESPACE_STIR
 
 //! Print error with format string a la \c printf and throw exception
@@ -77,7 +79,7 @@ error(const STRING& string)
   sstr << "\nERROR: "
 	    << string
 	    << std::endl;
-  std::cerr << sstr.str();
+  writeText(sstr.str().c_str(), ERROR_CHANNEL);
   throw std::runtime_error(sstr.str());
 }
 

--- a/src/include/stir/error.h
+++ b/src/include/stir/error.h
@@ -55,7 +55,7 @@ error(const char *const s, ...);
   std::ostream::operator\<\< would work.
 
   This function currently first writes a newline, then \c ERROR:, then \c string
-  and then another newline to std::cerr. Then it throws an exception (of type string).
+  and then another newline to std::cerr. Then it throws an exception.
 
   \todo At a later stage, it will also write to a log-file.
 
@@ -78,7 +78,7 @@ error(const STRING& string)
 	    << string
 	    << std::endl;
   std::cerr << sstr.str();
-  throw sstr.str();
+  throw std::runtime_error(sstr.str());
 }
 
 END_NAMESPACE_STIR

--- a/src/include/stir/find_fwhm_in_image.inl
+++ b/src/include/stir/find_fwhm_in_image.inl
@@ -19,6 +19,7 @@
 
  */
 #include <algorithm>
+#include "stir/warning.h"
 
 START_NAMESPACE_STIR
                           

--- a/src/include/stir/listmode/CListRecordGEHDF5.h
+++ b/src/include/stir/listmode/CListRecordGEHDF5.h
@@ -25,6 +25,7 @@
 #include "stir/ByteOrderDefine.h"
 #include <boost/static_assert.hpp>
 #include <boost/cstdint.hpp>
+#include "stir/error.h"
 #include <iostream>
 
 START_NAMESPACE_STIR

--- a/src/include/stir/listmode/CListRecordROOT.h
+++ b/src/include/stir/listmode/CListRecordROOT.h
@@ -26,6 +26,7 @@
 #include "boost/static_assert.hpp"
 #include "stir/DetectionPositionPair.h"
 #include <boost/cstdint.hpp>
+#include "stir/warning.h"
 
 START_NAMESPACE_STIR
 

--- a/src/include/stir/listmode/CListRecordSAFIR.inl
+++ b/src/include/stir/listmode/CListRecordSAFIR.inl
@@ -45,6 +45,7 @@
 #include "stir/ProjDataInfoBlocksOnCylindricalNoArcCorr.h"
 #include "stir/ProjDataInfoGenericNoArcCorr.h"
 #include "stir/CartesianCoordinate3D.h"
+#include "stir/error.h"
 
 START_NAMESPACE_STIR
 

--- a/src/include/stir/listmode/ListModeData.h
+++ b/src/include/stir/listmode/ListModeData.h
@@ -27,6 +27,7 @@
 #include "stir/ExamData.h"
 #include "stir/RegisteredParsingObject.h"
 #include "stir/listmode/ListRecord.h"
+#include "stir/error.h"
 # ifdef BOOST_NO_STDC_NAMESPACE
 namespace std { using ::time_t; }
 #endif

--- a/src/include/stir/listmode/ListModeData_dummy.h
+++ b/src/include/stir/listmode/ListModeData_dummy.h
@@ -17,6 +17,8 @@
 #ifndef __stir_listmode_ListModeData_dummy_H__
 #define __stir_listmode_ListModeData_dummy_H__
 
+#include "stir/error.h"
+
 START_NAMESPACE_STIR
 /*!
   \brief A class to trick the Objective function that we have list mode data,

--- a/src/include/stir/listmode/NiftyPET_listmode/LmToProjDataNiftyPET.h
+++ b/src/include/stir/listmode/NiftyPET_listmode/LmToProjDataNiftyPET.h
@@ -30,6 +30,7 @@
 */
 
 #include "stir/listmode/LmToProjDataAbstract.h"
+#include "stir/error.h"
 
 START_NAMESPACE_STIR
 

--- a/src/include/stir/modelling/ModelMatrix.inl
+++ b/src/include/stir/modelling/ModelMatrix.inl
@@ -18,6 +18,8 @@
 */
 
 #include <algorithm>
+#include "stir/warning.h"
+#include "stir/error.h"
 START_NAMESPACE_STIR
 
 //! default constructor

--- a/src/include/stir/modelling/PlasmaData.inl
+++ b/src/include/stir/modelling/PlasmaData.inl
@@ -18,6 +18,8 @@
 */
 #include "stir/decay_correction_factor.h"
 #include "stir/numerics/integrate_discrete_function.h"
+#include "stir/warning.h"
+#include "stir/error.h"
 #include <functional>
 
 START_NAMESPACE_STIR

--- a/src/include/stir/numerics/BSplines_weights.inl
+++ b/src/include/stir/numerics/BSplines_weights.inl
@@ -19,6 +19,7 @@
 
 */
 
+#include "stir/error.h"
 
 START_NAMESPACE_STIR
 namespace BSpline 

--- a/src/include/stir/numerics/integrate_discrete_function.inl
+++ b/src/include/stir/numerics/integrate_discrete_function.inl
@@ -17,6 +17,8 @@
 
 */
 
+#include "stir/error.h"
+
 START_NAMESPACE_STIR
 
 template <typename elemT>

--- a/src/include/stir/numerics/max_eigenvector.h
+++ b/src/include/stir/numerics/max_eigenvector.h
@@ -21,6 +21,7 @@
 #include "stir/numerics/norm.h"
 #include "stir/more_algorithms.h"
 #include "stir/Succeeded.h"
+#include "stir/error.h"
 
 START_NAMESPACE_STIR
 

--- a/src/include/stir/numerics/sampling_functions.inl
+++ b/src/include/stir/numerics/sampling_functions.inl
@@ -17,7 +17,7 @@ This file is part of STIR.
   \brief implementation of stir::sample_function_on_regular_grid and
          stir::sample_function_using_index_converter
 */
-
+#include "stir/warning.h"
 START_NAMESPACE_STIR
 
 template <class FunctionType, class elemT, class positionT>

--- a/src/include/stir/recon_buildblock/DataSymmetriesForBins_PET_CartesianGrid.inl
+++ b/src/include/stir/recon_buildblock/DataSymmetriesForBins_PET_CartesianGrid.inl
@@ -29,6 +29,8 @@
 #include "stir/recon_buildblock/SymmetryOperations_PET_CartesianGrid.h"
 #include "stir/ProjDataInfoBlocksOnCylindrical.h"
 #include "stir/ProjDataInfoGeneric.h"
+#include "stir/warning.h"
+#include "stir/error.h"
 
 START_NAMESPACE_STIR
 

--- a/src/include/stir/recon_buildblock/PoissonLogLikelihoodWithLinearKineticModelAndDynamicProjectionData.txx
+++ b/src/include/stir/recon_buildblock/PoissonLogLikelihoodWithLinearKineticModelAndDynamicProjectionData.txx
@@ -28,6 +28,8 @@
 #include "stir/Succeeded.h"
 #include "stir/recon_buildblock/ProjectorByBinPair.h"
 #include "stir/info.h"
+#include "stir/warning.h"
+#include "stir/error.h"
 
 // include the following to set defaults
 #ifndef USE_PMRT

--- a/src/include/stir/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMeanAndGatedProjDataWithMotion.txx
+++ b/src/include/stir/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMeanAndGatedProjDataWithMotion.txx
@@ -24,6 +24,8 @@
 #include "stir/Succeeded.h"
 #include "stir/recon_buildblock/ProjectorByBinPair.h"
 #include "stir/info.h"
+#include "stir/warning.h"
+#include "stir/error.h"
 #include "stir/is_null_ptr.h"
 
 // include the following to set defaults

--- a/src/include/stir/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMeanAndListModeDataWithProjMatrixByBin.h
+++ b/src/include/stir/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMeanAndListModeDataWithProjMatrixByBin.h
@@ -33,6 +33,7 @@
 #include "stir/ExamInfo.h"
 #include "stir/deprecated.h"
 #include "stir/recon_buildblock/distributable.h"
+#include "stir/error.h"
 START_NAMESPACE_STIR
 
 /*!

--- a/src/include/stir/recon_buildblock/ProjDataRebinning.h
+++ b/src/include/stir/recon_buildblock/ProjDataRebinning.h
@@ -28,6 +28,7 @@
 #include "stir/ParsingObject.h"
 #include "stir/ProjData.h"
 #include "stir/shared_ptr.h"
+#include "stir/error.h"
 #include <string>
 
 START_NAMESPACE_STIR

--- a/src/include/stir/recon_buildblock/SumOfGeneralisedObjectiveFunctions.inl
+++ b/src/include/stir/recon_buildblock/SumOfGeneralisedObjectiveFunctions.inl
@@ -17,6 +17,7 @@
 
 */
 #include "stir/Succeeded.h"
+#include "stir/error.h"
 #include <algorithm>
 
 START_NAMESPACE_STIR

--- a/src/include/stir/recon_buildblock/test/PoissonLLReconstructionTests.h
+++ b/src/include/stir/recon_buildblock/test/PoissonLLReconstructionTests.h
@@ -16,6 +16,7 @@
 #include "stir/recon_buildblock/ProjectorByBinPairUsingProjMatrixByBin.h"
 #include "stir/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMeanAndProjData.h"
 #include "stir/KeyParser.h"
+#include "stir/error.h"
 
 START_NAMESPACE_STIR
 

--- a/src/include/stir/recon_buildblock/test/ReconstructionTests.h
+++ b/src/include/stir/recon_buildblock/test/ReconstructionTests.h
@@ -22,6 +22,7 @@
 #include "stir/ArrayFunction.h"
 #include "stir/SeparableGaussianImageFilter.h"
 #include "stir/Verbosity.h"
+#include "stir/error.h"
 
 START_NAMESPACE_STIR
 

--- a/src/include/stir/stream.inl
+++ b/src/include/stir/stream.inl
@@ -27,6 +27,7 @@
 */
 
 #include <algorithm>
+#include "stir/warning.h"
 
 START_NAMESPACE_STIR
 

--- a/src/include/stir/utilities.inl
+++ b/src/include/stir/utilities.inl
@@ -16,6 +16,7 @@
     See STIR/LICENSE.txt for details
 */
 #include <iostream>
+#include "stir/error.h"
 #ifdef BOOST_NO_STRINGSTREAM
 #include <strstream.h>
 #else

--- a/src/include/stir/warning.h
+++ b/src/include/stir/warning.h
@@ -18,7 +18,10 @@
 
 */
 #include "stir/common.h"
+#include "stir/Verbosity.h"
 #include <iostream>
+
+#include "TextWriter.h"
 
 START_NAMESPACE_STIR
 
@@ -62,11 +65,15 @@ warning(const char *const s, ...);
 
 template <class STRING>
 inline void
-warning(const STRING& string)
+warning(const STRING& string, const int verbosity_level = 1)
 {
-  std::cerr << "\nWARNING: "
-	    << string
-	    << std::endl;
+  if (Verbosity::get() >= verbosity_level) {
+    std::stringstream sstr;
+    sstr << "\nWARNING: "
+        << string
+        << std::endl;
+    writeText(sstr.str().c_str(), WARNING_CHANNEL);
+  }
 }
 END_NAMESPACE_STIR
 #endif

--- a/src/include/stir_experimental/modelling/BloodFrameData.inl
+++ b/src/include/stir_experimental/modelling/BloodFrameData.inl
@@ -16,6 +16,8 @@
   \author Charalampos Tsoumpas
 
 */
+#include "stir/warning.h"
+#include "stir/error.h"
 
 START_NAMESPACE_STIR
 

--- a/src/include/stir_experimental/motion/bin_interpolate.h
+++ b/src/include/stir_experimental/motion/bin_interpolate.h
@@ -22,6 +22,7 @@
 #include "stir/Coordinate4D.h"
 #include "stir/LORCoordinates.h"
 #include "stir/DetectionPositionPair.h"
+#include "stir/error.h"
 
 START_NAMESPACE_STIR
 

--- a/src/iterative/KOSMAPOSL/KOSMAPOSLReconstruction.cxx
+++ b/src/iterative/KOSMAPOSL/KOSMAPOSLReconstruction.cxx
@@ -44,6 +44,8 @@
 #include "stir/ViewSegmentNumbers.h"
 #include "stir/stream.h"
 #include "stir/info.h"
+#include "stir/error.h"
+#include "stir/warning.h"
 #include "stir/VoxelsOnCartesianGrid.h"
 
 //#include "stir/modelling/ParametricDiscretisedDensity.h"

--- a/src/iterative/OSMAPOSL/OSMAPOSLReconstruction.cxx
+++ b/src/iterative/OSMAPOSL/OSMAPOSLReconstruction.cxx
@@ -43,6 +43,7 @@
 #include "stir/DataSymmetriesForViewSegmentNumbers.h"
 #include "stir/ViewSegmentNumbers.h"
 #include "stir/info.h"
+#include "stir/error.h"
 
 #include "stir/modelling/ParametricDiscretisedDensity.h"
 #include "stir/modelling/KineticParameters.h"

--- a/src/iterative/OSSPS/OSSPSReconstruction.cxx
+++ b/src/iterative/OSSPS/OSSPSReconstruction.cxx
@@ -31,6 +31,8 @@
 #include "stir/utilities.h"
 #include "stir/IO/read_from_file.h"
 #include "stir/info.h"
+#include "stir/warning.h"
+#include "stir/error.h"
 
 #include <iostream>
 #include <memory>

--- a/src/listmode_buildblock/CListModeDataECAT.cxx
+++ b/src/listmode_buildblock/CListModeDataECAT.cxx
@@ -20,6 +20,8 @@
 #include "stir/listmode/CListRecordECAT966.h"
 #include "stir/listmode/CListRecordECAT962.h"
 #include "stir/info.h"
+#include "stir/warning.h"
+#include "stir/error.h"
 #include <boost/format.hpp>
 #ifdef HAVE_LLN_MATRIX
 #include "stir/IO/stir_ecat7.h"

--- a/src/listmode_buildblock/CListModeDataGEHDF5.cxx
+++ b/src/listmode_buildblock/CListModeDataGEHDF5.cxx
@@ -24,6 +24,7 @@
 #include "stir/is_null_ptr.h"
 #include "stir/IO/GEHDF5Wrapper.h"
 #include "stir/Scanner.h"
+#include "stir/error.h"
 #include <boost/format.hpp>
 #include <iostream>
 #include <fstream>

--- a/src/listmode_buildblock/CListModeDataPENN.cxx
+++ b/src/listmode_buildblock/CListModeDataPENN.cxx
@@ -18,6 +18,7 @@
 #include "stir/listmode/CListModeDataPENN.h"
 #include "stir/listmode/CListRecordPENN.h"
 #include "stir/FilePath.h"
+#include "stir/error.h"
 
 START_NAMESPACE_STIR
 

--- a/src/listmode_buildblock/CListModeDataSAFIR.cxx
+++ b/src/listmode_buildblock/CListModeDataSAFIR.cxx
@@ -35,6 +35,7 @@ Coincidence LM Data Class for SAFIR: Implementation
 #include "stir/ExamInfo.h"
 #include "stir/Succeeded.h"
 #include "stir/info.h"
+#include "stir/error.h"
 
 //#include "boost/static_assert.hpp"
 

--- a/src/listmode_buildblock/CListRecordPENN.cxx
+++ b/src/listmode_buildblock/CListRecordPENN.cxx
@@ -15,7 +15,7 @@
 */
 
 #include "stir/listmode/CListRecordPENN.h"
-
+#include "stir/error.h"
 
 START_NAMESPACE_STIR
 

--- a/src/listmode_buildblock/CListRecordROOT.cxx
+++ b/src/listmode_buildblock/CListRecordROOT.cxx
@@ -18,6 +18,7 @@
 */
 
 #include "stir/listmode/CListRecordROOT.h"
+#include "stir/error.h"
 
 START_NAMESPACE_STIR
 

--- a/src/listmode_buildblock/ListModeData.cxx
+++ b/src/listmode_buildblock/ListModeData.cxx
@@ -20,6 +20,7 @@
 #include "stir/listmode/ListModeData.h"
 #include "stir/ExamInfo.h"
 #include "stir/is_null_ptr.h"
+#include "stir/error.h"
 
 START_NAMESPACE_STIR
 

--- a/src/listmode_buildblock/LmToProjData.cxx
+++ b/src/listmode_buildblock/LmToProjData.cxx
@@ -75,6 +75,8 @@ FRAME_BASED_DT_CORR:
 #include "stir/CPUTimer.h"
 #include "stir/recon_buildblock/TrivialBinNormalisation.h"
 #include "stir/is_null_ptr.h"
+#include "stir/warning.h"
+#include "stir/error.h"
 
 #include <fstream>
 #include <iostream>

--- a/src/listmode_buildblock/LmToProjDataBootstrap.cxx
+++ b/src/listmode_buildblock/LmToProjDataBootstrap.cxx
@@ -25,6 +25,8 @@
 #include "stir/listmode/ListRecord.h"
 #include "stir/Succeeded.h"
 #include "stir/info.h"
+#include "stir/error.h"
+#include "stir/warning.h"
 #include <iostream>
 #include <algorithm>
 

--- a/src/listmode_buildblock/LmToProjDataWithRandomRejection.cxx
+++ b/src/listmode_buildblock/LmToProjDataWithRandomRejection.cxx
@@ -24,6 +24,8 @@
 #include "stir/listmode/LmToProjDataWithRandomRejection.h"
 #include "stir/listmode/ListRecord.h"
 #include "stir/Succeeded.h"
+#include "stir/warning.h"
+#include "stir/error.h"
 #include <iostream>
 #include <algorithm>
 

--- a/src/listmode_utilities/add_ecat7_header_to_sgl.cxx
+++ b/src/listmode_utilities/add_ecat7_header_to_sgl.cxx
@@ -20,6 +20,8 @@
 
 
 #include "stir/IO/stir_ecat7.h"
+#include "stir/warning.h"
+#include "stir/error.h"
 
 #include <string>
 #include <stdio.h>

--- a/src/listmode_utilities/conv_NiftyPET_stir.cxx
+++ b/src/listmode_utilities/conv_NiftyPET_stir.cxx
@@ -22,6 +22,7 @@
 #include "stir/recon_buildblock/NiftyPET_projector/NiftyPETHelper.h"
 #include "stir/is_null_ptr.h"
 #include "stir/ProjDataInMemory.h"
+#include "stir/error.h"
 
 USING_NAMESPACE_STIR
 

--- a/src/listmode_utilities/list_lm_countrates.cxx
+++ b/src/listmode_utilities/list_lm_countrates.cxx
@@ -26,6 +26,7 @@
 #include "stir/Succeeded.h"
 #include "stir/utilities.h"
 #include "stir/IO/read_from_file.h"
+#include "stir/warning.h"
 #include <fstream>
 #include <iostream>
 #include <iomanip>

--- a/src/listmode_utilities/list_lm_info.cxx
+++ b/src/listmode_utilities/list_lm_info.cxx
@@ -28,6 +28,7 @@
 #include "stir/ProjDataInfo.h"
 #include "stir/is_null_ptr.h"
 #include "stir/IO/read_from_file.h"
+#include "stir/warning.h"
 #include <iostream> 
 #include <string>
 

--- a/src/listmode_utilities/lm_fansums.cxx
+++ b/src/listmode_utilities/lm_fansums.cxx
@@ -33,6 +33,7 @@
 #include "stir/stream.h"
 #include "stir/CPUTimer.h"
 #include "stir/IO/read_from_file.h"
+#include "stir/error.h"
 
 #include "stir/ProjDataInfoCylindricalNoArcCorr.h"
 #include <fstream>

--- a/src/listmode_utilities/rebin_sgl_file.cxx
+++ b/src/listmode_utilities/rebin_sgl_file.cxx
@@ -21,6 +21,7 @@
 
 #include "stir/data/SinglesRatesFromSglFile.h"
 #include "stir/TimeFrameDefinitions.h"
+#include "stir/error.h"
 
 #include <string>
 #include <fstream>

--- a/src/listmode_utilities/scan_sgl_file.cxx
+++ b/src/listmode_utilities/scan_sgl_file.cxx
@@ -17,6 +17,7 @@
 
 
 #include "stir/data/SinglesRatesFromSglFile.h"
+#include "stir/error.h"
 
 #include <string>
 #include <fstream>

--- a/src/modelling_buildblock/ParametricDiscretisedDensity.cxx
+++ b/src/modelling_buildblock/ParametricDiscretisedDensity.cxx
@@ -25,6 +25,7 @@
 #include "boost/lambda/lambda.hpp"
 #include "stir/DynamicDiscretisedDensity.h"
 #include "stir/IO/read_from_file.h"
+#include "stir/error.h"
 #include <iostream>
 
 START_NAMESPACE_STIR

--- a/src/modelling_buildblock/PatlakPlot.cxx
+++ b/src/modelling_buildblock/PatlakPlot.cxx
@@ -20,6 +20,8 @@
 
 #include "stir/modelling/PatlakPlot.h"
 #include "stir/linear_regression.h"
+#include "stir/warning.h"
+#include "stir/error.h"
 
 START_NAMESPACE_STIR
 

--- a/src/modelling_utilities/extract_single_images_from_parametric_image.cxx
+++ b/src/modelling_utilities/extract_single_images_from_parametric_image.cxx
@@ -47,6 +47,7 @@
 #include "stir/VoxelsOnCartesianGrid.h"
 #include "stir/IO/OutputFileFormat.h"
 #include "stir/Succeeded.h"
+#include "stir/error.h"
 
 int main(int argc, char *argv[])
 {

--- a/src/modelling_utilities/get_dynamic_images_from_parametric_images.cxx
+++ b/src/modelling_utilities/get_dynamic_images_from_parametric_images.cxx
@@ -50,6 +50,7 @@
 #include "stir/IO/OutputFileFormat.h"
 #include "stir/IO/read_from_file.h"
 #include "stir/is_null_ptr.h"
+#include "stir/warning.h"
 #include <string>
 #include <fstream>
 #include <iostream>

--- a/src/modelling_utilities/make_parametric_image_from_components.cxx
+++ b/src/modelling_utilities/make_parametric_image_from_components.cxx
@@ -31,6 +31,7 @@
 #include "stir/is_null_ptr.h"
 #include "stir/IO/OutputFileFormat.h"
 #include "stir/Succeeded.h"
+#include "stir/error.h"
 
 #include "stir/ProjDataInfo.h"
 

--- a/src/numerics_buildblock/determinant.cxx
+++ b/src/numerics_buildblock/determinant.cxx
@@ -21,6 +21,7 @@
 #include "stir/numerics/determinant.h"
 #include <complex>
 #include "stir/Array_complex_numbers.h"
+#include "stir/error.h"
 
 START_NAMESPACE_STIR
 

--- a/src/numerics_buildblock/fourier.cxx
+++ b/src/numerics_buildblock/fourier.cxx
@@ -18,6 +18,7 @@
 #include "stir/round.h"
 #include "stir/modulo.h"
 #include "stir/array_index_functions.h"
+#include "stir/error.h"
 START_NAMESPACE_STIR
 
 

--- a/src/recon_buildblock/AnalyticReconstruction.cxx
+++ b/src/recon_buildblock/AnalyticReconstruction.cxx
@@ -27,6 +27,8 @@
 #include "stir/Succeeded.h"
 #include "stir/is_null_ptr.h"
 #include "stir/info.h"
+#include "stir/warning.h"
+#include "stir/error.h"
 #include <iostream>
 #include "stir/IO/OutputFileFormat.h"
 

--- a/src/recon_buildblock/BackProjectorByBin.cxx
+++ b/src/recon_buildblock/BackProjectorByBin.cxx
@@ -29,6 +29,7 @@
 #include "stir/ProjData.h"
 #include "stir/DiscretisedDensity.h"
 #include "stir/info.h"
+#include "stir/error.h"
 #include "stir/is_null_ptr.h"
 #include "stir/DataProcessor.h"
 #include <vector>

--- a/src/recon_buildblock/BackProjectorByBinUsingInterpolation.cxx
+++ b/src/recon_buildblock/BackProjectorByBinUsingInterpolation.cxx
@@ -32,6 +32,7 @@
 #include "stir/round.h"
 #include "stir/shared_ptr.h"
 #include "stir/zoom.h"
+#include "stir/error.h"
 #include <memory>
 #include <math.h>
 

--- a/src/recon_buildblock/BackProjectorByBinUsingInterpolation_3DCho.cxx
+++ b/src/recon_buildblock/BackProjectorByBinUsingInterpolation_3DCho.cxx
@@ -77,6 +77,8 @@
 #include "stir/recon_buildblock/BackProjectorByBinUsingInterpolation.h"
 #include "stir/round.h"
 #include "stir/Succeeded.h"
+#include "stir/warning.h"
+#include "stir/error.h"
 #include <math.h>
 
 #include <algorithm>

--- a/src/recon_buildblock/BackProjectorByBinUsingProjMatrixByBin.cxx
+++ b/src/recon_buildblock/BackProjectorByBinUsingProjMatrixByBin.cxx
@@ -35,6 +35,8 @@
 #include "stir/Viewgram.h"
 #include "stir/RelatedViewgrams.h"
 #include "stir/is_null_ptr.h"
+#include "stir/warning.h"
+#include "stir/error.h"
 
 using std::vector;
 

--- a/src/recon_buildblock/BackProjectorByBinUsingSquareProjMatrixByBin.cxx
+++ b/src/recon_buildblock/BackProjectorByBinUsingSquareProjMatrixByBin.cxx
@@ -29,6 +29,7 @@
 #include "stir/BasicCoordinate.h"
 #include "stir/VoxelsOnCartesianGrid.h"
 #include "stir/is_null_ptr.h"
+#include "stir/error.h"
 
 START_NAMESPACE_STIR
 

--- a/src/recon_buildblock/BinNormalisationFromAttenuationImage.cxx
+++ b/src/recon_buildblock/BinNormalisationFromAttenuationImage.cxx
@@ -25,6 +25,8 @@
 #include "stir/Succeeded.h"
 #include "stir/is_null_ptr.h"
 #include "stir/IO/read_from_file.h"
+#include "stir/warning.h"
+#include "stir/error.h"
 #include <boost/format.hpp>
 
 START_NAMESPACE_STIR

--- a/src/recon_buildblock/BinNormalisationFromECAT7.cxx
+++ b/src/recon_buildblock/BinNormalisationFromECAT7.cxx
@@ -41,6 +41,8 @@
 #include "stir/Bin.h"
 #include "stir/display.h"
 #include "stir/is_null_ptr.h"
+#include "stir/warning.h"
+#include "stir/error.h"
 #include <algorithm>
 #include <fstream>
 

--- a/src/recon_buildblock/BinNormalisationFromECAT8.cxx
+++ b/src/recon_buildblock/BinNormalisationFromECAT8.cxx
@@ -39,6 +39,8 @@
 #include "stir/IO/InterfileHeader.h"
 #include "stir/ByteOrder.h"
 #include "stir/is_null_ptr.h"
+#include "stir/warning.h"
+#include "stir/error.h"
 #include <algorithm>
 #include <fstream>
 #include <cctype>

--- a/src/recon_buildblock/BinNormalisationFromGEHDF5.cxx
+++ b/src/recon_buildblock/BinNormalisationFromGEHDF5.cxx
@@ -44,6 +44,8 @@
 #include "stir/ByteOrder.h"
 #include "stir/is_null_ptr.h"
 #include "stir/modulo.h"
+#include "stir/warning.h"
+#include "stir/error.h"
 #include <algorithm>
 #include <fstream>
 #include <cctype>

--- a/src/recon_buildblock/BinNormalisationSPECT.cxx
+++ b/src/recon_buildblock/BinNormalisationSPECT.cxx
@@ -31,6 +31,7 @@
 #include "stir/IndexRange.h"
 #include "stir/Bin.h"
 #include "stir/info.h"
+#include "stir/error.h"
 #include "stir/display.h"
 #include "stir/is_null_ptr.h"
 #include <algorithm>

--- a/src/recon_buildblock/BinNormalisationWithCalibration.cxx
+++ b/src/recon_buildblock/BinNormalisationWithCalibration.cxx
@@ -23,6 +23,7 @@
 #include "stir/recon_buildblock/BinNormalisationWithCalibration.h"
 #include "stir/Succeeded.h"
 #include "stir/warning.h"
+#include "stir/error.h"
 
 START_NAMESPACE_STIR
 

--- a/src/recon_buildblock/ChainedBinNormalisation.cxx
+++ b/src/recon_buildblock/ChainedBinNormalisation.cxx
@@ -21,6 +21,7 @@
 #include "stir/recon_buildblock/ChainedBinNormalisation.h"
 #include "stir/is_null_ptr.h"
 #include "stir/Succeeded.h"
+#include "stir/error.h"
 
 START_NAMESPACE_STIR
 

--- a/src/recon_buildblock/DataSymmetriesForBins_PET_CartesianGrid.cxx
+++ b/src/recon_buildblock/DataSymmetriesForBins_PET_CartesianGrid.cxx
@@ -35,6 +35,8 @@
 #include <boost/format.hpp>
 #include "stir/ProjDataInfoBlocksOnCylindrical.h"
 #include "stir/ProjDataInfoGeneric.h"
+#include "stir/warning.h"
+#include "stir/error.h"
 
 using std::min;
 using std::max;

--- a/src/recon_buildblock/DistributedCachingInformation.cxx
+++ b/src/recon_buildblock/DistributedCachingInformation.cxx
@@ -22,6 +22,7 @@
 
 #include "stir/recon_buildblock/DistributedCachingInformation.h"
 #include "stir/recon_buildblock/distributed_functions.h"
+#include "stir/error.h"
 
 START_NAMESPACE_STIR
 

--- a/src/recon_buildblock/FilterRootPrior.cxx
+++ b/src/recon_buildblock/FilterRootPrior.cxx
@@ -23,6 +23,7 @@
 #include "stir/modelling/KineticParameters.h"
 #include "stir/DataProcessor.h"
 #include "stir/is_null_ptr.h"
+#include "stir/warning.h"
 
 START_NAMESPACE_STIR
 

--- a/src/recon_buildblock/ForwardProjectorByBin.cxx
+++ b/src/recon_buildblock/ForwardProjectorByBin.cxx
@@ -34,6 +34,7 @@
 #include "stir/Succeeded.h"
 #include "stir/info.h"
 #include "stir/error.h"
+#include "stir/warning.h"
 #include "stir/DataProcessor.h"
 #include "stir/is_null_ptr.h"
 #include <boost/format.hpp>

--- a/src/recon_buildblock/ForwardProjectorByBinUsingProjMatrixByBin.cxx
+++ b/src/recon_buildblock/ForwardProjectorByBinUsingProjMatrixByBin.cxx
@@ -27,6 +27,8 @@
 #include "stir/RelatedViewgrams.h"
 #include "stir/IndexRange2D.h"
 #include "stir/is_null_ptr.h"
+#include "stir/warning.h"
+#include "stir/error.h"
 #include <algorithm>
 #include <vector>
 #include <list>

--- a/src/recon_buildblock/ForwardProjectorByBinUsingRayTracing.cxx
+++ b/src/recon_buildblock/ForwardProjectorByBinUsingRayTracing.cxx
@@ -61,6 +61,8 @@
 #include "stir/IndexRange4D.h"
 #include "stir/Array.h"
 #include "stir/round.h"
+#include "stir/warning.h"
+#include "stir/error.h"
 
 #include <algorithm>
 using std::min;

--- a/src/recon_buildblock/FourierRebinning.cxx
+++ b/src/recon_buildblock/FourierRebinning.cxx
@@ -43,6 +43,8 @@
 #include "stir/numerics/fourier.h"
 #include "stir/interpolate.h"
 #include "stir/info.h"
+#include "stir/warning.h"
+#include "stir/error.h"
 
 #define POSITIVE_Z_SHIFT -1
 #define NEGATIVE_Z_SHIFT 1

--- a/src/recon_buildblock/GeneralisedObjectiveFunction.cxx
+++ b/src/recon_buildblock/GeneralisedObjectiveFunction.cxx
@@ -24,6 +24,8 @@
 #include "stir/Succeeded.h"
 #include "stir/modelling/ParametricDiscretisedDensity.h"
 #include "stir/modelling/KineticParameters.h"
+#include "stir/warning.h"
+#include "stir/error.h"
 
 using std::string;
 

--- a/src/recon_buildblock/GeneralisedPrior.cxx
+++ b/src/recon_buildblock/GeneralisedPrior.cxx
@@ -22,6 +22,7 @@
 #include "stir/Succeeded.h"
 #include "stir/modelling/ParametricDiscretisedDensity.h"
 #include "stir/modelling/KineticParameters.h"
+#include "stir/error.h"
 
 START_NAMESPACE_STIR
 

--- a/src/recon_buildblock/IterativeReconstruction.cxx
+++ b/src/recon_buildblock/IterativeReconstruction.cxx
@@ -40,6 +40,8 @@
 #include "stir/modelling/KineticParameters.h"
 
 #include "stir/info.h"
+#include "stir/warning.h"
+#include "stir/error.h"
 
 #ifndef STIR_NO_NAMESPACES
 using std::cerr;

--- a/src/recon_buildblock/LogcoshPrior.cxx
+++ b/src/recon_buildblock/LogcoshPrior.cxx
@@ -29,6 +29,8 @@
 #include "stir/IO/read_from_file.h"
 #include "stir/is_null_ptr.h"
 #include "stir/info.h"
+#include "stir/warning.h"
+#include "stir/error.h"
 #include <algorithm>
 using std::min;
 using std::max;

--- a/src/recon_buildblock/ML_estimate_component_based_normalisation.cxx
+++ b/src/recon_buildblock/ML_estimate_component_based_normalisation.cxx
@@ -26,6 +26,7 @@
 #include "stir/stream.h"
 #include "stir/display.h"
 #include "stir/info.h"
+#include "stir/warning.h"
 #include "stir/ProjData.h"
 #include <boost/format.hpp>
 #include <fstream>

--- a/src/recon_buildblock/NiftyPET_projector/BackProjectorByBinNiftyPET.cxx
+++ b/src/recon_buildblock/NiftyPET_projector/BackProjectorByBinNiftyPET.cxx
@@ -26,6 +26,7 @@
 #include "stir/recon_buildblock/TrivialDataSymmetriesForBins.h"
 #include "stir/ProjDataInfoCylindricalNoArcCorr.h"
 #include "stir/recon_array_functions.h"
+#include "stir/error.h"
 
 START_NAMESPACE_STIR
 

--- a/src/recon_buildblock/NiftyPET_projector/ForwardProjectorByBinNiftyPET.cxx
+++ b/src/recon_buildblock/NiftyPET_projector/ForwardProjectorByBinNiftyPET.cxx
@@ -28,6 +28,7 @@
 #include "stir/ProjDataInfoCylindricalNoArcCorr.h"
 #include "stir/recon_buildblock/TrivialDataSymmetriesForBins.h"
 #include "stir/recon_array_functions.h"
+#include "stir/error.h"
 
 START_NAMESPACE_STIR
 

--- a/src/recon_buildblock/NiftyPET_projector/NiftyPETHelper.cxx
+++ b/src/recon_buildblock/NiftyPET_projector/NiftyPETHelper.cxx
@@ -29,6 +29,7 @@
 #include "stir/IndexRange3D.h"
 #include "stir/FilePath.h"
 #include "stir/IO/stir_ecat_common.h"
+#include "stir/error.h"
 // Non-STIR includes
 #include <fstream>
 #include <math.h>

--- a/src/recon_buildblock/PLSPrior.cxx
+++ b/src/recon_buildblock/PLSPrior.cxx
@@ -27,6 +27,7 @@
 #include "stir/IO/read_from_file.h"
 #include "stir/is_null_ptr.h"
 #include "stir/info.h"
+#include "stir/error.h"
 #include <algorithm>
 using std::min;
 using std::max;

--- a/src/recon_buildblock/Parallelproj_projector/BackProjectorByBinParallelproj.cxx
+++ b/src/recon_buildblock/Parallelproj_projector/BackProjectorByBinParallelproj.cxx
@@ -37,6 +37,7 @@
 #endif
 // for debugging, remove later
 #include "stir/info.h"
+#include "stir/error.h"
 #include "stir/stream.h"
 #include <iostream>
 

--- a/src/recon_buildblock/Parallelproj_projector/ForwardProjectorByBinParallelproj.cxx
+++ b/src/recon_buildblock/Parallelproj_projector/ForwardProjectorByBinParallelproj.cxx
@@ -26,6 +26,7 @@
 #include "stir/ProjDataInfoCylindricalNoArcCorr.h"
 #include "stir/recon_buildblock/TrivialDataSymmetriesForBins.h"
 #include "stir/info.h"
+#include "stir/error.h"
 #include "stir/recon_array_functions.h"
 #ifdef parallelproj_built_with_CUDA
 #include "parallelproj_cuda.h"

--- a/src/recon_buildblock/PinholeSPECTUB_Tools.cxx
+++ b/src/recon_buildblock/PinholeSPECTUB_Tools.cxx
@@ -27,6 +27,8 @@
 #include <time.h>
 #include "stir/info.h"
 #include "stir/error.h"
+#include "stir/warning.h"
+#include "stir/error.h"
 #include <boost/format.hpp>
 #include <boost/math/constants/constants.hpp>
 #include <boost/math/special_functions/fpclassify.hpp>

--- a/src/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMean.cxx
+++ b/src/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMean.cxx
@@ -27,6 +27,7 @@
 #include "stir/modelling/ParametricDiscretisedDensity.h"
 #include "stir/modelling/KineticParameters.h"
 #include "stir/info.h"
+#include "stir/error.h"
 #include "boost/format.hpp"
 #include "boost/lexical_cast.hpp"
 

--- a/src/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMeanAndListModeData.cxx
+++ b/src/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMeanAndListModeData.cxx
@@ -28,6 +28,8 @@
 #include "stir/recon_buildblock/TrivialBinNormalisation.h"
 #include "stir/is_null_ptr.h"
 #include "stir/FilePath.h"
+#include "stir/warning.h"
+#include "stir/error.h"
 
 using std::vector;
 using std::pair;

--- a/src/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMeanAndListModeDataWithProjMatrixByBin.cxx
+++ b/src/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMeanAndListModeDataWithProjMatrixByBin.cxx
@@ -27,6 +27,8 @@
 #include "stir/listmode/ListRecord.h"
 #include "stir/Viewgram.h"
 #include "stir/info.h"
+#include "stir/warning.h"
+#include "stir/error.h"
 #include <boost/format.hpp>
 #include "stir/HighResWallClockTimer.h"
 #include "stir/Viewgram.h"

--- a/src/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMeanAndProjData.cxx
+++ b/src/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMeanAndProjData.cxx
@@ -26,6 +26,8 @@
 #include "stir/RelatedViewgrams.h"
 #include "stir/stream.h"
 #include "stir/info.h"
+#include "stir/warning.h"
+#include "stir/error.h"
 
 #include "stir/recon_buildblock/ProjectorByBinPair.h"
 

--- a/src/recon_buildblock/PostsmoothingBackProjectorByBin.cxx
+++ b/src/recon_buildblock/PostsmoothingBackProjectorByBin.cxx
@@ -22,6 +22,7 @@
 #include "stir/DataProcessor.h"
 #include "stir/DiscretisedDensity.h"
 #include "stir/is_null_ptr.h"
+#include "stir/warning.h"
 
 START_NAMESPACE_STIR
 const char * const 

--- a/src/recon_buildblock/PresmoothingForwardProjectorByBin.cxx
+++ b/src/recon_buildblock/PresmoothingForwardProjectorByBin.cxx
@@ -23,6 +23,7 @@
 #include "stir/DataProcessor.h"
 #include "stir/DiscretisedDensity.h"
 #include "stir/is_null_ptr.h"
+#include "stir/warning.h"
 
 START_NAMESPACE_STIR
 const char * const 

--- a/src/recon_buildblock/ProjDataRebinning.cxx
+++ b/src/recon_buildblock/ProjDataRebinning.cxx
@@ -19,6 +19,7 @@
 #include "stir/recon_buildblock/ProjDataRebinning.h"
 #include "stir/Succeeded.h"
 #include "stir/is_null_ptr.h"
+#include "stir/warning.h"
 
 using std::string;
 

--- a/src/recon_buildblock/ProjMatrixByBinFromFile.cxx
+++ b/src/recon_buildblock/ProjMatrixByBinFromFile.cxx
@@ -36,6 +36,8 @@
 //#include "stir/info.h"
 #include "boost/cstdint.hpp"
 #include "boost/scoped_ptr.hpp"
+#include "stir/warning.h"
+#include "stir/error.h"
 #include <fstream>
 #include <algorithm>
 

--- a/src/recon_buildblock/ProjMatrixByBinPinholeSPECTUB.cxx
+++ b/src/recon_buildblock/ProjMatrixByBinPinholeSPECTUB.cxx
@@ -56,6 +56,8 @@
 #include "stir/is_null_ptr.h"
 #include "stir/Coordinate3D.h"
 #include "stir/info.h"
+#include "stir/warning.h"
+#include "stir/error.h"
 #include "stir/CPUTimer.h"
 #ifdef STIR_OPENMP
 #include "stir/num_threads.h"

--- a/src/recon_buildblock/ProjMatrixByBinSPECTUB.cxx
+++ b/src/recon_buildblock/ProjMatrixByBinSPECTUB.cxx
@@ -32,6 +32,8 @@
 #include "stir/is_null_ptr.h"
 #include "stir/Coordinate3D.h"
 #include "stir/info.h"
+#include "stir/warning.h"
+#include "stir/error.h"
 #include "stir/CPUTimer.h"
 #ifdef STIR_OPENMP
 #include "stir/num_threads.h"

--- a/src/recon_buildblock/ProjMatrixByBinUsingInterpolation.cxx
+++ b/src/recon_buildblock/ProjMatrixByBinUsingInterpolation.cxx
@@ -27,6 +27,8 @@
 #include "stir/ProjDataInfoCylindricalNoArcCorr.h"
 #include "stir/Bin.h"
 #include "stir/round.h"
+#include "stir/warning.h"
+#include "stir/error.h"
 #include "stir/recon_buildblock/ProjMatrixElemsForOneBin.h"
 #include <algorithm>
 #include <math.h>

--- a/src/recon_buildblock/ProjMatrixByBinUsingRayTracing.cxx
+++ b/src/recon_buildblock/ProjMatrixByBinUsingRayTracing.cxx
@@ -52,6 +52,8 @@
 #include <algorithm>
 #include <math.h>
 #include <boost/format.hpp>
+#include "stir/warning.h"
+#include "stir/error.h"
 #include "stir/ProjDataInfoBlocksOnCylindricalNoArcCorr.h"
 #include "stir/ProjDataInfoGenericNoArcCorr.h"
 

--- a/src/recon_buildblock/ProjMatrixElemsForOneBin.cxx
+++ b/src/recon_buildblock/ProjMatrixElemsForOneBin.cxx
@@ -32,6 +32,7 @@
 #include "stir/recon_buildblock/DataSymmetriesForBins.h"
 
 #include "stir/recon_buildblock/RelatedBins.h"
+#include "stir/warning.h"
 #include <algorithm>
 //#include <iostream>
 //#include "stir/stream.h"

--- a/src/recon_buildblock/ProjMatrixElemsForOneDensel.cxx
+++ b/src/recon_buildblock/ProjMatrixElemsForOneDensel.cxx
@@ -23,6 +23,7 @@
 #include "stir/recon_buildblock/SymmetryOperation.h"
 #include "stir/recon_buildblock/DataSymmetriesForDensels.h"
 #include "stir/recon_buildblock/RelatedDensels.h"
+#include "stir/warning.h"
 
 #include <fstream>
 

--- a/src/recon_buildblock/ProjectorByBinPair.cxx
+++ b/src/recon_buildblock/ProjectorByBinPair.cxx
@@ -24,6 +24,7 @@
 #include "stir/ProjDataInfo.h"
 #include "stir/DiscretisedDensity.h"
 #include "stir/Succeeded.h"
+#include "stir/error.h"
 #include <boost/format.hpp>
 
 START_NAMESPACE_STIR

--- a/src/recon_buildblock/ProjectorByBinPairUsingProjMatrixByBin.cxx
+++ b/src/recon_buildblock/ProjectorByBinPairUsingProjMatrixByBin.cxx
@@ -25,6 +25,7 @@
 #include "stir/recon_buildblock/BackProjectorByBinUsingProjMatrixByBin.h"
 #include "stir/is_null_ptr.h"
 #include "stir/Succeeded.h"
+#include "stir/warning.h"
 
 START_NAMESPACE_STIR
 

--- a/src/recon_buildblock/ProjectorByBinPairUsingSeparateProjectors.cxx
+++ b/src/recon_buildblock/ProjectorByBinPairUsingSeparateProjectors.cxx
@@ -22,6 +22,7 @@
 #include "stir/recon_buildblock/ProjectorByBinPairUsingSeparateProjectors.h"
 #include "stir/is_null_ptr.h"
 #include "stir/Succeeded.h"
+#include "stir/warning.h"
 
 START_NAMESPACE_STIR
 

--- a/src/recon_buildblock/QuadraticPrior.cxx
+++ b/src/recon_buildblock/QuadraticPrior.cxx
@@ -26,6 +26,8 @@
 #include "stir/IO/read_from_file.h"
 #include "stir/is_null_ptr.h"
 #include "stir/info.h"
+#include "stir/warning.h"
+#include "stir/error.h"
 #include <algorithm>
 using std::min;
 using std::max;

--- a/src/recon_buildblock/RayTraceVoxelsOnCartesianGrid.cxx
+++ b/src/recon_buildblock/RayTraceVoxelsOnCartesianGrid.cxx
@@ -33,6 +33,7 @@
 #include "stir/recon_buildblock/ProjMatrixElemsForOneBin.h"
 #include "stir/CartesianCoordinate3D.h"
 #include "stir/round.h"
+#include "stir/warning.h"
 #include <math.h>
 #include <algorithm>
 

--- a/src/recon_buildblock/Reconstruction.cxx
+++ b/src/recon_buildblock/Reconstruction.cxx
@@ -29,7 +29,8 @@
 #include "stir/Succeeded.h"
 #include "stir/is_null_ptr.h"
 #include "stir/info.h"
-
+#include "stir/warning.h"
+#include "stir/error.h"
 
 #include "stir/modelling/ParametricDiscretisedDensity.h"
 #include "stir/modelling/KineticParameters.h"

--- a/src/recon_buildblock/RelativeDifferencePrior.cxx
+++ b/src/recon_buildblock/RelativeDifferencePrior.cxx
@@ -28,6 +28,8 @@
 #include "stir/IO/read_from_file.h"
 #include "stir/is_null_ptr.h"
 #include "stir/info.h"
+#include "stir/warning.h"
+#include "stir/error.h"
 #include <algorithm>
 using std::min;
 using std::max;

--- a/src/recon_buildblock/SqrtHessianRowSum.cxx
+++ b/src/recon_buildblock/SqrtHessianRowSum.cxx
@@ -18,6 +18,7 @@
 
 #include "stir/recon_buildblock/SqrtHessianRowSum.h"
 #include "stir/info.h"
+#include "stir/error.h"
 #include "stir/modelling/ParametricDiscretisedDensity.h"
 #include "stir/IO/OutputFileFormat.h"
 #include "stir/IO/read_from_file.h"

--- a/src/recon_buildblock/distributable.cxx
+++ b/src/recon_buildblock/distributable.cxx
@@ -50,6 +50,7 @@
 #include "stir/recon_buildblock/find_basic_vs_nums_in_subsets.h"
 #include "stir/is_null_ptr.h"
 #include "stir/info.h"
+#include "stir/error.h"
 #include <boost/format.hpp>
 #include <algorithm>
 

--- a/src/recon_buildblock/distributed_functions.cxx
+++ b/src/recon_buildblock/distributed_functions.cxx
@@ -29,6 +29,7 @@
 #include <fstream>
 #include "stir/Succeeded.h"
 #include "stir/error.h"
+#include "stir/warning.h"
 #include <boost/shared_array.hpp>
 
 using std::ios;

--- a/src/recon_test/fwdtest.cxx
+++ b/src/recon_test/fwdtest.cxx
@@ -58,6 +58,8 @@
 #include "stir/Succeeded.h"
 #include "stir/KeyParser.h"
 #include "stir/is_null_ptr.h"
+#include "stir/warning.h"
+#include "stir/error.h"
 #include <fstream>
 
 

--- a/src/scatter_buildblock/CreateTailMaskFromACFs.cxx
+++ b/src/scatter_buildblock/CreateTailMaskFromACFs.cxx
@@ -11,6 +11,7 @@
 #include "stir/scatter/CreateTailMaskFromACFs.h"
 #include "stir/Bin.h"
 #include "boost/lambda/lambda.hpp"
+#include "stir/error.h"
 
 START_NAMESPACE_STIR
 

--- a/src/scatter_buildblock/ScatterEstimation.cxx
+++ b/src/scatter_buildblock/ScatterEstimation.cxx
@@ -40,6 +40,8 @@
 #include "stir/NumericInfo.h"
 #include "stir/SegmentByView.h"
 #include "stir/VoxelsOnCartesianGrid.h"
+#include "stir/warning.h"
+#include "stir/error.h"
 
 // The calculation of the attenuation coefficients
 #include "stir/recon_buildblock/ForwardProjectorByBinUsingRayTracing.h"

--- a/src/scatter_buildblock/ScatterSimulation.cxx
+++ b/src/scatter_buildblock/ScatterSimulation.cxx
@@ -33,6 +33,7 @@
 #include "stir/IO/write_to_file.h"
 #include "stir/info.h"
 #include "stir/error.h"
+#include "stir/warning.h"
 #include "stir/stream.h"
 #include "stir/round.h"
 #include <fstream>

--- a/src/scatter_buildblock/SingleScatterSimulation.cxx
+++ b/src/scatter_buildblock/SingleScatterSimulation.cxx
@@ -7,6 +7,7 @@
     See STIR/LICENSE.txt for details
 */
 #include "stir/scatter/SingleScatterSimulation.h"
+#include "stir/error.h"
 
 START_NAMESPACE_STIR
 

--- a/src/scatter_buildblock/sample_scatter_points.cxx
+++ b/src/scatter_buildblock/sample_scatter_points.cxx
@@ -21,6 +21,7 @@
 #include "stir/scatter/ScatterSimulation.h"
 #include "stir/VoxelsOnCartesianGrid.h"
 #include "stir/info.h"
+#include "stir/error.h"
 #include <time.h>
 #include <boost/format.hpp>
 using namespace std;

--- a/src/scatter_buildblock/scatter_detection_modelling.cxx
+++ b/src/scatter_buildblock/scatter_detection_modelling.cxx
@@ -25,6 +25,7 @@
 #include "stir/ProjDataInfoBlocksOnCylindricalNoArcCorr.h"
 #include "stir/numerics/erf.h"
 #include "stir/info.h"
+#include "stir/error.h"
 #include <iostream>
 
 START_NAMESPACE_STIR

--- a/src/scatter_buildblock/upsample_and_fit_scatter_estimate.cxx
+++ b/src/scatter_buildblock/upsample_and_fit_scatter_estimate.cxx
@@ -31,6 +31,8 @@
 #include "stir/Succeeded.h"
 #include "stir/thresholding.h"
 #include "stir/is_null_ptr.h"
+#include "stir/warning.h"
+#include "stir/error.h"
 #include "stir/ArrayFilter1DUsingConvolution.h"
 #include <iostream>
 #include <fstream>

--- a/src/scatter_utilities/create_tail_mask_from_ACFs.cxx
+++ b/src/scatter_utilities/create_tail_mask_from_ACFs.cxx
@@ -53,7 +53,8 @@
 #include <string>
 
 #include "stir/scatter/CreateTailMaskFromACFs.h"
-
+#include "stir/warning.h"
+#include "stir/error.h"
 
 /***********************************************************/     
 

--- a/src/spatial_transformation_buildblock/GatedSpatialTransformation.cxx
+++ b/src/spatial_transformation_buildblock/GatedSpatialTransformation.cxx
@@ -19,6 +19,8 @@
 #include "stir/spatial_transformation/GatedSpatialTransformation.h"
 #include "stir/spatial_transformation/warp_image.h"
 #include "stir/info.h"
+#include "stir/warning.h"
+#include "stir/error.h"
 #include <boost/format.hpp>
 
 START_NAMESPACE_STIR

--- a/src/spatial_transformation_buildblock/InvertAxis.cxx
+++ b/src/spatial_transformation_buildblock/InvertAxis.cxx
@@ -15,6 +15,7 @@
 */
 
 #include "stir/spatial_transformation/InvertAxis.h"
+#include "stir/error.h"
 
 START_NAMESPACE_STIR
 

--- a/src/spatial_transformation_buildblock/warp_image.cxx
+++ b/src/spatial_transformation_buildblock/warp_image.cxx
@@ -15,6 +15,7 @@
 */
 
 #include "stir/spatial_transformation/warp_image.h"
+#include "stir/error.h"
 
 START_NAMESPACE_STIR
 //using namespace BSpline;

--- a/src/test/NiftyPET_projector/test_ProjectorNiftyPET_adjoint.cxx
+++ b/src/test/NiftyPET_projector/test_ProjectorNiftyPET_adjoint.cxx
@@ -22,6 +22,7 @@
 #include "stir/num_threads.h"
 #include "stir/CPUTimer.h"
 #include "stir/Verbosity.h"
+#include "stir/error.h"
 #include "stir/recon_array_functions.h"
 #include "stir/Shape/Ellipsoid.h"
 #include "stir/ProjDataInMemory.h"

--- a/src/test/modelling/test_ParametricDiscretisedDensity.cxx
+++ b/src/test/modelling/test_ParametricDiscretisedDensity.cxx
@@ -35,6 +35,7 @@
 #include <utility>
 #include <vector>
 #include <string>
+#include "stir/warning.h"
 
 #include <algorithm>
 #include <iomanip>

--- a/src/test/test_DateTime.cxx
+++ b/src/test/test_DateTime.cxx
@@ -19,6 +19,7 @@
 */
 #include "stir/RunTests.h"
 #include "stir/date_time_functions.h"
+#include "stir/error.h"
 
 #include <iostream>
 

--- a/src/test/test_DynamicDiscretisedDensity.cxx
+++ b/src/test/test_DynamicDiscretisedDensity.cxx
@@ -29,6 +29,7 @@
 #include "stir/TimeFrameDefinitions.h"
 #include "stir/Scanner.h"
 #include "stir/IO/read_from_file.h"
+#include "stir/warning.h"
 #include <utility>
 #include <vector>
 #include <string>

--- a/src/test/test_Scanner.cxx
+++ b/src/test/test_Scanner.cxx
@@ -22,6 +22,7 @@
 #include "stir/Scanner.h"
 #include "stir/Succeeded.h"
 #include "stir/shared_ptr.h"
+#include "stir/warning.h"
 #ifdef HAVE_LLN_MATRIX
 #include "ecat_model.h"
 extern "C" {

--- a/src/test/test_export_array.cxx
+++ b/src/test/test_export_array.cxx
@@ -27,6 +27,8 @@
 #include "stir/IndexRange2D.h"
 #include "stir/IndexRange3D.h"
 #include "stir/info.h"
+#include "stir/warning.h"
+#include "stir/error.h"
 #include "stir/copy_fill.h"
 
 #include <boost/format.hpp>

--- a/src/test/test_proj_data_maths.cxx
+++ b/src/test/test_proj_data_maths.cxx
@@ -28,6 +28,7 @@
 #include "stir/RunTests.h"
 #include "stir/Scanner.h"
 #include "stir/copy_fill.h"
+#include "stir/error.h"
 START_NAMESPACE_STIR
 
 

--- a/src/utilities/apply_normfactors.cxx
+++ b/src/utilities/apply_normfactors.cxx
@@ -28,6 +28,7 @@
 #include "stir/Sinogram.h"
 #include "stir/IndexRange2D.h"
 #include "stir/display.h"
+#include "stir/warning.h"
 #include <iostream>
 #include <fstream>
 #include <string>

--- a/src/utilities/apply_normfactors3D.cxx
+++ b/src/utilities/apply_normfactors3D.cxx
@@ -26,6 +26,7 @@
 #include "stir/ProjDataInterfile.h"
 #include "stir/ProjDataInMemory.h"
 #include "stir/stream.h"
+#include "stir/warning.h"
 #include <iostream>
 #include <string>
 

--- a/src/utilities/attenuation_coefficients_to_projections.cxx
+++ b/src/utilities/attenuation_coefficients_to_projections.cxx
@@ -34,6 +34,7 @@
 #include "stir/Viewgram.h"
 #include "stir/ArrayFunction.h"
 #include "stir/thresholding.h"
+#include "stir/warning.h"
 #include <iostream>
 
 USING_NAMESPACE_STIR

--- a/src/utilities/calculate_attenuation_coefficients.cxx
+++ b/src/utilities/calculate_attenuation_coefficients.cxx
@@ -62,6 +62,7 @@
 #include "stir/DataSymmetriesForViewSegmentNumbers.h"
 #include "stir/IO/read_from_file.h"
 #include "stir/info.h"
+#include "stir/warning.h"
 #include <boost/format.hpp>
 #include <iostream>
 #include <list>

--- a/src/utilities/compare_image.cxx
+++ b/src/utilities/compare_image.cxx
@@ -37,6 +37,7 @@ if the files are identical or not.
 #include "stir/recon_array_functions.h"
 #include "stir/IO/read_from_file.h"
 #include "stir/is_null_ptr.h"
+#include "stir/warning.h"
 #include <numeric>
 #include <stdlib.h>
 

--- a/src/utilities/construct_randoms_from_GEsingles.cxx
+++ b/src/utilities/construct_randoms_from_GEsingles.cxx
@@ -28,6 +28,7 @@
 #include "stir/IndexRange2D.h"
 #include "stir/IO/GEHDF5Wrapper.h"
 #include "stir/info.h"
+#include "stir/error.h"
 #include <iostream>
 #include <string>
 #include "stir/data/SinglesRatesFromGEHDF5.h"

--- a/src/utilities/construct_randoms_from_singles.cxx
+++ b/src/utilities/construct_randoms_from_singles.cxx
@@ -23,6 +23,7 @@
 #include "stir/multiply_crystal_factors.h"
 #include "stir/stream.h"
 #include "stir/IndexRange2D.h"
+#include "stir/error.h"
 #include <iostream>
 #include <fstream>
 #include <string>

--- a/src/utilities/conv_AVW.cxx
+++ b/src/utilities/conv_AVW.cxx
@@ -25,6 +25,7 @@
 #include "stir/is_null_ptr.h"
 #include "stir/Succeeded.h"
 #include "stir/shared_ptr.h"
+#include "stir/warning.h"
 #include <iostream>
 #include <string.h>
 

--- a/src/utilities/conv_GATE_raw_ECAT_projdata_to_interfile.cxx
+++ b/src/utilities/conv_GATE_raw_ECAT_projdata_to_interfile.cxx
@@ -26,6 +26,8 @@
 #include "stir/IO/read_data.h"
 #include "stir/Succeeded.h"
 #include "stir/NumericType.h"
+#include "stir/warning.h"
+#include "stir/error.h"
 
 #define NUMARG 8
 

--- a/src/utilities/correct_projdata.cxx
+++ b/src/utilities/correct_projdata.cxx
@@ -137,6 +137,8 @@ This parameter will be removed.
 #include "stir/TrivialDataSymmetriesForViewSegmentNumbers.h"
 #include "stir/ArrayFunction.h"
 #include "stir/TimeFrameDefinitions.h"
+#include "stir/warning.h"
+#include "stir/error.h"
 #ifndef USE_PMRT
 #include "stir/recon_buildblock/ForwardProjectorByBinUsingRayTracing.h"
 #else

--- a/src/utilities/ctac_to_mu_values.cxx
+++ b/src/utilities/ctac_to_mu_values.cxx
@@ -36,6 +36,7 @@
 #include "stir/IO/write_to_file.h"
 #include "stir/DiscretisedDensity.h"
 #include "stir/getopt.h"
+#include "stir/warning.h"
 #include <string>
 #include <exception>
 

--- a/src/utilities/do_linear_regression.cxx
+++ b/src/utilities/do_linear_regression.cxx
@@ -33,6 +33,7 @@
 
 #include "stir/linear_regression.h"
 #include "stir/VectorWithOffset.h"
+#include "stir/error.h"
 
 #include <fstream>
 #include <iostream>

--- a/src/utilities/ecat/conv_to_ecat6.cxx
+++ b/src/utilities/ecat/conv_to_ecat6.cxx
@@ -58,6 +58,8 @@ Note that to store projection data in ECAT6, a 3D sinogram cannot be axially com
 #include <iostream>
 #include <vector>
 #include <string>
+#include "stir/warning.h"
+#include "stir/error.h"
 
 #ifndef STIR_NO_NAMESPACES
 using std::cerr;

--- a/src/utilities/ecat/conv_to_ecat7.cxx
+++ b/src/utilities/ecat/conv_to_ecat7.cxx
@@ -44,6 +44,7 @@ be surrounded by double quotes (&quot;) when used as a command line argument.
 #include "stir/Succeeded.h"
 #include "stir/IO/stir_ecat7.h"
 #include "stir/IO/read_from_file.h"
+#include "stir/warning.h"
 #include <iostream>
 #include <vector>
 #include <string>

--- a/src/utilities/ecat/convecat6_if.cxx
+++ b/src/utilities/ecat/convecat6_if.cxx
@@ -60,6 +60,7 @@
 #include "stir/IO/ecat6_utils.h"
 #include "stir/Scanner.h"
 #include "stir/Succeeded.h"
+#include "stir/error.h"
 #include <stdio.h>
 #include <iostream>
 #include <algorithm>

--- a/src/utilities/ecat/copy_ecat7_header.cxx
+++ b/src/utilities/ecat/copy_ecat7_header.cxx
@@ -36,6 +36,8 @@ To copy a subheader (but keeping essential info)
 #include "stir/Succeeded.h"
 #include "stir/utilities.h"
 #include "stir/IO/stir_ecat7.h"
+#include "stir/warning.h"
+#include "stir/error.h"
 
 #include <iostream>
 #include <string>

--- a/src/utilities/ecat/ecat_swap_corners.cxx
+++ b/src/utilities/ecat/ecat_swap_corners.cxx
@@ -99,6 +99,7 @@
 #include "stir/utilities.h"
 #include "stir/SegmentBySinogram.h"
 #include "stir/Succeeded.h"
+#include "stir/error.h"
 #include <iostream>
 #include <algorithm>
 #ifndef STIR_NO_NAMESPACES

--- a/src/utilities/estimate_triple_energy_window_scatter_sinogram.cxx
+++ b/src/utilities/estimate_triple_energy_window_scatter_sinogram.cxx
@@ -29,6 +29,7 @@
 #include "stir/is_null_ptr.h"
 #include "stir/stir_math.h"
 #include "stir/ArrayFunction.h"
+#include "stir/warning.h"
 
 #include "stir/IndexRange3D.h"
 #include "stir/ArrayFilter3DUsingConvolution.h"

--- a/src/utilities/extract_single_images_from_dynamic_image.cxx
+++ b/src/utilities/extract_single_images_from_dynamic_image.cxx
@@ -42,6 +42,7 @@
 #include "stir/VoxelsOnCartesianGrid.h"
 #include "stir/IO/OutputFileFormat.h"
 #include "stir/Succeeded.h"
+#include "stir/error.h"
 
 int main(int argc, char *argv[])
 {

--- a/src/utilities/find_ML_normfactors.cxx
+++ b/src/utilities/find_ML_normfactors.cxx
@@ -25,6 +25,7 @@
 #include "stir/CPUTimer.h"
 #include "stir/utilities.h"
 #include "stir/info.h"
+#include "stir/warning.h"
 #include "stir/error.h"
 #include <boost/format.hpp>
 #include <iostream>

--- a/src/utilities/find_ML_singles_from_delayed.cxx
+++ b/src/utilities/find_ML_singles_from_delayed.cxx
@@ -23,6 +23,7 @@
 #include "stir/display.h"
 #include "stir/CPUTimer.h"
 #include "stir/utilities.h"
+#include "stir/warning.h"
 #include <iostream>
 #include <fstream>
 #include <string>

--- a/src/utilities/find_maxima_in_image.cxx
+++ b/src/utilities/find_maxima_in_image.cxx
@@ -35,6 +35,7 @@
 #include "stir/DiscretisedDensity.h"
 #include "stir/DiscretisedDensityOnCartesianGrid.h"
 #include "stir/IO/read_from_file.h"
+#include "stir/warning.h"
 
 #include <iostream>
 #include <iomanip>

--- a/src/utilities/find_recovery_coefficients_in_image_quality_phantom_nema_nu4.cxx
+++ b/src/utilities/find_recovery_coefficients_in_image_quality_phantom_nema_nu4.cxx
@@ -38,6 +38,8 @@ limitations under the License.
 #include <vector>
 #include "stir/IO/read_from_file.h"
 #include "stir/info.h"
+#include "stir/warning.h"
+#include "stir/error.h"
 #include "stir/Succeeded.h"
 
 #ifndef STIR_NO_NAMESPACES

--- a/src/utilities/find_sum_projection_of_viewgram_and_sinogram.cxx
+++ b/src/utilities/find_sum_projection_of_viewgram_and_sinogram.cxx
@@ -36,9 +36,7 @@ limitations under the License.
 #include "stir/SegmentByView.h"
 #include "stir/ProjDataInterfile.h"
 #include "stir/ProjDataInfo.h"
-
-
-
+#include "stir/error.h"
 
 #ifndef STIR_NO_NAMESPACES
 using std::cerr;

--- a/src/utilities/forward_project.cxx
+++ b/src/utilities/forward_project.cxx
@@ -44,6 +44,8 @@
 #include "stir/IO/read_from_file.h"
 #include "stir/recon_buildblock/ForwardProjectorByBinUsingProjMatrixByBin.h"
 #include "stir/recon_buildblock/ProjMatrixByBinUsingRayTracing.h"
+#include "stir/warning.h"
+#include "stir/error.h"
 #include <iostream>
 #include <stdlib.h>
 

--- a/src/utilities/get_time_frame_info.cxx
+++ b/src/utilities/get_time_frame_info.cxx
@@ -18,6 +18,7 @@
     See STIR/LICENSE.txt for details
 */
 #include "stir/TimeFrameDefinitions.h"
+#include "stir/warning.h"
 #include <iostream>
 #include <string>
 

--- a/src/utilities/list_ROI_values.cxx
+++ b/src/utilities/list_ROI_values.cxx
@@ -48,6 +48,8 @@
 #include "stir/KeyParser.h"
 #include "stir/is_null_ptr.h"
 #include "stir/IO/read_from_file.h"
+#include "stir/warning.h"
+#include "stir/error.h"
 #include <iostream>
 #include <iomanip>
 #include <fstream>

--- a/src/utilities/list_image_info.cxx
+++ b/src/utilities/list_image_info.cxx
@@ -26,6 +26,7 @@
 #include "stir/VoxelsOnCartesianGrid.h"
 #include "stir/DynamicDiscretisedDensity.h"
 #include "stir/stream.h"
+#include "stir/error.h"
 #include "stir/Succeeded.h"
 #include "stir/IO/read_from_file.h"
 #include "stir/date_time_functions.h"

--- a/src/utilities/list_projdata_info.cxx
+++ b/src/utilities/list_projdata_info.cxx
@@ -30,6 +30,7 @@
 #include "stir/ProjDataInfo.h"
 #include "stir/SegmentByView.h"
 #include "stir/is_null_ptr.h"
+#include "stir/warning.h"
 #include <iostream> 
 #include <limits>
 #include <string>

--- a/src/utilities/postfilter.cxx
+++ b/src/utilities/postfilter.cxx
@@ -68,6 +68,8 @@
 #include "stir/IO/OutputFileFormat.h"
 #include "stir/IO/read_from_file.h"
 #include "stir/Succeeded.h"
+#include "stir/warning.h"
+#include "stir/error.h"
 #include <iostream> 
 
 #ifndef STIR_NO_NAMESPACES

--- a/src/utilities/rebin_projdata.cxx
+++ b/src/utilities/rebin_projdata.cxx
@@ -35,6 +35,8 @@ END:=
 #include "stir/Succeeded.h"
 #include "stir/shared_ptr.h"
 #include "stir/is_null_ptr.h"
+#include "stir/warning.h"
+#include "stir/error.h"
 #include <iostream> 
 
 #ifndef STIR_NO_NAMESPACES

--- a/src/utilities/separate_true_from_random_scatter_for_necr.cxx
+++ b/src/utilities/separate_true_from_random_scatter_for_necr.cxx
@@ -39,6 +39,7 @@ limitations under the License.
 #include "stir/ProjDataInterfile.h"
 #include "stir/ProjDataInfo.h"
 #include <algorithm>
+#include "stir/error.h"
 
 
 

--- a/src/utilities/shift_image.cxx
+++ b/src/utilities/shift_image.cxx
@@ -16,6 +16,7 @@
 #include "stir/IO/OutputFileFormat.h"
 #include "stir/Succeeded.h"
 #include "stir/round.h"
+#include "stir/error.h"
 
 #include <math.h>
 

--- a/src/utilities/stir_math.cxx
+++ b/src/utilities/stir_math.cxx
@@ -123,6 +123,8 @@
 #include "stir/modelling/ParametricDiscretisedDensity.h"
 #include "stir/DynamicDiscretisedDensity.h"
 #include "stir/stir_math.h"
+#include "stir/warning.h"
+#include "stir/error.h"
 
 #include <fstream> 
 #include <iostream> 

--- a/src/utilities/stir_write_pgm.cxx
+++ b/src/utilities/stir_write_pgm.cxx
@@ -30,6 +30,7 @@
 #include "stir/Coordinate2D.h"
 #include "stir/shared_ptr.h"
 #include "stir/error.h"
+#include "stir/warning.h"
 
 #include <cstdio>
 #include <fstream>

--- a/src/utilities/zoom_image.cxx
+++ b/src/utilities/zoom_image.cxx
@@ -26,6 +26,7 @@
 #include "stir/IO/read_from_file.h"
 //#include "stir/utilities.h"
 #include "stir/Succeeded.h"
+#include "stir/error.h"
 
 
 #ifndef STIR_NO_NAMESPACES


### PR DESCRIPTION
I decided against calling the other error function, because that one is deprecated.