### PR TITLE
DetectionPosition fixes

### DIFF
--- a/documentation/release_6.0.htm
+++ b/documentation/release_6.0.htm
@@ -118,6 +118,13 @@
             derived classes.
           </li>
         </ul>
+      </li>
+      <li>
+        add <code>DetectionPositionPair.__repr__</code>  for printing and
+        change order of text in <code>DetectionPosition.__repr__</code> to
+        fit with constructor to avoid confusion.<br>
+        <a href="https://github.com/UCL/STIR/pull/1316">PR #1316</a>
+      </li>
     </ul>
 
 

--- a/src/include/stir/stream.h
+++ b/src/include/stir/stream.h
@@ -14,7 +14,7 @@
     Copyright (C) 2000 PARAPET partners
     Copyright (C) 2000-2009 Hammersmith Imanet Ltd
     Copyright (C) 2013 Kris Thielemans
-    Copyright (C) 2023 University College London
+    Copyright (C) 2023, 2024 University College London
 
     This file is part of STIR.
 
@@ -29,6 +29,7 @@
 #include "stir/BasicCoordinate.h"
 #include "stir/Bin.h"
 #include "stir/DetectionPosition.h"
+#include "stir/DetectionPositionPair.h"
 #include <iostream>
 #include <vector>
 
@@ -86,6 +87,7 @@ operator<<(std::ostream& str, const std::vector<elemT>& v);
 
 /*!
   \brief Outputs a Bin to a stream.
+  \ingroup projdata
 
   Output is of the form
   \verbatim
@@ -103,17 +105,34 @@ inline std::ostream& operator<<(std::ostream& out, const Bin& bin)
 
 /*!
   \brief Outputs a DetectionPosition to a stream.
+  \ingroup projdata
 
   Output is of the form
   \verbatim
-  [radial=.., axial=..., tangential=...]
+  [tangential=..., axial=..., radial=...]
   \endverbatim
 */
 template <class T>
 inline std::ostream& operator<<(std::ostream& out, const DetectionPosition<T>& det_pos)
 {
-  return out << "[radial=" << det_pos.radial_coord() << ", axial=" << det_pos.axial_coord()
-             << ", tangential=" << det_pos.tangential_coord() << "]";
+  return out << "[tangential=" << det_pos.tangential_coord() << ", axial=" << det_pos.axial_coord()
+             << ", radial=" << det_pos.radial_coord() << "]";
+}
+
+/*!
+  \brief Outputs a DetectionPosition to a stream.
+  \ingroup projdata
+
+  Output is of the form
+  \verbatim
+  [pos1=..., pos2=..., timing_pos=...]
+  \endverbatim
+*/
+template <class T>
+inline std::ostream& operator<<(std::ostream& out, const DetectionPositionPair<T>& det_pos)
+{
+  return out << "[pos1=" << det_pos.pos1() << ", pos2=" << det_pos.pos2()
+             << ", timing_pos=" << det_pos.timing_pos() << "]";
 }
 
 /*!

--- a/src/recon_buildblock/BinNormalisationFromECAT8.cxx
+++ b/src/recon_buildblock/BinNormalisationFromECAT8.cxx
@@ -570,8 +570,8 @@ get_uncalibrated_bin_efficiency(const Bin& bin) const {
 					      uncompressed_bin, detection_position_pair);
 
       
-      const DetectionPosition<>& pos1 = detection_position_pair.pos1();
-     const DetectionPosition<>& pos2 = detection_position_pair.pos2();
+      //const DetectionPosition<>& pos1 = detection_position_pair.pos1();
+      //const DetectionPosition<>& pos2 = detection_position_pair.pos2();
       float lor_efficiency= 0.;   
       
       /*

--- a/src/swig/stir_projdata.i
+++ b/src/swig/stir_projdata.i
@@ -41,23 +41,18 @@
 %attributeref(stir::DetectionPosition<unsigned int>, unsigned int, axial_coord);
 %attributeref(stir::DetectionPosition<unsigned int>, unsigned int, radial_coord);
 %include "stir/DetectionPosition.h"
-#ifdef STIR_TOF
 ADD_REPR(stir::DetectionPosition, %arg(*$self))
-#endif
 %template(DetectionPosition) stir::DetectionPosition<unsigned int>;
 
+%attributeref(stir::DetectionPositionPair<unsigned int>, int, timing_pos);
 %attributeref(stir::DetectionPositionPair<unsigned int>, stir::DetectionPosition<unsigned int>, pos1);
 %attributeref(stir::DetectionPositionPair<unsigned int>, stir::DetectionPosition<unsigned int>, pos2);
 %include "stir/DetectionPositionPair.h"
-#ifdef STIR_TOF
- //ADD_REPR(stir::DetectionPositionPair, %arg(*$self))
-#endif
+ADD_REPR(stir::DetectionPositionPair, %arg(*$self))
 %template(DetectionPositionPair) stir::DetectionPositionPair<unsigned int>;
 
 %attributeref(stir::SegmentIndices, int, segment_num);
-#ifdef STIR_TOF
 %attributeref(stir::SegmentIndices, int, timing_pos_num);
-#endif
 %attributeref(stir::ViewgramIndices, int, view_num);
 %attributeref(stir::SinogramIndices, int, axial_pos_num);
 %attributeref(stir::Bin, int, axial_pos_num);
@@ -69,9 +64,8 @@ ADD_REPR(stir::DetectionPosition, %arg(*$self))
 %include "stir/ViewgramIndices.h"
 %include "stir/SinogramIndices.h"
 %include "stir/Bin.h"
-#ifdef STIR_TOF
 ADD_REPR(stir::Bin, %arg(*$self))
-#endif
+
 
 %newobject stir::Scanner::get_scanner_from_name;
 %include "stir/Scanner.h"

--- a/src/swig/test/python/test_buildblock.py
+++ b/src/swig/test/python/test_buildblock.py
@@ -185,7 +185,18 @@ def test_zoom_image():
     assert abs(zoomed_image[ind]-1)<.001
     zoomed_image=zoom_image(image, zoom, offset, offset, new_size, ZoomOptions(ZoomOptions.preserve_projections))
     assert abs(zoomed_image[ind]-1./(zoom))<.001
-    
+
+def test_DetectionPositionPair():
+    d1=DetectionPosition(1,2,0)
+    d2=DetectionPosition(4,5,6)
+    dp=DetectionPositionPair(d1,d2,3)
+    assert d1==dp.pos1
+    assert d2==dp.pos2
+    assert dp.timing_pos == 3
+    dp.pos1.tangential_coord = 7
+    assert dp.pos1.tangential_coord == 7
+    assert d1.tangential_coord == 1
+
 def test_Scanner():
     scanner=Scanner.get_scanner_from_name("ECAT 962")
     assert scanner.get_num_rings()==32


### PR DESCRIPTION
make printing in Python of `DetectionPosition` and `DetectionPositionPair` better and make `DetectionPositionPair.timing_pos`  an attribute.

Fixes #1314 