### PR TITLE
add capability for discreted shapes with labels

### DIFF
--- a/documentation/STIR-UsersGuide.tex
+++ b/documentation/STIR-UsersGuide.tex
@@ -3109,11 +3109,14 @@ Using no arguments will give a more extensive usage message showing
 some options to select which data to print.
 
 { \subsubsubsection{list\_ROI\_values}
-}
+\label{sec:list_ROI_values}}
 
-This is a test-release of a program that can be used to find 
-ROI values for an image. See the online documentation generated 
-by doxygen for more info.
+This program can be used to find 
+ROI values for an image. See its usage message, and/or the online documentation generated 
+by doxygen for more info. ROIs can be specified by geometric shapes or
+discretised ``masks", see section \ref{sec:shapes}.
+Example files specifying the ROIs can be found in the
+\texttt{examples/samples} folder.
 
 { \subsubsubsection{extract\_single\_images\_from\_dynamic\_image}
 }
@@ -5509,7 +5512,8 @@ Bin Normalisation type := SPECT
 Available shapes}
 \label{sec:shapes}
 \textbf{STIR} can use shapes, \textit{e.g.} in the \texttt{generate\_image}
-utility (see section \ref{sec:generate_image}), or for specifying ROIs. The distribution contains sample parameter files in the
+utility (see section \ref{sec:generate_image}), or for specifying ROIs, see \ref{sec:list_ROI_values}.
+The distribution contains sample parameter files in the
 \texttt{samples} directory. In the following sub-sections the available shapes are listed.
 
 Most shapes have a centre and orientation. This is specified in the parameter files
@@ -5586,13 +5590,20 @@ In addition, this shape can be restricted to a wedge by specifying initial and f
 
 { \subsubsubsection{Discretised Shape3D}
 }
-This shape can be used to read for instance saved ROIs. Image values are supposed to be between $0$ and $1$.
+This shape can be used to read for instance saved ROIs. This class supports 2 options:
+\begin{itemize}
+  \item a label-image with associated label index (an integer), suitable for multiple ROIs in a single file.
+  \item a ``weight" image, with (potentially) smooth edges, where voxel values
+    are supposed to be between $0$ and $1$.
+\end{itemize}
 Note that centre and orientation are taken from the image data, not from the parameter file.
 { \subsubsubsubsection{Parameters}
 }
 \begin{verbatim}
   Discretised Shape3D Parameters:=
     input filename := <filename>
+    ; optional member (if not set, or negative, STIR will use the image as weights
+    label index := <int>
   END:=
 \end{verbatim}
 where \texttt{filename} needs to specify a volume that can be read by STIR.

--- a/documentation/release_5.2.htm
+++ b/documentation/release_5.2.htm
@@ -31,7 +31,12 @@
 
 <h3>New functionality</h3>
 <ul>
-<li>Global variables in SPECTUB have been substituted by class members, such that multiple SPECTUB projectors can be used.
+  <li>The <tt>Discretised Shape3D</tt> shape/ROI has now an extra value <tt>label index</tt>. For ROIs, this allows
+    using a single volume with multiple ROIs encoded as labels, such as output by ITKSnap and many others.
+    When used as a shape in <tt>generate_image</tt>, it could be used to extract a single ROI from such a label image.
+    <br /><a href="https://github.com/UCL/STIR/pull/1196/">PR #1196</a>.
+  </li>
+  <li>Global variables in SPECTUB have been substituted by class members, such that multiple SPECTUB projectors can be used.
     <br /><a href="https://github.com/UCL/STIR/pull/1169/">PR #1169</a>.
   </li>
   <li>Scatter estimation is now smoothed in axial direction for BlocksOnCylindrical scanners.

--- a/examples/samples/list_ROI_values_with_label_image.par
+++ b/examples/samples/list_ROI_values_with_label_image.par
@@ -1,0 +1,30 @@
+ROIValues Parameters :=
+; This file illustrates using a single volume with multiple "labels"
+; (integer values) for different ROIs
+
+; Note that without label index, the ROI computations will use the voxel values as
+; weights, assumed to be between 0 and 1, to allow for "soft" ROIs
+; (e.g., the ROI mean will just be computed by multiplying with these weights)
+
+  ; give the ROI an (optional) name. Defaults to the empty string.              
+  ROI name := label_1
+  ROI shape type:= Discretised shape3D
+  Discretised Shape3D Parameters:=
+   input filename := label_indices.hv
+   ; select the index for the ROI you want. This just uses
+   ; a numerical comparison of the voxel value with the (integer) label index.
+   label index := 1
+  END:=
+
+  next shape:=
+
+  ROI name := label_2
+  ROI shape type:= Discretised shape3D
+  Discretised Shape3D Parameters:=
+   input filename := label_indices.hv
+   label index := 2
+  END:=
+
+  ; you can add other ROIs here, including shape-based ones
+  
+END:=

--- a/src/include/stir/Shape/DiscretisedShape3D.h
+++ b/src/include/stir/Shape/DiscretisedShape3D.h
@@ -32,13 +32,16 @@ template <int num_dimensions, typename elemT> class DiscretisedDensity;
 
   Currently only supports discretisation via VoxelsOnCartesianGrid.
 
-  For DiscretisedShaped3D objects with smooth edges, voxel values
-    will vary between 0 and 1. 
+  This class supports 2 options:
+  - a label-image with associated label index (an integer), suitable for multiple ROIs in a single file.
+  - a "weight" image, with (potentially) smooth edges, where voxel values
+    vary between 0 and 1.
 
   \par Parameters for parsing
   \verbatim
   Discretised Shape3D Parameters:=
   input filename := <filename>
+  label index := -1 ; if less than 1 (default), we will use "weights"
   END:=
   \endverbatim
   where \a filename needs to specify a volume that can be read by STIR.
@@ -100,16 +103,20 @@ public:
           \a voxel_size is identical to the image's voxel_size
 
     The argument \a num_samples is ignored.
+
+    If get_label_index() >= 0, the weight will be 1 for those voxels whose value is equal to the label_index and zero otherwise.
+    If get_label_index() < 0 (default), the weight will be the actual voxel value.
   */
  virtual float get_voxel_weight(
    const CartesianCoordinate3D<float>& coord,
    const CartesianCoordinate3D<float>& voxel_size, 
    const CartesianCoordinate3D<int>& num_samples) const;
 
- //! Construct a new image (using zoom_image) from the underlying density
+ //! Construct a new image from the underlying density
  /*! 
-   If the images do not have the same characteristics, zoom_image is called for interpolation.
-   The result is scaled such that mean ROI values remain the same (at least for ROIs which avoid edges).
+   If get_label_index() >= 0, the imags need to have the same characteristics, but in the other case,
+   zoom_image is called for interpolation.
+   The result is then scaled such that mean ROI values remain the same (at least for ROIs which avoid edges).
 
    The argument \a num_samples is ignored.
   */
@@ -124,8 +131,14 @@ public:
 
  //! provide (const) access to the underlying density
  const DiscretisedDensity<3,float>& get_discretised_density() const;
+
+ //! Return label index
+ int get_label_index() const;
+ //! Set label index
+ void set_label_index(int label_index);
   
 private:
+  int _label_index;
   shared_ptr<DiscretisedDensity<3,float> > density_sptr;
   
   inline const VoxelsOnCartesianGrid<float>& image() const;
@@ -133,6 +146,7 @@ private:
 
   //! \name Parsing functions
   //@{
+  //! Sets defaults i.e. label index=-1 and reset density_sptr
   virtual void set_defaults();  
   virtual void initialise_keymap();
   //! Checks validity of parameters

--- a/src/include/stir/Shape/DiscretisedShape3D.h
+++ b/src/include/stir/Shape/DiscretisedShape3D.h
@@ -2,6 +2,7 @@
 //
 /*
     Copyright (C) 2000- 2007, Hammersmith Imanet Ltd
+    Copyright (C) 2023, University College London
     This file is part of STIR.
 
     SPDX-License-Identifier: Apache-2.0
@@ -22,13 +23,14 @@
 #include "stir/RegisteredParsingObject.h"
 #include "stir/Shape/Shape3D.h"
 #include "stir/shared_ptr.h"
+#include "stir/error.h"
 
 START_NAMESPACE_STIR
 
 template <int num_dimensions, typename elemT> class DiscretisedDensity;
 
 /*! \ingroup Shape
-  \brief A class for shapes that have been discretised
+  \brief A class for shapes that have been discretised as a volume
 
   Currently only supports discretisation via VoxelsOnCartesianGrid.
 

--- a/src/test/test_ROIs.cxx
+++ b/src/test/test_ROIs.cxx
@@ -77,13 +77,15 @@ private:
   */
   void run_tests_one_shape(Shape3D& shape,
 			   VoxelsOnCartesianGrid<float>& image,
-			   const bool do_rotated_ROI_test=true);
+			   const bool do_rotated_ROI_test=true,
+         const bool do_separate_translate_test=true);
 };
 
 void
 ROITests::run_tests_one_shape(Shape3D& shape,
 			      VoxelsOnCartesianGrid<float>& image,
-			      const bool do_rotated_ROI_test)
+			      const bool do_rotated_ROI_test,
+            const bool do_separate_translate_test)
 {
     shape.construct_volume(image, Coordinate3D<int>(1,1,1));
 
@@ -157,6 +159,7 @@ ROITests::run_tests_one_shape(Shape3D& shape,
       shape.translate(translation*-1);
     }
     // test on translation (image and shape translate separately)
+    if (do_separate_translate_test)
     {
       const CartesianCoordinate3D<float> translation (3,1,10);  
       image.set_origin(image.get_origin()+translation);
@@ -376,6 +379,18 @@ ROITests::run_tests()
       VoxelsOnCartesianGrid<float>  other_image(other_range,other_origin, other_grid_spacing);
       this->run_tests_one_shape(discretised_shape, other_image);
     }
+    // need to fill in image again, as the tests change it
+    ellipsoid.construct_volume(image, make_coordinate(1, 1, 1));
+    {
+      std::cerr << "\t\tlabel image\n";
+      VoxelsOnCartesianGrid<float> other_image(image);
+      other_image += 1;
+      DiscretisedShape3D discretised_shape(other_image);
+      discretised_shape.set_label_index(2);
+      this->run_tests_one_shape(discretised_shape, image, false, false);
+    }
+
+
 
   }
 


### PR DESCRIPTION
segmentations often give 1 file with values 0,1,2,3... for each mask. We now have a "label_index" parameter for the discretised shape to say which index you want.