### PR TITLE
Disable logging within distributed OpenMP calls by default and make all logging thread safe.

### DIFF
--- a/documentation/release_5.2.htm
+++ b/documentation/release_5.2.htm
@@ -85,6 +85,10 @@
   <li>The parameter <code>use_view_offset</code> was removed from the <code>interpolate_projdata</code> functions. View-offset is now always taken into account.
   <br /><a href="https://github.com/UCL/STIR/pull/1172/">PR #1172</a>.
   </li>
+  <li>The info, warning and error calls are thread safe now (which makes them slower), and the logging output in <code>distributable.cxx</code> was changed from verbosity 2 (which is the STIR default) to verbosity 3.
+    This is to reduce the default output during iterative reconstructions.
+  <br /><a href="https://github.com/UCL/STIR/pull/1243/">PR #1243</a>.
+  </li>
 </ul>
 
 <h3>Deprecated functionality</h3>

--- a/src/buildblock/TextWriter.cxx
+++ b/src/buildblock/TextWriter.cxx
@@ -7,17 +7,22 @@ aTextWriter* TextWriterHandle::warning_channel_;
 aTextWriter* TextWriterHandle::error_channel_;
 
 void writeText(const char* text, OUTPUT_CHANNEL channel) {
-	TextWriterHandle h;
-	switch (channel) {
-	case INFORMATION_CHANNEL:
-		h.print_information(text);
-		break;
-	case WARNING_CHANNEL:
-		h.print_warning(text);
-		break;
-	case ERROR_CHANNEL:
-		h.print_error(text);
-	}
+#if defined(STIR_OPENMP)
+  #pragma omp critical(TEXTWRITER)
+#endif
+  {
+    TextWriterHandle h;
+    switch (channel) {
+    case INFORMATION_CHANNEL:
+      h.print_information(text);
+      break;
+    case WARNING_CHANNEL:
+      h.print_warning(text);
+      break;
+    case ERROR_CHANNEL:
+      h.print_error(text);
+    }
+  }
 }
 
 END_NAMESPACE_STIR

--- a/src/recon_buildblock/distributable.cxx
+++ b/src/recon_buildblock/distributable.cxx
@@ -479,10 +479,10 @@ void distributable_computation(
           const int thread_num=omp_get_thread_num();
           info(boost::format("Thread %d/%d calculating segment_num: %d, view_num: %d")
                % thread_num % omp_get_num_threads()
-               % view_segment_num.segment_num() % view_segment_num.view_num(), 2);
+               % view_segment_num.segment_num() % view_segment_num.view_num(), 3);
 #else
           info(boost::format("calculating segment_num: %d, view_num: %d")
-               % view_segment_num.segment_num() % view_segment_num.view_num(), 2);
+               % view_segment_num.segment_num() % view_segment_num.view_num(), 3);
 #endif
 
 #ifdef STIR_OPENMP


### PR DESCRIPTION
Fixes https://github.com/UCL/STIR/issues/1241.