### PR TITLE
SWIG: expose more LOR and listmode classes

### DIFF
--- a/examples/python/listmode_loop_demo.py
+++ b/examples/python/listmode_loop_demo.py
@@ -1,0 +1,43 @@
+# Demo how to use STIR from Python to access events in a list-mode file
+
+# Copyright 2023 - University College London
+# This file is part of STIR.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# See STIR/LICENSE.txt for details
+
+#%% Initial imports
+import stir
+import os
+
+#%% read file
+filename = '20170809_NEMA_60min_UCL.l.hdr'
+# example using the hroot file in recon_test_pack, which needs some env variables to be set
+#os.environ["INPUT_ROOT_FILE"]="test_PET_GATE.root"
+#os.environ["EXCLUDE_SCATTERED"] = "1"
+#os.environ["EXCLUDE_RANDOM"] = "0"
+#filename = "root_header.hroot"
+
+lm=stir.ListModeData.read_from_file(filename)
+# could print some exam info
+# print(lm.get_exam_info().parameter_info())
+proj_data_info = lm.get_proj_data_info()
+# could print some geometric info
+#print(proj_data_info.parameter_info())
+
+#%% loop over first few events and print some information
+# create some variables for re-use in the loop
+record = lm.get_empty_record()
+bin = stir.Bin()
+for i in range(50):
+    lm.get_next_record(record)
+    if (record.is_time()):
+        print(f"Time: {record.time().get_time_in_millisecs()}")
+    if (record.is_event()):
+        event = record.event()
+        lor = event.get_LOR()
+        event.get_bin(bin, proj_data_info);
+        # TODO We can will be able to simply print bin once STIR_TOF is on
+        print(f"Event: p/d: {event.is_prompt()} LOR: {[lor.p1(), lor.p2()]}, ",
+              f"bin: s:{bin.segment_num}, a: {bin.axial_pos_num}, v: {bin.view_num}, t:{bin.tangential_pos_num}")

--- a/examples/python/listmode_loop_demo.py
+++ b/examples/python/listmode_loop_demo.py
@@ -9,11 +9,11 @@
 
 #%% Initial imports
 import stir
-import os
 
 #%% read file
 filename = '20170809_NEMA_60min_UCL.l.hdr'
 # example using the hroot file in recon_test_pack, which needs some env variables to be set
+#import os
 #os.environ["INPUT_ROOT_FILE"]="test_PET_GATE.root"
 #os.environ["EXCLUDE_SCATTERED"] = "1"
 #os.environ["EXCLUDE_RANDOM"] = "0"
@@ -29,7 +29,7 @@ proj_data_info = lm.get_proj_data_info()
 #%% loop over first few events and print some information
 # create some variables for re-use in the loop
 record = lm.get_empty_record()
-bin = stir.Bin()
+b = stir.Bin()
 for i in range(50):
     lm.get_next_record(record)
     if (record.is_time()):
@@ -37,7 +37,7 @@ for i in range(50):
     if (record.is_event()):
         event = record.event()
         lor = event.get_LOR()
-        event.get_bin(bin, proj_data_info);
+        event.get_bin(b, proj_data_info);
         # TODO We can will be able to simply print bin once STIR_TOF is on
         print(f"Event: p/d: {event.is_prompt()} LOR: {[lor.p1(), lor.p2()]}, ",
-              f"bin: s:{bin.segment_num}, a: {bin.axial_pos_num}, v: {bin.view_num}, t:{bin.tangential_pos_num}")
+              f"bin: s:{b.segment_num}, a: {b.axial_pos_num}, v: {b.view_num}, t:{b.tangential_pos_num}")

--- a/src/include/stir/LORCoordinates.h
+++ b/src/include/stir/LORCoordinates.h
@@ -161,7 +161,12 @@ class LORCylindricalCoordinates_z_and_radius
 template <class coordT>
 class LORInCylinderCoordinates : public LOR<coordT>
 {
+#ifdef SWIG
+  // SWIG needs this typedef to be public
+ public:
+#endif
   typedef  LORInCylinderCoordinates<coordT> self_type;
+ private:
   void check_state() const
   {
     assert(_radius>0);
@@ -220,13 +225,8 @@ class LORInCylinderCoordinates : public LOR<coordT>
   inline
     LORInCylinderCoordinates(const LORAs2Points<coordT>&);
 
-  virtual
-#ifndef STIR_NO_COVARIANT_RETURN_TYPES
-    self_type* 
-#else
-      LOR<coordT>*
-#endif    
-    clone() const { return new self_type(*this); }
+  self_type* clone() const override
+  { return new self_type(*this); }
 
   virtual
     Succeeded
@@ -259,6 +259,10 @@ class LORInCylinderCoordinates : public LOR<coordT>
 template <class coordT>
 class LORAs2Points : public LOR<coordT>
 {
+#ifdef SWIG
+  // SWIG needs this typedef to be public
+ public:
+#endif
   typedef LORAs2Points<coordT> self_type;
  public:
   const CartesianCoordinate3D<coordT>& p1() const { return _p1; }
@@ -282,13 +286,8 @@ class LORAs2Points : public LOR<coordT>
   inline
     LORAs2Points(const LORInAxialAndNoArcCorrSinogramCoordinates<coordT>&);
 
-  virtual
-#ifndef STIR_NO_COVARIANT_RETURN_TYPES
-    self_type* 
-#else
-      LOR<coordT>*
-#endif
-      clone() const { return new self_type(*this); }
+  self_type* clone() const override
+  { return new self_type(*this); }
 
   virtual
     Succeeded
@@ -326,7 +325,12 @@ class LORInAxialAndSinogramCoordinates
   : public LOR<coordT>, private LORCylindricalCoordinates_z_and_radius<coordT>
 {
  private:
+#ifdef SWIG
+  // SWIG needs this typedef to be public
+ public:
+#endif
   typedef LORInAxialAndSinogramCoordinates<coordT> self_type;
+ private:
   typedef LORCylindricalCoordinates_z_and_radius<coordT> private_base_type;
   // sorry: has to be first to give the compiler a better chance of inlining
   void check_state() const
@@ -371,18 +375,11 @@ class LORInAxialAndSinogramCoordinates
   inline
     LORInAxialAndSinogramCoordinates(const LORInAxialAndNoArcCorrSinogramCoordinates<coordT>&);
 
-#if __cplusplus>= 201103L
   inline
     LORInAxialAndSinogramCoordinates(const LORAs2Points<coordT>&);
-#endif
 
-  virtual
-#ifndef STIR_NO_COVARIANT_RETURN_TYPES
-    self_type* 
-#else
-      LOR<coordT>*
-#endif
-      clone() const { return new self_type(*this); }
+  self_type* clone() const override
+  { return new self_type(*this); }
 
   void reset(coordT radius=1)
     {
@@ -506,18 +503,11 @@ class LORInAxialAndNoArcCorrSinogramCoordinates
   inline
   LORInAxialAndNoArcCorrSinogramCoordinates(const LORInAxialAndSinogramCoordinates<coordT>&);
 
-#if __cplusplus>= 201103L
   inline
     LORInAxialAndNoArcCorrSinogramCoordinates(const LORAs2Points<coordT>&);
-#endif
 
-  virtual
-#ifndef STIR_NO_COVARIANT_RETURN_TYPES
-    self_type* 
-#else
-      LOR<coordT>*
-#endif
-      clone() const { return new self_type(*this); }
+  self_type* clone() const override
+  { return new self_type(*this); }
 
   virtual
     Succeeded

--- a/src/include/stir/LORCoordinates.h
+++ b/src/include/stir/LORCoordinates.h
@@ -222,8 +222,11 @@ class LORInCylinderCoordinates : public LOR<coordT>
   inline
     LORInCylinderCoordinates(const LORInAxialAndSinogramCoordinates<coordT>&);
 
+#if 0
+  // disabled as would need radius argument as well, but currently not needed
   inline
     LORInCylinderCoordinates(const LORAs2Points<coordT>&);
+#endif
 
   self_type* clone() const override
   { return new self_type(*this); }
@@ -375,8 +378,10 @@ class LORInAxialAndSinogramCoordinates
   inline
     LORInAxialAndSinogramCoordinates(const LORInAxialAndNoArcCorrSinogramCoordinates<coordT>&);
 
+#if 0
   inline
     LORInAxialAndSinogramCoordinates(const LORAs2Points<coordT>&);
+#endif
 
   self_type* clone() const override
   { return new self_type(*this); }
@@ -503,8 +508,10 @@ class LORInAxialAndNoArcCorrSinogramCoordinates
   inline
   LORInAxialAndNoArcCorrSinogramCoordinates(const LORInAxialAndSinogramCoordinates<coordT>&);
 
+#if 0
   inline
     LORInAxialAndNoArcCorrSinogramCoordinates(const LORAs2Points<coordT>&);
+#endif
 
   self_type* clone() const override
   { return new self_type(*this); }

--- a/src/include/stir/LORCoordinates.inl
+++ b/src/include/stir/LORCoordinates.inl
@@ -269,7 +269,7 @@ LORInAxialAndNoArcCorrSinogramCoordinates(const LORInAxialAndSinogramCoordinates
   check_state();
 }
 
-#if __cplusplus>= 201103L
+#if 0
 template <class coordT>
 LORInAxialAndSinogramCoordinates<coordT>::
 LORInAxialAndSinogramCoordinates(const LORAs2Points<coordT>& coords)

--- a/src/include/stir/listmode/CListRecord.h
+++ b/src/include/stir/listmode/CListRecord.h
@@ -23,7 +23,7 @@
 #ifndef __stir_listmode_CListRecord_H__
 #define __stir_listmode_CListRecord_H__
 
-#include "ListRecord.h"
+#include "stir/listmode/ListRecord.h"
 
 START_NAMESPACE_STIR
 class Bin;

--- a/src/include/stir/listmode/ListEvent.h
+++ b/src/include/stir/listmode/ListEvent.h
@@ -24,8 +24,6 @@
 #ifndef __stir_listmode_ListEvent_H__
 #define __stir_listmode_ListEvent_H__
 
-#include "stir/round.h"
-#include "stir/Succeeded.h"
 #include "stir/Bin.h"
 #include "stir/ProjDataInfo.h"
 #include "stir/CartesianCoordinate3D.h"

--- a/src/include/stir/listmode/ListRecord.h
+++ b/src/include/stir/listmode/ListRecord.h
@@ -24,9 +24,8 @@
 #ifndef __stir_listmode_ListRecord_H__
 #define __stir_listmode_ListRecord_H__
 
-#include "ListEvent.h"
-#include "ListTime.h"
-#include "stir/Succeeded.h"
+#include "stir/listmode/ListEvent.h"
+#include "stir/listmode/ListTime.h"
 
 START_NAMESPACE_STIR
 

--- a/src/swig/CMakeLists.txt
+++ b/src/swig/CMakeLists.txt
@@ -108,6 +108,7 @@ set(swig_stir_dependencies
   stir_objectivefunctions.i
   stir_priors.i
   stir_projdata.i
+  stir_listmode.i
   stir_projectors.i
   stir_reconstruction.i
   stir_shapes.i

--- a/src/swig/stir.i
+++ b/src/swig/stir.i
@@ -70,8 +70,12 @@
  #include "stir/recon_buildblock/BinNormalisationFromProjData.h"
  #include "stir/recon_buildblock/BinNormalisationFromAttenuationImage.h"
  #include "stir/recon_buildblock/TrivialBinNormalisation.h"
- #include "stir/listmode/LmToProjData.h"
+ #include "stir/listmode/ListRecord.h"
+ #include "stir/listmode/ListEvent.h"
+ #include "stir/listmode/CListRecord.h"
  #include "stir/listmode/ListModeData.h"
+ #include "stir/listmode/CListModeData.h"
+ #include "stir/listmode/LmToProjData.h"
 
 #include "stir/CartesianCoordinate2D.h"
 #include "stir/CartesianCoordinate3D.h"
@@ -955,6 +959,7 @@ ADD_REPR(stir::Succeeded, %arg($self->succeeded() ? "yes" : "no"));
 
 %shared_ptr(stir::DataSymmetriesForViewSegmentNumbers);
 %include "stir_projdata.i"
+%include "stir_listmode.i"
 %include "stir/DataSymmetriesForViewSegmentNumbers.h"
 
 %include "stir_voxels.i"
@@ -989,10 +994,6 @@ ADD_REPR(stir::Succeeded, %arg($self->succeeded() ? "yes" : "no"));
 %include "stir/multiply_crystal_factors.h"
 %include "stir/decay_correction_factor.h"
 
-%rename (set_template_proj_data_info) *::set_template_proj_data_info_sptr;
-%shared_ptr(stir::LmToProjData);
-%include "stir/listmode/LmToProjData.h"
-
 %shared_ptr(stir::ScatterSimulation);
 %shared_ptr(stir::RegisteredParsingObject<stir::SingleScatterSimulation,
   stir::ScatterSimulation, stir::ScatterSimulation>);
@@ -1010,18 +1011,6 @@ ADD_REPR(stir::Succeeded, %arg($self->succeeded() ? "yes" : "no"));
 
 %shared_ptr(stir::CreateTailMaskFromACFs);
 %include "stir/scatter/CreateTailMaskFromACFs.h"
-
-%shared_ptr(stir::ListModeData);
-%include "stir/listmode/ListModeData.h"
-
-%extend stir::ListModeData {
-  static shared_ptr<stir::ListModeData> read_from_file(const std::string& filename)
-    {
-      using namespace stir;
-      shared_ptr<ListModeData> ret(read_from_file<ListModeData>(filename));
-      return ret;
-    }
-}
 
 %shared_ptr(stir::FanProjData);
 %shared_ptr(stir::GeoData3D);

--- a/src/swig/stir.i
+++ b/src/swig/stir.i
@@ -908,9 +908,6 @@ namespace std {
 %shared_ptr(stir::ParsingObject);
 
 %shared_ptr(stir::Verbosity);
-%shared_ptr(stir::LORAs2Points<float>);
-%shared_ptr(stir::LOR<float>);
-%shared_ptr(stir::LORInAxialAndNoArcCorrSinogramCoordinates<float>);
 
 //  William S Fulton trick for passing templates (with commas) through macro arguments
 // (already defined in swgmacros.swg)
@@ -951,24 +948,7 @@ ADD_REPR(stir::Succeeded, %arg($self->succeeded() ? "yes" : "no"));
 %include "stir/ByteOrder.h"
 
 %include "stir_coordinates.i"
-
-#if 0
- // TODO enable this in STIR version 6 (breaks backwards compatibility
-%attributeref(stir::LORInAxialAndNoArcCorrSinogramCoordinates<float>, float, z1);
-%attributeref(stir::LORInAxialAndNoArcCorrSinogramCoordinates<float>, float, z2);
-%attributeref(stir::LORInAxialAndNoArcCorrSinogramCoordinates<float>, float, beta);
-%attributeref(stir::LORInAxialAndNoArcCorrSinogramCoordinates<float>, float, phi);
-#else
-%ignore *::z1() const;
-%ignore *::z2() const;
-%ignore *::beta() const;
-%ignore *::phi() const;
-#endif
-%ignore *::check_state;
-%include "stir/LORCoordinates.h"
-
-%template(FloatLOR) stir::LOR<float>;
-%template(FloatLORInAxialAndNoArcCorrSinogramCoordinates) stir::LORInAxialAndNoArcCorrSinogramCoordinates<float>;
+%include "stir_LOR.i"
 
 %include "stir_array.i"
 %include "stir_exam.i"

--- a/src/swig/stir_LOR.i
+++ b/src/swig/stir_LOR.i
@@ -1,0 +1,49 @@
+/*
+    Copyright (C) 2023 University College London
+    Copyright (C) 2022 National Physical Laboratory
+    This file is part of STIR.
+
+    SPDX-License-Identifier: Apache-2.0
+
+    See STIR/LICENSE.txt for details
+*/
+/*!
+  \file
+  \brief Interface file for SWIG: stir::LOR and derived classes
+
+  \author Kris Thielemans
+  \author Daniel Deidda
+*/
+
+%shared_ptr(stir::LOR<float>);
+%shared_ptr(stir::LORAs2Points<float>);
+%shared_ptr(stir::LORInAxialAndNoArcCorrSinogramCoordinates<float>);
+%shared_ptr(stir::LORInAxialAndSinogramCoordinates<float>);
+%shared_ptr(stir::PointOnCylinder<float>);
+%shared_ptr(stir::LORInCylinderCoordinates<float>);
+
+#if 0
+ // TODO enable this in STIR version 6 (breaks backwards compatibility
+%attributeref(stir::LORInAxialAndNoArcCorrSinogramCoordinates<float>, float, z1);
+%attributeref(stir::LORInAxialAndNoArcCorrSinogramCoordinates<float>, float, z2);
+%attributeref(stir::LORInAxialAndNoArcCorrSinogramCoordinates<float>, float, beta);
+%attributeref(stir::LORInAxialAndNoArcCorrSinogramCoordinates<float>, float, phi);
+#else
+%ignore *::z1() const;
+%ignore *::z2() const;
+%ignore *::beta() const;
+%ignore *::phi() const;
+#endif
+%ignore *::check_state;
+
+%attributeref(stir::PointOnCylinder<float>, float, z);
+%attributeref(stir::PointOnCylinder<float>, float, psi);
+
+%include "stir/LORCoordinates.h"
+
+%template(LOR) stir::LOR<float>;
+%template(LORInAxialAndNoArcCorrSinogramCoordinates) stir::LORInAxialAndNoArcCorrSinogramCoordinates<float>;
+%template(LORAs2Points) stir::LORAs2Points<float>;
+%template(LORInAxialAndSinogramCoordinates) stir::LORInAxialAndSinogramCoordinates<float>;
+%template(PointOnCylinder) stir::PointOnCylinder<float>;
+%template(LORInCylinderCoordinates) stir::LORInCylinderCoordinates<float>;

--- a/src/swig/stir_listmode.i
+++ b/src/swig/stir_listmode.i
@@ -1,0 +1,53 @@
+/*
+    Copyright (C) 2023 University College London
+    Copyright (C) 2022 Positrigo
+    This file is part of STIR.
+
+    SPDX-License-Identifier: Apache-2.0
+
+    See STIR/LICENSE.txt for details
+*/
+/*!
+  \file
+  \brief Interface file for SWIG: stir::ListModeData, stir:LmToProjData, stir::ListRecord
+
+  \author Kris Thielemans
+  \author Markus Jehl
+*/
+%shared_ptr(stir::ListRecord);
+%shared_ptr(stir::ListEvent);
+%shared_ptr(stir::CListRecord);
+%shared_ptr(stir::CListEvent);
+%shared_ptr(stir::CListRecordWithGatingInput);
+
+%include "stir/listmode/ListRecord.h"
+%include "stir/listmode/ListEvent.h"
+%include "stir/listmode/CListRecord.h"
+
+%rename (get_empty_record) *::get_empty_record_sptr;
+
+%rename (set_template_proj_data_info) *::set_template_proj_data_info_sptr;
+%shared_ptr(stir::LmToProjData);
+%include "stir/listmode/LmToProjData.h"
+ADD_REPR_PARAMETER_INFO(stir::LmToProjData);
+
+%shared_ptr(stir::ListModeData);
+%include "stir/listmode/ListModeData.h"
+
+%extend stir::ListModeData {
+  static shared_ptr<stir::ListModeData> read_from_file(const std::string& filename)
+    {
+      using namespace stir;
+      shared_ptr<ListModeData> ret(read_from_file<ListModeData>(filename));
+      return ret;
+    }
+}
+
+%extend stir::CListModeData {
+  static shared_ptr<stir::CListModeData> read_from_file(const std::string& filename)
+    {
+      using namespace stir;
+      shared_ptr<CListModeData> ret(read_from_file<CListModeData>(filename));
+      return ret;
+    }
+}

--- a/src/swig/stir_listmode.i
+++ b/src/swig/stir_listmode.i
@@ -16,13 +16,15 @@
 */
 %shared_ptr(stir::ListRecord);
 %shared_ptr(stir::ListEvent);
+%shared_ptr(stir::ListTime);
 %shared_ptr(stir::CListRecord);
 %shared_ptr(stir::CListEvent);
 %shared_ptr(stir::CListRecordWithGatingInput);
 
-%include "stir/listmode/ListRecord.h"
 %include "stir/listmode/ListEvent.h"
-%include "stir/listmode/CListRecord.h"
+%include "stir/listmode/ListTime.h"
+%include "stir/listmode/ListRecord.h"
+%include "stir/listmode/CListRecord.h" // currently also contains CListEvent
 
 %rename (get_empty_record) *::get_empty_record_sptr;
 
@@ -33,6 +35,8 @@ ADD_REPR_PARAMETER_INFO(stir::LmToProjData);
 
 %shared_ptr(stir::ListModeData);
 %include "stir/listmode/ListModeData.h"
+%shared_ptr(stir::CListModeData);
+%include "stir/listmode/CListModeData.h"
 
 %extend stir::ListModeData {
   static shared_ptr<stir::ListModeData> read_from_file(const std::string& filename)

--- a/src/swig/test/python/test_listmode.py
+++ b/src/swig/test/python/test_listmode.py
@@ -1,0 +1,63 @@
+# Test file for STIR listmode reading
+# Use as follows:
+# on command line
+#     py.test test_listmode.py
+
+# Copyright 2023 - University College London
+# This file is part of STIR.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# See STIR/LICENSE.txt for details
+
+# This file checks the first 2 events in the recon_test_pack/test_PET_GATE.root
+
+#%% Initial imports
+import stir
+import os
+
+#%% read file
+# location of script
+dir = os.path.dirname(__file__)
+# location of ROOT file
+dir = os.path.join(dir, "..", "..", "..", "..", "recon_test_pack")
+filename = "root_header.hroot"
+
+os.environ["INPUT_ROOT_FILE"]="test_PET_GATE.root"
+os.environ["EXCLUDE_SCATTERED"] = "1"
+os.environ["EXCLUDE_RANDOM"] = "0"
+
+def test_get_record():
+    try:
+        lm=stir.ListModeData.read_from_file(os.path.join(dir, filename))
+        proj_data_info = lm.get_proj_data_info()
+    except:
+        print(f"Could not open {filename}")
+        print("ROOT support not enabled?")
+        return
+
+    record = lm.get_empty_record()
+    bin = stir.Bin()
+    # first event
+    lm.get_next_record(record)
+    assert record.is_time()
+    assert record.time().get_time_in_millisecs() == 2
+    assert record.is_event()
+    event = record.event()
+    lor = event.get_LOR()
+    event.get_bin(bin, proj_data_info);
+    diff = stir.FloatCartesianCoordinate3D(lor.p1() - stir.Float3BasicCoordinate((2.03125, -149.102, -299.989)))
+    assert abs(diff.x()) < .1 and abs(diff.y()) < .1 and abs(diff.z()) < .1
+    assert bin.segment_num == 1 and bin.axial_pos_num == 1 and bin.view_num == 112 and bin.tangential_pos_num == -102
+    # second event
+    lm.get_next_record(record)
+    assert record.is_time()
+    assert record.time().get_time_in_millisecs() == 3
+    assert record.is_event()
+    event = record.event()
+    lor = event.get_LOR()
+    event.get_bin(bin, proj_data_info);
+    diff = stir.FloatCartesianCoordinate3D(lor.p1() - stir.Float3BasicCoordinate((-2.03125, 325.646, -78.6102)))
+    assert abs(diff.x()) < .1 and abs(diff.y()) < .1 and abs(diff.z()) < .1
+    assert bin.segment_num == -1 and bin.axial_pos_num == 1 and bin.view_num == 12 and bin.tangential_pos_num == -14
+

--- a/src/swig/test/python/test_listmode.py
+++ b/src/swig/test/python/test_listmode.py
@@ -18,9 +18,9 @@ import os
 
 #%% read file
 # location of script
-dir = os.path.dirname(__file__)
+loc = os.path.dirname(__file__)
 # location of ROOT file
-dir = os.path.join(dir, "..", "..", "..", "..", "recon_test_pack")
+loc = os.path.join(loc, "..", "..", "..", "..", "recon_test_pack")
 filename = "root_header.hroot"
 
 os.environ["INPUT_ROOT_FILE"]="test_PET_GATE.root"
@@ -29,15 +29,15 @@ os.environ["EXCLUDE_RANDOM"] = "0"
 
 def test_get_record():
     try:
-        lm=stir.ListModeData.read_from_file(os.path.join(dir, filename))
+        lm=stir.ListModeData.read_from_file(os.path.join(loc, filename))
         proj_data_info = lm.get_proj_data_info()
-    except:
+    except RuntimeError:
         print(f"Could not open {filename}")
         print("ROOT support not enabled?")
         return
 
     record = lm.get_empty_record()
-    bin = stir.Bin()
+    b = stir.Bin()
     # first event
     lm.get_next_record(record)
     assert record.is_time()
@@ -45,10 +45,10 @@ def test_get_record():
     assert record.is_event()
     event = record.event()
     lor = event.get_LOR()
-    event.get_bin(bin, proj_data_info);
+    event.get_bin(b, proj_data_info);
     diff = stir.FloatCartesianCoordinate3D(lor.p1() - stir.Float3BasicCoordinate((2.03125, -149.102, -299.989)))
     assert abs(diff.x()) < .1 and abs(diff.y()) < .1 and abs(diff.z()) < .1
-    assert bin.segment_num == 1 and bin.axial_pos_num == 1 and bin.view_num == 112 and bin.tangential_pos_num == -102
+    assert b.segment_num == 1 and b.axial_pos_num == 1 and b.view_num == 112 and b.tangential_pos_num == -102
     # second event
     lm.get_next_record(record)
     assert record.is_time()
@@ -56,8 +56,8 @@ def test_get_record():
     assert record.is_event()
     event = record.event()
     lor = event.get_LOR()
-    event.get_bin(bin, proj_data_info);
+    event.get_bin(b, proj_data_info);
     diff = stir.FloatCartesianCoordinate3D(lor.p1() - stir.Float3BasicCoordinate((-2.03125, 325.646, -78.6102)))
     assert abs(diff.x()) < .1 and abs(diff.y()) < .1 and abs(diff.z()) < .1
-    assert bin.segment_num == -1 and bin.axial_pos_num == 1 and bin.view_num == 12 and bin.tangential_pos_num == -14
+    assert b.segment_num == -1 and b.axial_pos_num == 1 and b.view_num == 12 and b.tangential_pos_num == -14
 


### PR DESCRIPTION
- Add missing LOR classes
- Rename `FloatLOR` to `LOR` in SWIG
- Add missing `ListRecord` etc.

Currently python3 crashes when I `import stir`, but that might be a local problem.
