### PR TITLE
[Python] fix ProjData_read_from_file

### DIFF
--- a/documentation/release_5.2.htm
+++ b/documentation/release_5.2.htm
@@ -63,6 +63,8 @@
 
 <h4>Python</h4>
 <ul>
+  <li>Examples use <code>stir.ProjData.read_from_file</code> as opposed to <code>stir.ProjData_read_from_file</code>. The former is supported since SWIG 3.0, and the <a href="https://swig.org/Doc4.1/Python.html#Python_nn20">default from SWIG 4.1</a>.
+    </li>
 </ul>
 
 <h3>Changed functionality</h3>

--- a/examples/python/plot_sinogram_profiles.py
+++ b/examples/python/plot_sinogram_profiles.py
@@ -36,7 +36,7 @@ def plot_sinogram_profiles(projection_data_list, sumaxis=0, select=0):
         if isinstance(f, str):
             print(f"Handling:\n  {f}")
             label = f
-            f = stir.ProjData_read_from_file(f)
+            f = stir.ProjData.read_from_file(f)
  
         if isinstance(f, stir.ProjData):
             f = stirextra.to_numpy(f)

--- a/examples/python/projdata_visualisation/BackendTools/STIRInterface.py
+++ b/examples/python/projdata_visualisation/BackendTools/STIRInterface.py
@@ -43,7 +43,7 @@ class ProjDataVisualisationBackend:
         if self.projdata_filename != "":
             print("ProjDataVisualisationBackend.load_data: Loading data from file: " + self.projdata_filename)
             try:
-                self.projdata = stir.ProjData_read_from_file(self.projdata_filename)
+                self.projdata = stir.ProjData.read_from_file(self.projdata_filename)
                 self.segment_data = self.refresh_segment_data()
                 print("ProjDataVisualisationBackend.load_data: Data loaded.")
                 self.print_projdata_configuration()

--- a/examples/python/projdata_visualisation/demo_ProjDataVisualisation.py
+++ b/examples/python/projdata_visualisation/demo_ProjDataVisualisation.py
@@ -17,7 +17,7 @@ from ProjDataVisualisation import OpenProjDataVisualisation
 
 # Load data for demo (example case)
 filename = "examples/recon_demo/smalllong.hs"
-proj_data = stir.ProjData_read_from_file(filename)
+proj_data = stir.ProjData.read_from_file(filename)
 
 # Now open the GUI and pass the proj_data object
 OpenProjDataVisualisation(proj_data)


### PR DESCRIPTION
`stir.ProjData_read_from_file` is not available on recent SWIG (4.1) unless you use a specific switch, see https://swig.org/Doc4.1/Python.html#Python_nn20. So use `stir.ProjData.read_from_file`
