### PR TITLE
.gitignore install/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,7 @@ install_manifest.txt
 
 # Ignore Visual Studio Code User-specific files
 build/
+install/
 
 # MATLAB
 


### PR DESCRIPTION
Similar to `build/`, vs code creates an `install/` directory that is annoying for tracking. This should have been added to  #1135
