### PR TITLE
Allow KeyParser keyword with colon

### DIFF
--- a/documentation/release_5.2.htm
+++ b/documentation/release_5.2.htm
@@ -41,6 +41,7 @@
     hard-coded variables for the Siemens mMR have been removed. Further testing of this functionality is still required however.
     <br /><a href="https://github.com/UCL/STIR/pull/1182/">PR #1182</a>.
   </li>
+  <li>Interfile header parsing now correctly identifies keywords that contain a colon by checking for <tt>:=</tt>./li>
 </ul>
 
 <h3>New functionality</h3>

--- a/src/IO/InterfileHeaderSiemens.cxx
+++ b/src/IO/InterfileHeaderSiemens.cxx
@@ -10,7 +10,7 @@
 /*!
   \file 
   \ingroup InterfileIO 
-  \brief implementations for the stir::InterfileHeaderSiemens class
+  \brief implementations for the stir::InterfileHeaderSiemens classes
 
   \author Kris Thielemans
   \author PARAPET project
@@ -163,6 +163,36 @@ void InterfileHeaderSiemens::set_type_of_data()
 }
 
 
+void
+InterfileHeaderSiemens::ignore_Siemens_date_and_time_keys(const std::string& keyword)
+{
+  ignore_key(keyword + " date (yyyy:mm:dd)");
+  ignore_key(keyword + " time (hh:mm:ss GMT+00:00)");
+  ignore_key(keyword + " time (hh:mm:ss GMT+01:00)");
+  ignore_key(keyword + " time (hh:mm:ss GMT+02:00)");
+  ignore_key(keyword + " time (hh:mm:ss GMT+03:00)");
+  ignore_key(keyword + " time (hh:mm:ss GMT+04:00)");
+  ignore_key(keyword + " time (hh:mm:ss GMT+05:00)");
+  ignore_key(keyword + " time (hh:mm:ss GMT+06:00)");
+  ignore_key(keyword + " time (hh:mm:ss GMT+07:00)");
+  ignore_key(keyword + " time (hh:mm:ss GMT+08:00)");
+  ignore_key(keyword + " time (hh:mm:ss GMT+09:00)");
+  ignore_key(keyword + " time (hh:mm:ss GMT+10:00)");
+  ignore_key(keyword + " time (hh:mm:ss GMT+11:00)");
+  ignore_key(keyword + " time (hh:mm:ss GMT-01:00)");
+  ignore_key(keyword + " time (hh:mm:ss GMT-02:00)");
+  ignore_key(keyword + " time (hh:mm:ss GMT-03:00)");
+  ignore_key(keyword + " time (hh:mm:ss GMT-04:00)");
+  ignore_key(keyword + " time (hh:mm:ss GMT-05:00)");
+  ignore_key(keyword + " time (hh:mm:ss GMT-06:00)");
+  ignore_key(keyword + " time (hh:mm:ss GMT-07:00)");
+  ignore_key(keyword + " time (hh:mm:ss GMT-08:00)");
+  ignore_key(keyword + " time (hh:mm:ss GMT-09:00)");
+  ignore_key(keyword + " time (hh:mm:ss GMT-10:00)");
+  ignore_key(keyword + " time (hh:mm:ss GMT-11:00)");
+}
+
+
 /**********************************************************************/
 
 InterfileRawDataHeaderSiemens::InterfileRawDataHeaderSiemens()
@@ -205,13 +235,11 @@ InterfileRawDataHeaderSiemens::InterfileRawDataHeaderSiemens()
   ignore_key("%listmode header file");
   ignore_key("%listmode data file");
   ignore_key("%compressor version");
-  ignore_key("%study date (yyyy");
-  ignore_key("%study time (hh");
+  ignore_Siemens_date_and_time_keys("%study");
   ignore_key("isotope gamma halflife (sec)");
   ignore_key("isotope branching factor");
   ignore_key("radiopharmaceutical");
-  ignore_key("%tracer injection date (yyyy");
-  ignore_key("%tracer injection time (hh");
+  ignore_Siemens_date_and_time_keys("%tracer injection");
   ignore_key("relative time of tracer injection (sec)");
   ignore_key("tracer activity at time of injection (bq)");
   ignore_key("injected volume (ml)");
@@ -223,8 +251,7 @@ InterfileRawDataHeaderSiemens::InterfileRawDataHeaderSiemens()
   ignore_key("method of scatter correction");
   ignore_key("%method of random correction");
   ignore_key("%decay correction");
-  ignore_key("%decay correction reference date (yyyy");
-  ignore_key("%decay correction reference time (hh");
+  ignore_Siemens_date_and_time_keys("%decay correction reference");
   ignore_key("decay correction factor");
   ignore_key("scatter fraction (%)");
   ignore_key("scan data type description");
@@ -542,11 +569,7 @@ InterfileNormHeaderSiemens::InterfileNormHeaderSiemens()
   is_arccorrected = false; // norm data is never arc-corrected
 
   ignore_key("data description");
-  ignore_key("%expiration date (yyyy:mm:dd)");
-  ignore_key("%expiration time (hh:mm:ss GMT-05:00)");
-  // currently keywords are truncated at :
-  ignore_key("%expiration time (hh");
-  ignore_key("%expiration date (yyyy");
+  ignore_Siemens_date_and_time_keys("%expiration");
   ignore_key("%raw normalization scans description");
 
   // remove some standard keys, which Siemens has replaced with similar names
@@ -573,11 +596,7 @@ InterfileNormHeaderSiemens::InterfileNormHeaderSiemens()
   ignore_key("%global scanner calibration factor");
   add_key("%scanner quantification factor (Bq*s/ECAT counts)",& calib_factor);
   add_key("%cross calibration factor",& cross_calib_factor);
-  ignore_key("%calibration date (yyyy:mm:dd)");
-  ignore_key("%calibration time (hh:mm:ss GMT+00:00)");
-  // currently keywords are truncated at :
-  ignore_key("%calibration time (hh");
-  ignore_key("%calibration date (yyyy");
+  ignore_Siemens_date_and_time_keys("%calibration");
 
   // isotope things are vectorised in norm files and not in other raw data, so we could
   // fix that, but as we are not interested in it anyway (tends to be Ge-68), let's just ignore it.

--- a/src/buildblock/KeyParser.cxx
+++ b/src/buildblock/KeyParser.cxx
@@ -309,8 +309,12 @@ string
 KeyParser::get_keyword(const string& line) const
 {
   // keyword stops at either := or an index []	
-  // TODO should check that = follows : to allow keywords with colons in there
-  const string::size_type eok = line.find_first_of(":[",0);
+  string::size_type eok = line.find_first_of(":[",0);
+  // check that = follows : to allow keywords containing colons
+  while (line[eok] == ':' && eok+1 < line.size() && line[eok+1] != '=')
+    {
+      eok = line.find_first_of(":[", eok+1);
+    }
   return line.substr(0,eok);
 }
 

--- a/src/include/stir/IO/InterfileHeaderSiemens.h
+++ b/src/include/stir/IO/InterfileHeaderSiemens.h
@@ -52,6 +52,19 @@ public:
 protected:
   // Returns false if OK, true if not.
   virtual bool post_processing();
+  //! ignore multiple GMT times
+  /*!
+  Siemens uses keywords like
+  \verbatim
+  %study date (yyyy:mm:dd") := ...
+  %study time (hh:mm:ss GMT+00:00) := ...
+  \endvarbatim
+  You can ignore this for all (?) time zones by using
+  \code
+  ignore_Siemens_date_and_time_keys("%study");
+  \endcode
+  */
+  void ignore_Siemens_date_and_time_keys(const std::string& keyword);
 
 private:
 

--- a/src/include/stir/KeyParser.h
+++ b/src/include/stir/KeyParser.h
@@ -110,7 +110,9 @@ public :
   \brief A class to parse Interfile headers
 
   Currently, Interfile 3.3 parsing rules are hard-coded, with
-  some extensions.
+  some extensions. Note that some functions such as `get_keyword()` are `virtual`
+  such that a derived class could use non-Interfile parsing (but this might need
+  more work).
 
   KeyParser reads input line by line and parses each line separately.
   It allows for '\\r' at the end of the line (as in files
@@ -349,16 +351,14 @@ protected :
 
   
   //! convert 'rough' keyword into a standardised form
-  /*! \todo Implementation note: this function is non-static such that it can
-      be overloaded. Probably a template with a function object would be 
-      better. */
+  /*! Calls standardise_interfile_keyword().
+. */
   virtual std::string 
     standardise_keyword(const std::string& keyword) const;
 
 
   //! gets a keyword from a string
-  /*! Implementation note: this function is non-static as it uses 
-      standardise_keyword().
+  /*! Find `:=` or `[`. Note that the returned keyword is not standardised yet.
   */ 
   virtual std::string 
     get_keyword(const std::string&) const;


### PR DESCRIPTION
Fixes #149 

Also ignores more timezones in Siemens interfile "time" keywords