### PR TITLE
fix SPECTUB bug with collimator slope division by 10

### DIFF
--- a/documentation/release_5.2.htm
+++ b/documentation/release_5.2.htm
@@ -26,7 +26,8 @@
 
 <h3>Bug fixes</h3>
 <ul>
-<li>Scatter estimation was setting initial activity image to 1 at set-up, effectively ignoring the initial image, aside from geometric info.</li>
+  <li>Scatter estimation was setting initial activity image to 1 at set-up, effectively ignoring the initial image, aside from geometric info.</li>
+  <li>Setting SPECTUB resolution model with STIR python or SIRF divided slope by 10 in error. The problem did not occur when set using parameter file</li>
 </ul>
 
 <h3>New functionality</h3>

--- a/src/include/stir/recon_buildblock/ProjMatrixByBinSPECTUB.h
+++ b/src/include/stir/recon_buildblock/ProjMatrixByBinSPECTUB.h
@@ -148,7 +148,7 @@ class ProjMatrixByBinSPECTUB :
   */
 
   void
-    set_resolution_model(const float collimator_sigma_0_in_mm, const float collimator_slope_in_mm, const bool full_3D = true);
+    set_resolution_model(const float collimator_sigma_0_in_mm, const float collimator_slope, const bool full_3D = true);
  private:
 
   // parameters that will be parsed

--- a/src/recon_buildblock/ProjMatrixByBinSPECTUB.cxx
+++ b/src/recon_buildblock/ProjMatrixByBinSPECTUB.cxx
@@ -205,10 +205,11 @@ set_attenuation_image_sptr(const std::string& value)
 
 void
 ProjMatrixByBinSPECTUB::
-set_resolution_model(const float collimator_sigma_0_in_mm, const float collimator_slope_in_mm, const bool full_3D)
+set_resolution_model(const float collimator_sigma_0_in_mm, const float collimator_slope, const bool full_3D)
 {
+  // convert sigma_0 to cm. slope is dimensionless
   this->collimator_sigma_0 = collimator_sigma_0_in_mm / 10;
-  this->collimator_slope = collimator_slope_in_mm / 10;
+  this->collimator_slope = collimator_slope;
   if (collimator_slope == 0.F && collimator_sigma_0 == 0.F)
     {
       this->psf_type = "geometrical";


### PR DESCRIPTION
Using set_resolution_model() with SPECTUB currently divides the slope by 10. This should not be the case as the slope is dimensionless.

Changed the code to reflect this and renamed the collimator slope variable