### PR TITLE
[CMake] fix ITK/HDF5 dependency if they are found by dependencies

### DIFF
--- a/src/IO/CMakeLists.txt
+++ b/src/IO/CMakeLists.txt
@@ -34,7 +34,7 @@ set(${dir_LIB_SOURCES}
 ) 
 
 # we can use IO from the itk library
-if (ITK_FOUND)
+if (HAVE_ITK)
   list(APPEND ${dir_LIB_SOURCES}
     ITKOutputFileFormat.cxx
     ITKImageInputFileFormat.cxx
@@ -67,7 +67,7 @@ list(APPEND ${dir_LIB_SOURCES}
 	InputStreamWithRecordsFromUPENNtxt.cxx)
 endif()
 
-if (HDF5_FOUND)
+if (HAVE_HDF5)
  list(APPEND ${dir_LIB_SOURCES}
     GEHDF5Wrapper.cxx
     GEHDF5ListmodeInputFileFormat
@@ -95,7 +95,7 @@ if (CERN_ROOT_FOUND)
   endif()
 endif()
 
-if (HDF5_FOUND)
+if (HAVE_HDF5)
   target_link_libraries(IO ${HDF5_CXX_LIBRARIES})
 endif()
 
@@ -103,7 +103,7 @@ if (AVW_FOUND)
   target_link_libraries(IO ${AVW_LIBRARIES})
 endif()
 
-if (ITK_FOUND) 
+if (HAVE_ITK)
   target_link_libraries(IO ITKCommon ${ITK_LIBRARIES})
 endif()
 

--- a/src/utilities/CMakeLists.txt
+++ b/src/utilities/CMakeLists.txt
@@ -75,7 +75,7 @@ set(${dir_EXE_SOURCES}
         separate_true_from_random_scatter_for_necr.cxx
 )
 
-if (ITK_FOUND)
+if (HAVE_ITK)
   list(APPEND ${dir_EXE_SOURCES} SPECT_dicom_to_interfile.cxx)
 endif()
 
@@ -83,7 +83,7 @@ if (AVW_FOUND)
   list(APPEND ${dir_EXE_SOURCES}  conv_AVW.cxx)
 endif()
 
-if (HDF5_FOUND)
+if (HAVE_HDF5)
  list(APPEND ${dir_EXE_SOURCES}
    construct_randoms_from_GEsingles.cxx
    GE/print_GE_singles_values.cxx


### PR DESCRIPTION
When using ITK, but disabling HDF5, we were including some STIR files depending on HDF5 anyway, resulting in linking failures. This was because we were using HDF5_FOUND. Now we use our own variable HAVE_HDF5.

A similar fix was applied for ITK, although it's more unlikely that ITK is found by some other library I guess.

Fixes #1165