### PR TITLE
fix buffer-overrun when parsing if no keyword on line

### DIFF
--- a/src/buildblock/KeyParser.cxx
+++ b/src/buildblock/KeyParser.cxx
@@ -309,9 +309,9 @@ string
 KeyParser::get_keyword(const string& line) const
 {
   // keyword stops at either := or an index []	
-  string::size_type eok = line.find_first_of(":[",0);
+  auto eok = line.find_first_of(":[",0);
   // check that = follows : to allow keywords containing colons
-  while (line[eok] == ':' && eok+1 < line.size() && line[eok+1] != '=')
+  while (eok != string::npos && line[eok] == ':' && eok+1 < line.size() && line[eok+1] != '=')
     {
       eok = line.find_first_of(":[", eok+1);
     }


### PR DESCRIPTION
Fixes #1274 