### PR TITLE
Change PinholeSPECTUB global variables to class members

### DIFF
--- a/documentation/release_5.2.htm
+++ b/documentation/release_5.2.htm
@@ -40,7 +40,7 @@
     <br /><a href="https://github.com/UCL/STIR/pull/1169/">PR #1169</a>.
   </li>
   <li>Global variables in PinholeSPECTUB have been substituted by class members, such that multiple PinholeSPECTUB projectors can be used.
-    <br /><a href="https://github.com/UCL/STIR/pull/1211/">PR #1211</a>.
+    <br /><a href="https://github.com/UCL/STIR/pull/1212/">PR #1212</a>.
   </li>
   <li>Scatter estimation is now smoothed in axial direction for BlocksOnCylindrical scanners.
     <br /><a href="https://github.com/UCL/STIR/pull/1172/">PR #1172</a>.

--- a/documentation/release_5.2.htm
+++ b/documentation/release_5.2.htm
@@ -39,6 +39,9 @@
   <li>Global variables in SPECTUB have been substituted by class members, such that multiple SPECTUB projectors can be used.
     <br /><a href="https://github.com/UCL/STIR/pull/1169/">PR #1169</a>.
   </li>
+  <li>Global variables in PinholeSPECTUB have been substituted by class members, such that multiple PinholeSPECTUB projectors can be used.
+    <br /><a href="https://github.com/UCL/STIR/pull/1211/">PR #1211</a>.
+  </li>
   <li>Scatter estimation is now smoothed in axial direction for BlocksOnCylindrical scanners.
     <br /><a href="https://github.com/UCL/STIR/pull/1172/">PR #1172</a>.
   </li>

--- a/src/include/stir/recon_buildblock/PinholeSPECTUB_Tools.h
+++ b/src/include/stir/recon_buildblock/PinholeSPECTUB_Tools.h
@@ -384,43 +384,43 @@ namespace SPECTUB_mph
 
     //... functions from wmtools_SPECT.cpp .........................................
 
-    void wm_alloc ( int * Nitems);                        // allocate wm
+    void wm_alloc ( int * Nitems, wm_da_type &wm, wmh_mph_type &wmh );                        // allocate wm
 
-    void free_wm () ;                                      // delete wm
-
-
-    void write_wm_FC_mph ();                               // write double array weight matrix
-
-    void write_wm_hdr_mph ();                              // write header of a matrix
-
-    void write_wm_STIR_mph ();                             // write matrix in STIR format
+    // void free_wm () ;                                      // delete wm
 
 
-    void read_prj_params_mph ();                          // read ring parameters from a file
+    // void write_wm_FC_mph ();                               // write double array weight matrix
 
-    void read_coll_params_mph ();                          // read collimator parameters from a file
+    // void write_wm_hdr_mph ();                              // write header of a matrix
 
-    void which_hole();
+    // void write_wm_STIR_mph ();                             // write matrix in STIR format
 
 
-    void fill_pcf ();                                      // fill precalculated functions
+    void read_prj_params_mph ( wmh_mph_type &wmh );                          // read ring parameters from a file
 
-    void free_pcf ();                                      // fill precalculated functions
+    void read_coll_params_mph ( wmh_mph_type &wmh );                          // read collimator parameters from a file
+
+    // void which_hole();
+
+
+    void fill_pcf ( wmh_mph_type &wmh, pcf_type &pcf );                                      // fill precalculated functions
+
+    // void free_pcf ();                                      // fill precalculated functions
 
 
 
     void calc_cumsum ( discrf2d_type *f );
 
-    void generate_msk_mph ( bool *msk_3d, float *att );    // create a boolean mask for wm (no weights outside the msk)
+    void generate_msk_mph ( bool *msk_3d, float *att, wmh_mph_type &wmh );    // create a boolean mask for wm (no weights outside the msk)
 
-    void read_msk_file_mph ( bool * msk );                 // read mask from a file
+    // void read_msk_file_mph ( bool * msk );                 // read mask from a file
 
 
     std::string wm_SPECT_read_value_1d ( std::ifstream * stream1, char DELIMITER );
 
-    void wm_SPECT_read_hvalues_mph ( std::ifstream * stream1, char DELIMITER, int * nh, bool do_cyl );
+    void wm_SPECT_read_hvalues_mph ( std::ifstream * stream1, char DELIMITER, int * nh, bool do_cyl, wmh_mph_type &wmh );
 
-    void read_att_map_mph ( float *attmap );               // read attenuation map from a file
+    // void read_att_map_mph ( float *attmap );               // read attenuation map from a file
 
 
 

--- a/src/include/stir/recon_buildblock/PinholeSPECTUB_Weight3d.h
+++ b/src/include/stir/recon_buildblock/PinholeSPECTUB_Weight3d.h
@@ -18,26 +18,19 @@
 
 namespace SPECTUB_mph
 {
-/* Global variables: the matrix etc TODO 
-   Need to be defined elsewhere
-
-   A lot of the functions below modify these variables.
-*/
-    //... global variables ..............................................
-
-    extern wmh_mph_type wmh;
-    extern wm_da_type wm;
-    extern pcf_type pcf;
 
     void wm_calculation_mph ( bool do_estim,
                 const int kOS,
                 psf2d_type *psf2d_bin,
-                psf2d_type *psf_subs ,
-                psf2d_type *psf2d_aux ,
+                psf2d_type *psf_subs,
+                psf2d_type *psf2d_aux,
                 psf2d_type *kern,
                 float *attmap,
                 bool *msk_3d,
-                int *Nitems );
+                int *Nitems,
+                wmh_mph_type &wmh,
+                wm_da_type &wm,
+                pcf_type &pcf );
 
     //... geometric component ............................................
 
@@ -49,21 +42,21 @@ namespace SPECTUB_mph
 
     //bool check_zang_obl( lor_type * l, voxel_type * vox, hole_type * h);
 
-    void voxel_projection_mph ( lor_type * l, voxel_type * v, hole_type * h );
+    void voxel_projection_mph ( lor_type * l, voxel_type * v, hole_type * h, wmh_mph_type &wmh );
 
 
-    void fill_psfi ( psf2d_type * kern );
+    void fill_psfi ( psf2d_type * kern, wmh_mph_type &wmh );
 
     void downsample_psf ( psf2d_type * psf_in, psf2d_type * psf_out, int factor, bool do_calc );
 
     void psf_convol( psf2d_type * psf1, psf2d_type * psf_aux, psf2d_type * psf2, bool do_calc );
 
-    float bresenh_f( int i1, int j1, int i2, int j2, float ** f, int imax, int jmax, float dcr );
+    float bresenh_f( int i1, int j1, int i2, int j2, float ** f, int imax, int jmax, float dcr, wmh_mph_type &wmh, pcf_type &pcf );
 
 
-    void fill_psf_geo ( psf2d_type *psf2d, lor_type *l, discrf2d_type *f, int factor, bool do_calc );
+    void fill_psf_geo ( psf2d_type *psf2d, lor_type *l, discrf2d_type *f, int factor, bool do_calc, wmh_mph_type &wmh );
 
-    void fill_psf_depth ( psf2d_type *psf2d, lor_type *l, discrf2d_type *f, int factor, bool do_calc );
+    void fill_psf_depth ( psf2d_type *psf2d, lor_type *l, discrf2d_type *f, int factor, bool do_calc, wmh_mph_type &wmh, pcf_type &pcf );
 
     void psf_convol ( psf2d_type * psf2d, psf2d_type * psf_aux, psf2d_type * kern );
 
@@ -71,7 +64,7 @@ namespace SPECTUB_mph
 
     //... attenuation...................................................
 
-    float calc_att_mph ( bin_type bin, voxel_type vox, float *attmap );
+    float calc_att_mph ( bin_type bin, voxel_type vox, float *attmap, wmh_mph_type &wmh );
 
     int comp_dist ( float dx, float dy, float dz, float dlast );
 

--- a/src/include/stir/recon_buildblock/ProjMatrixByBinPinholeSPECTUB.h
+++ b/src/include/stir/recon_buildblock/ProjMatrixByBinPinholeSPECTUB.h
@@ -137,6 +137,9 @@ class ProjMatrixByBinPinholeSPECTUB :
     //! Default constructor (calls set_defaults())
     ProjMatrixByBinPinholeSPECTUB();
 
+    // disable copy-constructor as currently unsafe to copy due to bare pointers
+    ProjMatrixByBinPinholeSPECTUB(const ProjMatrixByBinPinholeSPECTUB&) = delete;
+
     //! Destructor (deallocates UB SPECT memory)
     ~ProjMatrixByBinPinholeSPECTUB();
 
@@ -243,6 +246,10 @@ class ProjMatrixByBinPinholeSPECTUB :
     shared_ptr<const ProjDataInfo> proj_data_info_ptr;
 
     bool already_setup;
+
+    mutable SPECTUB_mph::wmh_mph_type wmh;       // weight matrix header.
+    mutable SPECTUB_mph::wm_da_type wm;          // double array weight matrix structure.
+    mutable SPECTUB_mph::pcf_type pcf;           // pre-calculated functions
 
     virtual void 
         calculate_proj_matrix_elems_for_one_bin(ProjMatrixElemsForOneBin&) const;

--- a/src/recon_buildblock/PinholeSPECTUB_Tools.cxx
+++ b/src/recon_buildblock/PinholeSPECTUB_Tools.cxx
@@ -27,8 +27,6 @@
 #include <time.h>
 #include "stir/info.h"
 #include "stir/error.h"
-#include "stir/warning.h"
-#include "stir/error.h"
 #include <boost/format.hpp>
 #include <boost/math/constants/constants.hpp>
 #include <boost/math/special_functions/fpclassify.hpp>
@@ -63,17 +61,12 @@ float dg2rd = boost::math::constants::pi<float>() / (float)180. ;
 #define DELIMITER1 '#' //delimiter character in input parameter text file
 #define DELIMITER2 '%' //delimiter character in input parameter text file
 
-//... global variables ..............................................
-
-extern wmh_mph_type wmh;
-extern wm_da_type wm;
-extern pcf_type pcf;
 
 //=============================================================================
 //=== wm_alloc =============================================================
 //=============================================================================
 
-void wm_alloc( int * Nitems)
+void wm_alloc( int * Nitems, wm_da_type &wm, wmh_mph_type &wmh )
 {
 
     //... double array wm.val and wm.col .....................................................
@@ -279,7 +272,7 @@ void write_wm_STIR_mph()
 //=== precalculated functions ===============================================
 //==============================================================================
 
-void fill_pcf()
+void fill_pcf( wmh_mph_type &wmh, pcf_type &pcf )
 {
     
     //... distribution function for a round shape hole .................
@@ -576,7 +569,7 @@ void read_prj_params_mph()
 }*/
 
 
-void read_prj_params_mph()
+void read_prj_params_mph( wmh_mph_type &wmh )
 {
 	string token;
     detel_type d;
@@ -729,7 +722,7 @@ void read_prj_params_mph()
 //=== read collimator params mph ===============================================
 //==============================================================================
 
-void read_coll_params_mph( )
+void read_coll_params_mph( wmh_mph_type &wmh )
 {
 	string token;
     vector<string> param;
@@ -757,9 +750,9 @@ void read_coll_params_mph( )
 //    wmh.collim.holes = new hole_type [ wmh.collim.Nht ];
     
     int nh = 0;
-    if ( wmh.collim.model == "cyl" ) wm_SPECT_read_hvalues_mph( &stream1, DELIMITER, &nh, true );
+    if ( wmh.collim.model == "cyl" ) wm_SPECT_read_hvalues_mph( &stream1, DELIMITER, &nh, true, wmh );
     else{
-        if ( wmh.collim.model == "pol" ) wm_SPECT_read_hvalues_mph( &stream1, DELIMITER, &nh, false );
+        if ( wmh.collim.model == "pol" ) wm_SPECT_read_hvalues_mph( &stream1, DELIMITER, &nh, false, wmh );
         else error_wmtools_SPECT_mph ( 334, 0, wmh.collim.model );
     }
     
@@ -790,7 +783,7 @@ void read_coll_params_mph( )
 //======== wm_SPECT_read_hvalues_mph ==============================
 //=====================================================================
 
-void wm_SPECT_read_hvalues_mph( ifstream * stream1 , char DELIMITER, int * nh, bool do_cyl )
+void wm_SPECT_read_hvalues_mph( ifstream * stream1 , char DELIMITER, int * nh, bool do_cyl, wmh_mph_type &wmh )
 {
     
     size_t pos1, pos2, pos3;
@@ -994,7 +987,7 @@ void wm_SPECT_read_hvalues_mph( ifstream * stream1 , char DELIMITER, int * nh, b
 //=== generate_msk_mph ========================================================
 //=============================================================================
 
-void generate_msk_mph ( bool *msk_3d, float *attmap )
+void generate_msk_mph ( bool *msk_3d, float *attmap, wmh_mph_type &wmh )
 {
     
 //    bool do_save_resulting_msk = true;


### PR DESCRIPTION
Fixes #1211 by changing global variables to class members. Info added to `release_5.2.htm`.

See #1169 for further discussion made during removal of global variables for SPECTUB.

All tests pass in `recon_test_pack/SPECT/PinholeSPECT/` and SIRF allows multiple projectors with PinholeSPECTUBMatrix.