### PR TITLE
rewrite ProjDataInMemory to avoid streams

### DIFF
--- a/documentation/release_5.2.htm
+++ b/documentation/release_5.2.htm
@@ -126,6 +126,10 @@
     re-use for generic/blocksoncylindrical scanners.
     <br /><a href="https://github.com/UCL/STIR/pull/1222/">PR #1222</a>.
   </li>
+  <li>rewritten <code>ProjDataInMemory</code> to avoid streams, causing a speed-up of some
+    operations, and removing a limit of total size of 2GB.
+    <br /><a href="https://github.com/UCL/STIR/pull/1260/">PR #1260</a>.
+  </li>
 </ul>
 
 

--- a/src/buildblock/ProjDataInMemory.cxx
+++ b/src/buildblock/ProjDataInMemory.cxx
@@ -5,11 +5,15 @@
   \brief Implementations for non-inline functions of class stir::ProjDataInMemory
 
   \author Kris Thielemans
+  \author Nikos Efthimiou
+  \author Gemma Fardell
 */
 /*
     Copyright (C) 2002 - 2011-02-23, Hammersmith Imanet Ltd
     Copyright (C) 2011, Kris Thielemans
-    Copyright (C) 2019, 2020, UCL
+    Copyright (C) 2016, University of Hull
+    Copyright (C) 2016, 2019, 2020, 2023, UCL
+    Copyright (C) 2020,  Rutherford Appleton Laboratory STFC
     This file is part of STIR.
 
     SPDX-License-Identifier: Apache-2.0
@@ -24,46 +28,47 @@
 #include "stir/SegmentByView.h"
 #include "stir/Bin.h"
 #include "stir/is_null_ptr.h"
-#include "stir/error.h"
-#include <fstream>
+#include <iostream>
 #include <cstring>
+#include <algorithm>
 
-#ifdef STIR_USE_OLD_STRSTREAM
-#include <strstream>
-#else
-#include <boost/interprocess/streams/bufferstream.hpp>
-#endif
-
-#ifndef STIR_NO_NAMESPACES
-using std::fstream;
-using std::iostream;
-using std::ios;
-#ifdef STIR_USE_OLD_STRSTREAM
-using std::strstream;
-#endif
 using std::string;
-#endif
+using std::streamoff;
 
 START_NAMESPACE_STIR
 
 ProjDataInMemory::
 ~ProjDataInMemory()
-{
-  // release such that it can deallocate safely
-  this->buffer.release_data_ptr();
-}
+{}
 
 ProjDataInMemory::
 ProjDataInMemory(shared_ptr<const ExamInfo> const& exam_info_sptr,
 		 shared_ptr<const ProjDataInfo> const& proj_data_info_ptr, const bool initialise_with_0)
   :
-  ProjDataFromStream(exam_info_sptr, proj_data_info_ptr, shared_ptr<iostream>(), // trick: first initialise sino_stream_ptr to 0
-                     std::streamoff(0),
-                     ProjData::standard_segment_sequence(*proj_data_info_ptr),
-                     Segment_AxialPos_View_TangPos)
+  ProjData(exam_info_sptr, proj_data_info_ptr),
+  segment_sequence(ProjData::standard_segment_sequence(*proj_data_info_ptr))
 {
   this->create_buffer(initialise_with_0);
-  this->create_stream();
+
+  int sum = 0;
+  for (int segment_num = proj_data_info_sptr->get_min_segment_num();
+       segment_num<=proj_data_info_sptr->get_max_segment_num();
+       ++segment_num)
+    {
+      sum += get_num_axial_poss(segment_num) * get_num_views() * get_num_tangential_poss();
+    }
+
+  offset_3d_data = static_cast<streamoff> (sum);
+
+  timing_poss_sequence.resize(proj_data_info_sptr->get_num_tof_poss());
+
+  for (int i= 0, timing_pos_num = proj_data_info_sptr->get_min_tof_pos_num();
+       timing_pos_num<=proj_data_info_sptr->get_max_tof_pos_num();
+       ++i, ++timing_pos_num)
+    {
+      timing_poss_sequence[i] = timing_pos_num;
+    }
+
 }
 
 void
@@ -71,38 +76,317 @@ ProjDataInMemory::
 create_buffer(const bool initialise_with_0)
 {
 #if 0  
-  float *b = new float[this->get_size_of_buffer_in_bytes()/sizeof(float)];
+  float *b = new float[this->size_all()];
   if (initialise_with_0)
-      memset(b, 0, this->get_size_of_buffer_in_bytes());
+    memset(b, 0, this->size_all()*sizeof(float));
   return b;
 #else
-  this->buffer = Array<1,float>(0, static_cast<int>(this->get_size_of_buffer_in_bytes()/sizeof(float))-1);
+  this->buffer = Array<1,float>(static_cast<int>(this->size_all()));
 #endif
 }
 
-void
-ProjDataInMemory::
-create_stream()
+///////////////// /set functions
+
+namespace detail {
+  template <int num_dimensions>
+  void copy_data_from_buffer(const Array<1,float>& buffer, Array<num_dimensions, float>& array, std::streamoff offset)
+  {
+#ifdef STIR_OPENMP
+#pragma omp critical(PROJDATAINMEMORYCOPY)
+#endif
+    {
+      const float * ptr = buffer.get_const_data_ptr() + offset;
+      std::copy(ptr, ptr + array.size_all(), array.begin_all());
+      buffer.release_const_data_ptr();
+    }
+  }
+
+  template <int num_dimensions>
+  void copy_data_to_buffer(Array<1,float>& buffer, const Array<num_dimensions, float>& array, std::streamoff offset)
+  {
+#ifdef STIR_OPENMP
+#pragma omp critical(PROJDATAINMEMORYCOPY)
+#endif
+    {
+      float * ptr = buffer.get_data_ptr() + offset;
+      std::copy(array.begin_all(), array.end_all(), ptr);
+      buffer.release_data_ptr();
+    }
+  }
+}
+
+Viewgram<float>
+ProjDataInMemory::get_viewgram(const int view_num, const int segment_num,
+                                 const bool make_num_tangential_poss_odd
+#ifdef STIR_TOF
+                               , const int timing_pos
+#endif
+                               ) const
 {
-  shared_ptr<std::iostream> output_stream_sptr;
-#ifdef STIR_USE_OLD_STRSTREAM
-  output_stream_sptr.reset(new strstream(buffer.get_data_ptr(), this->get_size_of_buffer_in_bytes(), ios::in | ios::out | ios::binary));
-#else
-  // Use boost::bufferstream to avoid reallocate.
-  // For std::stringstream, the only way to do this is by passing a string of the appropriate size
-  // However, if basic_string doesn't do reference counting, we would have
-  // temporarily 2 strings of a (potentially large) size in memory.
-  output_stream_sptr.reset
-          (new boost::interprocess::bufferstream(reinterpret_cast<char*>(this->buffer.get_data_ptr()), this->get_size_of_buffer_in_bytes(), ios::in | ios::out | ios::binary));
+  Viewgram<float> viewgram(proj_data_info_sptr, view_num, segment_num
+#ifdef STIR_TOF
+                           , timing_pos
+#endif
+                           );
+  Bin bin(segment_num, view_num, this->get_min_axial_pos_num(segment_num), this->get_min_tangential_pos_num()
+#ifdef STIR_TOF
+          , timing_pos
+#endif
+          );
+
+  for (bin.axial_pos_num() = get_min_axial_pos_num(segment_num); bin.axial_pos_num() <= get_max_axial_pos_num(segment_num); bin.axial_pos_num()++)
+    {
+      detail::copy_data_from_buffer(this->buffer, viewgram[bin.axial_pos_num()], this->get_index(bin));
+    }
+
+  if (make_num_tangential_poss_odd &&(get_num_tangential_poss()%2==0))
+
+    {
+      const int new_max_tangential_pos = get_max_tangential_pos_num() + 1;
+
+      viewgram.grow(
+                    IndexRange2D(get_min_axial_pos_num(segment_num),
+                                 get_max_axial_pos_num(segment_num),
+                                 get_min_tangential_pos_num(),
+                                 new_max_tangential_pos));
+    }
+  return viewgram;
+}
+
+Succeeded
+ProjDataInMemory::set_viewgram(const Viewgram<float>& v)
+{
+  if (*get_proj_data_info_sptr() != *(v.get_proj_data_info_sptr()))
+    {
+      warning("ProjDataInMemory::set_viewgram: viewgram has incompatible ProjDataInfo member\n"
+              "Original ProjDataInfo: %s\n"
+              "ProjDataInfo From viewgram: %s",
+              this->get_proj_data_info_sptr()->parameter_info().c_str(),
+              v.get_proj_data_info_sptr()->parameter_info().c_str()
+              );
+
+      return Succeeded::no;
+    }
+  const int segment_num = v.get_segment_num();
+  const int view_num = v.get_view_num();
+#ifdef STIR_TOF
+  const int timing_pos = v.get_timing_pos_num();
 #endif
 
-  if (!*output_stream_sptr)
-    error("ProjDataInMemory error initialising stream");
+  Bin bin(segment_num, view_num, this->get_min_axial_pos_num(segment_num), this->get_min_tangential_pos_num()
+#ifdef STIR_TOF
+          , timing_pos
+#endif
+          );
 
-  this->sino_stream = output_stream_sptr;
+  for (bin.axial_pos_num() = get_min_axial_pos_num(segment_num); bin.axial_pos_num() <= get_max_axial_pos_num(segment_num); bin.axial_pos_num()++)
+    {
+      detail::copy_data_to_buffer(this->buffer, v[bin.axial_pos_num()], this->get_index(bin));
+    }
+
+  return Succeeded::yes;
 }
 
 
+std::streamoff
+ProjDataInMemory::get_index(const Bin& this_bin) const
+{
+  if (!(this_bin.segment_num() >= get_min_segment_num() &&
+        this_bin.segment_num() <=  get_max_segment_num()))
+    error("ProjDataInMemory::this->get_index: segment_num out of range : %d", this_bin.segment_num());
+
+  if (!(this_bin.axial_pos_num() >= get_min_axial_pos_num(this_bin.segment_num()) &&
+        this_bin.axial_pos_num() <=  get_max_axial_pos_num(this_bin.segment_num())))
+    error("ProjDataInMemory::this->get_index: axial_pos_num out of range : %d", this_bin.axial_pos_num());
+#ifdef STIR_TOF
+  if (!(this_bin.timing_pos_num() >= get_min_tof_pos_num() &&
+        this_bin.timing_pos_num() <=  get_max_tof_pos_num()))
+    error("ProjDataInMemory::this->get_index: timing_pos_num out of range : %d", this_bin.timing_pos_num());
+#endif
+
+  const int index =
+    static_cast<int>(std::find(segment_sequence.begin(), segment_sequence.end(), this_bin.segment_num()) -
+                     segment_sequence.begin());
+
+  streamoff num_axial_pos_offset = 0;
+
+  for (int i=0; i<index; i++)
+    num_axial_pos_offset +=
+      get_num_axial_poss(segment_sequence[i]);
+
+  streamoff segment_offset =
+    static_cast<streamoff>(num_axial_pos_offset*
+                           get_num_tangential_poss() *
+                           get_num_views());
+
+  // Now we are just in front of  the correct segment
+  {
+#ifdef STIR_TOF
+    if (proj_data_info_sptr->get_num_tof_poss() > 1)
+      {
+        const int timing_index = static_cast<int>(std::find(timing_poss_sequence.begin(), timing_poss_sequence.end(), this_bin.timing_pos_num()) -
+                                                  timing_poss_sequence.begin());
+
+        assert(offset_3d_data > 0);
+        segment_offset += static_cast<streamoff>(timing_index) * offset_3d_data;
+      }
+#endif
+    // skip axial positions
+    const streamoff ax_pos_offset =
+      (this_bin.axial_pos_num() - get_min_axial_pos_num(this_bin.segment_num()))*
+      get_num_views() *
+      get_num_tangential_poss();
+
+    // sinogram location
+
+    //find view
+    const streamoff view_offset =
+      (this_bin.view_num() - get_min_view_num())
+      * get_num_tangential_poss();
+
+    // find tang pos
+    const streamoff tang_offset =
+      (this_bin.tangential_pos_num() - get_min_tangential_pos_num());
+
+    return segment_offset + ax_pos_offset + view_offset +tang_offset;
+  }
+}
+
+Sinogram<float>
+ProjDataInMemory::get_sinogram(const int ax_pos_num, const int segment_num,
+                                 const bool make_num_tangential_poss_odd
+#ifdef STIR_TOF
+                               , const int timing_pos
+#endif
+                               ) const
+{
+  Sinogram<float> sinogram(proj_data_info_sptr, ax_pos_num, segment_num
+#ifdef STIR_TOF
+                           , timing_pos
+#endif
+                           );
+  Bin bin(segment_num, this->get_min_view_num(), ax_pos_num, this->get_min_tangential_pos_num()
+#ifdef STIR_TOF
+          , timing_pos
+#endif
+          );
+
+  detail::copy_data_from_buffer(this->buffer, sinogram, this->get_index(bin));
+
+  if (make_num_tangential_poss_odd&&(get_num_tangential_poss()%2==0))
+    {
+      int new_max_tangential_pos = get_max_tangential_pos_num() + 1;
+
+      sinogram.grow(IndexRange2D(get_min_view_num(),
+                                 get_max_view_num(),
+                                 get_min_tangential_pos_num(),
+                                 new_max_tangential_pos));
+    }
+
+  return sinogram;
+}
+
+Succeeded
+ProjDataInMemory::set_sinogram(const Sinogram<float>& s)
+{
+  if (*get_proj_data_info_sptr() != *(s.get_proj_data_info_sptr()))
+  {
+    warning("ProjDataInMemory::set_sinogram: Sinogram<float> has incompatible ProjDataInfo member.\n"
+            "Original ProjDataInfo: %s\n"
+            "ProjDataInfo from sinogram: %s",
+            this->get_proj_data_info_sptr()->parameter_info().c_str(),
+            s.get_proj_data_info_sptr()->parameter_info().c_str()
+            );
+
+    return Succeeded::no;
+  }
+  int segment_num = s.get_segment_num();
+  int ax_pos_num = s.get_axial_pos_num();
+#ifdef STIR_TOF
+  int timing_pos = s.get_timing_pos_num();
+#endif
+  Bin bin(segment_num, this->get_min_view_num(), ax_pos_num, this->get_min_tangential_pos_num()
+#ifdef STIR_TOF
+          , timing_pos
+#endif
+          );
+
+  detail::copy_data_to_buffer(this->buffer, s, this->get_index(bin));
+  return Succeeded::yes;
+}
+
+SegmentBySinogram<float>
+ProjDataInMemory::get_segment_by_sinogram(const int segment_num
+#ifdef STIR_TOF
+                                          , const int timing_pos_num
+#endif
+                                          ) const
+{
+  SegmentBySinogram<float> segment(proj_data_info_sptr,segment_num
+#ifdef STIR_TOF
+                                   , timing_pos_num
+#endif
+                                   );
+  const Bin bin(segment_num, this->get_min_view_num(), this->get_min_axial_pos_num(segment_num), this->get_min_tangential_pos_num()
+#ifdef STIR_TOF
+                , timing_pos_num
+#endif
+                );
+  detail::copy_data_from_buffer(this->buffer, segment, this->get_index(bin));
+  return segment;
+}
+
+SegmentByView<float>
+ProjDataInMemory::get_segment_by_view(const int segment_num
+#ifdef STIR_TOF
+                                      , const int timing_pos
+#endif
+                                      ) const
+{
+  // TODO rewrite in terms of get_sinogram as this doubles memory temporarily
+  return SegmentByView<float> (get_segment_by_sinogram(segment_num
+#ifdef STIR_TOF
+                                                       , timing_pos
+#endif
+                                                       ));
+}
+
+Succeeded
+ProjDataInMemory::set_segment(const SegmentBySinogram<float>& segmentbysinogram_v)
+{
+  if (get_num_tangential_poss() != segmentbysinogram_v.get_num_tangential_poss())
+  {
+    warning("ProjDataInMemory::set_segmen: num_bins is not correct\n");
+    return Succeeded::no;
+  }
+  if (get_num_views() != segmentbysinogram_v.get_num_views())
+  {
+    warning("ProjDataInMemory::set_segment: num_views is not correct\n");
+    return Succeeded::no;
+  }
+
+  const int segment_num = segmentbysinogram_v.get_segment_num();
+  const Bin bin(segment_num, this->get_min_view_num(), this->get_min_axial_pos_num(segment_num), this->get_min_tangential_pos_num()
+#ifdef STIR_TOF
+                , segmentbysinogram_v.get_timing_pos_num()
+#endif
+                );
+
+  detail::copy_data_to_buffer(this->buffer, segmentbysinogram_v, this->get_index(bin));
+  return Succeeded::yes;
+}
+
+
+Succeeded
+ProjDataInMemory::set_segment(const SegmentByView<float>& segmentbyview_v)
+{
+  // TODO rewrite in terms of set_sinogram
+  const SegmentBySinogram<float> segmentbysinogram(segmentbyview_v);
+  return set_segment(segmentbysinogram);
+}
+
+
+/////////////////  other functions
 void
 ProjDataInMemory::fill(const float value)
 {
@@ -126,63 +410,32 @@ ProjDataInMemory::fill(const ProjData& proj_data)
 
 ProjDataInMemory::
 ProjDataInMemory(const ProjData& proj_data)
-  : ProjDataFromStream(proj_data.get_exam_info_sptr(),
-		       proj_data.get_proj_data_info_sptr()->create_shared_clone(), shared_ptr<iostream>(),
-                       std::streamoff(0),
-                       ProjData::standard_segment_sequence(*proj_data.get_proj_data_info_sptr()),
-                       Segment_AxialPos_View_TangPos)
+  : ProjDataInMemory(proj_data.get_exam_info_sptr(),
+		       proj_data.get_proj_data_info_sptr()->create_shared_clone(),
+                     false)
 {
-  this->create_buffer();
-  this->create_stream();
-
-  // copy data
   this->fill(proj_data);
 }
 
 ProjDataInMemory::
 ProjDataInMemory (const ProjDataInMemory& proj_data)
-    : ProjDataFromStream(proj_data.get_exam_info_sptr(),
-                         proj_data.get_proj_data_info_sptr()->create_shared_clone(), shared_ptr<iostream>(),
-                         std::streamoff(0),
-                         ProjData::standard_segment_sequence(*proj_data.get_proj_data_info_sptr()),
-                         Segment_AxialPos_View_TangPos)
+    : ProjDataInMemory(proj_data.get_exam_info_sptr(),
+                       proj_data.get_proj_data_info_sptr()->create_shared_clone(),
+                       false)
 {
-  this->create_buffer();
-  this->create_stream();
-
-  // copy data
-  std::copy(proj_data.begin_all(), proj_data.end_all(), begin_all());
-  //this->fill(proj_data);
-}
-
-size_t
-ProjDataInMemory::
-get_size_of_buffer_in_bytes() const
-{
-  return size_all() * sizeof(float);
+  std::copy(proj_data.begin_all(), proj_data.end_all(), this->begin_all());
 }
 
 float 
 ProjDataInMemory::get_bin_value(Bin& bin)
 {
-  // first find offset in the stream
-  std::vector<std::streamoff> offsets = get_offsets_bin(bin);
-  const std::streamoff total_offset = offsets[0];
-  // now convert to index in the buffer
-  const int index = static_cast<int>(total_offset/sizeof(float));
-  return buffer[index];
+  return buffer[this->get_index(bin)];
 }
 
 void 
 ProjDataInMemory::set_bin_value(const Bin& bin)
 {
-  // first find offset in the stream
-  std::vector<std::streamoff> offsets = get_offsets_bin(bin);
-  const std::streamoff total_offset = offsets[0];
-  // now convert to index in the buffer
-  const int index = static_cast<int>(total_offset/sizeof(float));
-  
-   buffer[index]=bin.get_bin_value();
+  buffer[this->get_index(bin)]=bin.get_bin_value();
 }
 
 void


### PR DESCRIPTION
`ProjDataInMemory` was derived from `ProjDataFromStream`, which meant we had to write less code. However, this meant it was slower than just doing the copies from memory directly.

Also, due to a limitation in `boost::interprocess::bufferstream`, total size was limited to 2 GB.

Bits of the code are currently ugly to be compatible with both master and the TOF branch. There's some copies related to offsets from the (TOF) `ProjDataFromStream` class.

Fixes #1240