### PR TITLE
fix xy imagesize of FBP SPECTUB image in test

### DIFF
--- a/recon_test_pack/SPECT/SPECTUB/FBP2D.par
+++ b/recon_test_pack/SPECT/SPECTUB/FBP2D.par
@@ -3,6 +3,7 @@ output filename prefix := out/FBP
 input file := input.hs
 Z output image size (in pixels):=64
 z zoom:=.5
+xy output image size (in pixels) := 129
 Back Projector type:= matrix
   Back Projector Using Matrix Parameters :=
 	Matrix type := SPECT UB


### PR DESCRIPTION
The code determining the xy image size is sensitive to rounding errors, so we now say in the .par file what the test expects.

Fixes #1193