### PR TITLE
make _already_set_up protected as opposed to private

### DIFF
--- a/src/include/stir/recon_buildblock/SqrtHessianRowSum.h
+++ b/src/include/stir/recon_buildblock/SqrtHessianRowSum.h
@@ -112,9 +112,9 @@ public:
     void compute_approximate_Hessian_row_sum();
 
 protected:
+    bool _already_setup = false;
 
 private:
-    bool _already_setup = false;
 
     //! Objective function object
     shared_ptr<GeneralisedObjectiveFunction<TargetT> >  objective_function_sptr;

--- a/src/include/stir/scatter/ScatterEstimation.h
+++ b/src/include/stir/scatter/ScatterEstimation.h
@@ -291,9 +291,10 @@ public:
 
     std::string output_additive_estimate_prefix;
 
-private:
     //! variable to check if we have called set_up()
     bool _already_setup;
+
+private:
 
     //! attenuation in 3D
     shared_ptr<BinNormalisation>  atten_norm_3d_sptr;

--- a/src/include/stir/scatter/ScatterSimulation.h
+++ b/src/include/stir/scatter/ScatterSimulation.h
@@ -435,6 +435,7 @@ protected:
     int downsample_scanner_dets;
 
     bool downsample_scanner_bool;
+    bool _already_set_up;
 
  private:
     int total_detectors;
@@ -446,7 +447,6 @@ protected:
     // numbers that we don't want to recompute all the time
     mutable float detector_efficiency_no_scatter;
 
-    bool _already_set_up;
 
     //! a function that checks if image sizes are ok
     /*! It will call \c error() if not.


### PR DESCRIPTION
Derived classes should share the same set_up status as the base-class.

Just a few classes currently