### PR TITLE
ProjData Visualisation window improvement and segment num bug fix

### DIFF
--- a/examples/python/projdata_visualisation/BackendTools/STIRInterface.py
+++ b/examples/python/projdata_visualisation/BackendTools/STIRInterface.py
@@ -85,8 +85,6 @@ class ProjDataVisualisationBackend:
             f"Number of non-tof sinograms:         {self.projdata.get_num_non_tof_sinograms():>10}\n\n"
         )
 
-
-
     def print_segment_data_configuration(self) -> None:
         """Prints the configuration of the segment data."""
         print(

--- a/examples/python/projdata_visualisation/BackendTools/STIRInterface.py
+++ b/examples/python/projdata_visualisation/BackendTools/STIRInterface.py
@@ -8,13 +8,12 @@
 #
 # See STIR/LICENSE.txt for details
 
-import time
+from enum import Enum, auto
 
 import numpy
+
 import stir
 import stirextra
-
-from enum import Enum, auto
 
 
 class ProjDataDims(Enum):
@@ -57,7 +56,7 @@ class ProjDataVisualisationBackend:
         self.projdata = new_projdata
         self.segment_data = new_segment_data
         print("ProjDataVisualisationBackend.load_data: Data loaded.")
-        self.print_projdata_configuration() 
+        self.print_projdata_configuration()
         return True
         
     def set_projdata(self, projdata: stir.ProjData) -> None:

--- a/examples/python/projdata_visualisation/BackendTools/STIRInterface.py
+++ b/examples/python/projdata_visualisation/BackendTools/STIRInterface.py
@@ -35,17 +35,16 @@ class ProjDataVisualisationBackend:
 
         self.segment_data = None
 
-    def load_projdata(self, filename=None) -> bool:
+    def load_projdata_from_file(self, filename: str | None = None) -> bool:
         """
         Loads STIR projection data from a file and updates the segment data in memory.
         :param filename: The filename to load the projection data from.
         :return: True if the data was loaded successfully, False otherwise.
         """
-        if filename is not None and filename != "":
-            self.projdata_filename = filename
-
-        if self.projdata_filename == "":
+        if filename is None or filename == "":
             return False
+
+        self.projdata_filename = filename
         
         print("ProjDataVisualisationBackend.load_data: Loading data from file: " + self.projdata_filename)
         try:
@@ -60,16 +59,12 @@ class ProjDataVisualisationBackend:
         print("ProjDataVisualisationBackend.load_data: Data loaded.")
         self.print_projdata_configuration() 
         return True
-    
-    def get_segment_data(self, segment_number=0, timing_pos=0) -> stir.FloatSegmentByView:
-        """Returns the segment data."""
-        return self.projdata.get_segment_by_view(stir.SegmentIndices(segment_number, timing_pos))
         
     def set_projdata(self, projdata: stir.ProjData) -> None:
         """Sets the projection data stream."""
         self.projdata = projdata
         self.projdata_filename = "ProjData filename set externally, no filename"
-        self.segment_data = self.projdata.get_segment_by_view(stir.SegmentIndices(segment_number, timing_pos))
+        self.segment_data = self.projdata.get_segment_by_view(stir.SegmentIndices(0, 0))
         self.print_projdata_configuration()
 
     def print_projdata_configuration(self) -> None:

--- a/examples/python/projdata_visualisation/BackendTools/STIRInterface.py
+++ b/examples/python/projdata_visualisation/BackendTools/STIRInterface.py
@@ -76,25 +76,28 @@ class ProjDataVisualisationBackend:
         """Prints the configuration of the projection data."""
         print(
             f"\nProjection data configuration for:\n"
-            f"\t'{self.projdata_filename}'\n"
-            f"\tNumber of views:\t\t\t\t\t{self.projdata.get_num_views()}\n"
-            f"\tNumber of tangential positions:\t\t{self.projdata.get_num_tangential_poss()}\n"
-            f"\tNumber of segments:\t\t\t\t\t{self.projdata.get_num_segments()}\n"
-            f"\tNumber of axial positions:\t\t\t{self.projdata.get_num_axial_poss(0)}\n"
-            f"\tNumber of tof positions:\t\t\t{self.projdata.get_num_tof_poss()}\n"
-            f"\tNumber of non-tof sinograms:\t\t{self.projdata.get_num_non_tof_sinograms()}\n\n"
+            f"'{self.projdata_filename}'\n"
+            f"Number of views:                     {self.projdata.get_num_views():>10}\n"
+            f"Number of tangential positions:      {self.projdata.get_num_tangential_poss():>10}\n"
+            f"Number of segments:                  {self.projdata.get_num_segments():>10}\n"
+            f"Number of axial positions:           {self.projdata.get_num_axial_poss(0):>10}\n"
+            f"Number of tof positions:             {self.projdata.get_num_tof_poss():>10}\n"
+            f"Number of non-tof sinograms:         {self.projdata.get_num_non_tof_sinograms():>10}\n\n"
         )
+
+
 
     def print_segment_data_configuration(self) -> None:
         """Prints the configuration of the segment data."""
         print(
             f"\nSegment data configuration for:\n"
-            f"\t'{self.projdata_filename}':\n"
-            f"\tSegment Number: {self.get_current_segment_num()}\n"
-            f"\tNumber of views:\t\t\t\t\t{self.segment_data.get_num_views()}\n"
-            f"\tNumber of tangential positions:\t\t{self.segment_data.get_num_tangential_poss()}\n"
-            f"\tNumber of axial positions:\t\t\t{self.segment_data.get_num_axial_poss()}\n"
+            f"'{self.projdata_filename}':\n"
+            f"Segment Number: {self.get_current_segment_num()}\n"
+            f"Number of views:                     {self.segment_data.get_num_views():>10}\n"
+            f"Number of tangential positions:      {self.segment_data.get_num_tangential_poss():>10}\n"
+            f"Number of axial positions:           {self.segment_data.get_num_axial_poss():>10}\n"
         )
+
 
     @staticmethod
     def as_numpy(data: stir.ProjData) -> numpy.array:

--- a/examples/python/projdata_visualisation/BackendTools/STIRInterface.py
+++ b/examples/python/projdata_visualisation/BackendTools/STIRInterface.py
@@ -113,8 +113,8 @@ class ProjDataVisualisationBackend:
             return self.projdata.get_min_segment_num(), \
                    self.projdata.get_max_segment_num()
         elif dimension == ProjDataDims.AXIAL_POS:
-            return self.projdata.get_min_axial_pos_num(self.get_current_segment_num()), \
-                   self.projdata.get_max_axial_pos_num(self.get_current_segment_num())
+            return self.projdata.get_min_axial_pos_num(segment_number), \
+                   self.projdata.get_max_axial_pos_num(segment_number)
         elif dimension == ProjDataDims.VIEW_NUMBER:
             return self.projdata.get_min_view_num(), \
                    self.projdata.get_max_view_num()

--- a/examples/python/projdata_visualisation/BackendTools/UIGroupboxProjdataDimensions.py
+++ b/examples/python/projdata_visualisation/BackendTools/UIGroupboxProjdataDimensions.py
@@ -117,8 +117,7 @@ class UIGroupboxProjDataDimensions:
             return
         # Update all slider and spinbox ranges, should start with segment number
         for dimension in ProjDataDims:
-            current_segment_num = self.stir_interface.get_current_segment_num()
-            limits = self.stir_interface.get_limits(dimension, current_segment_num)
+            limits = self.stir_interface.get_limits(dimension, self.stir_interface.get_current_segment_num())
             self.UI_slider_spinboxes[dimension].update_limits(limits=limits)
 
     def update_enable_disable(self, sinogram_radio_button_state: bool):

--- a/examples/python/projdata_visualisation/BackendTools/UIGroupboxProjdataDimensions.py
+++ b/examples/python/projdata_visualisation/BackendTools/UIGroupboxProjdataDimensions.py
@@ -89,7 +89,7 @@ class UIGroupboxProjDataDimensions:
         Because of the way the STIR segment data is handled, the segment_data needs to change first."""
         new_segment_num = self.UI_slider_spinboxes[ProjDataDims.SEGMENT_NUM].value()
         new_timing_pos = self.UI_slider_spinboxes[ProjDataDims.TIMING_POS].value()
-        self.stir_interface.get_segment_data(new_segment_num, new_timing_pos)
+        self.stir_interface.segment_data = self.stir_interface.get_segment_data(new_segment_num, new_timing_pos)
         self.UI_controller_UI_change_trigger()
 
     def axial_pos_refresh(self):

--- a/examples/python/projdata_visualisation/BackendTools/UIGroupboxProjdataDimensions.py
+++ b/examples/python/projdata_visualisation/BackendTools/UIGroupboxProjdataDimensions.py
@@ -120,7 +120,7 @@ class UIGroupboxProjDataDimensions:
             limits = self.stir_interface.get_limits(dimension, self.stir_interface.get_current_segment_num())
             self.UI_slider_spinboxes[dimension].update_limits(limits=limits)
 
-    def update_enable_disable(self, sinogram_radio_button_state: bool):
+    def configure_enable_disable_sliders(self, sinogram_radio_button_state: bool):
         # Segment slider and scroll box handling
         segment_limits = self.stir_interface.get_limits(ProjDataDims.SEGMENT_NUM,
                                                         self.stir_interface.get_current_segment_num())
@@ -143,10 +143,22 @@ class UIGroupboxProjDataDimensions:
 
         elif not sinogram_radio_button_state:
             self.disable(ProjDataDims.AXIAL_POS)
-            self.enable(ProjDataDims.VIEW_NUMBER)
+            view_num_limits = self.stir_interface.get_limits(ProjDataDims.VIEW_NUMBER,
+                                                             self.stir_interface.get_current_segment_num())
+            if (view_num_limits[0] - view_num_limits[1]) != 0:
+                self.enable(ProjDataDims.VIEW_NUMBER)
+            else:
+                self.disable(ProjDataDims.VIEW_NUMBER)
 
         if True:  # Until I work out what to do with tangential position
             self.disable(ProjDataDims.TANGENTIAL_POS)
+
+        tof_limits = self.stir_interface.get_limits(ProjDataDims.TIMING_POS,
+                                                    self.stir_interface.get_current_segment_num())
+        if (tof_limits[0] - tof_limits[1]) != 0:
+            self.enable(ProjDataDims.TIMING_POS)
+        else:
+            self.disable(ProjDataDims.TIMING_POS)
 
     def __construct_slider_spinboxes(self, slider_spinbox_configurations: dict) -> dict:
         """

--- a/examples/python/projdata_visualisation/BackendTools/UIGroupboxProjdataDimensions.py
+++ b/examples/python/projdata_visualisation/BackendTools/UIGroupboxProjdataDimensions.py
@@ -89,7 +89,7 @@ class UIGroupboxProjDataDimensions:
         Because of the way the STIR segment data is handled, the segment_data needs to change first."""
         new_segment_num = self.UI_slider_spinboxes[ProjDataDims.SEGMENT_NUM].value()
         new_timing_pos = self.UI_slider_spinboxes[ProjDataDims.TIMING_POS].value()
-        self.stir_interface.refresh_segment_data(new_segment_num, new_timing_pos)
+        self.stir_interface.get_segment_data(new_segment_num, new_timing_pos)
         self.UI_controller_UI_change_trigger()
 
     def axial_pos_refresh(self):
@@ -108,7 +108,7 @@ class UIGroupboxProjDataDimensions:
         """This function is called when the user changes the TOF bin value."""
         new_segment_num = self.UI_slider_spinboxes[ProjDataDims.SEGMENT_NUM].value()
         new_timing_pos = self.UI_slider_spinboxes[ProjDataDims.TIMING_POS].value()
-        self.stir_interface.refresh_segment_data(new_segment_num, new_timing_pos)
+        self.stir_interface.segment_data = self.stir_interface.get_segment_data(new_segment_num, new_timing_pos)
         self.UI_controller_UI_change_trigger()
 
     def refresh_sliders_and_spinboxes_ranges(self) -> None:

--- a/examples/python/projdata_visualisation/BackendTools/UIGroupboxProjdataDimensions.py
+++ b/examples/python/projdata_visualisation/BackendTools/UIGroupboxProjdataDimensions.py
@@ -8,10 +8,11 @@
 #
 # See STIR/LICENSE.txt for details
 
+from BackendTools.STIRInterface import ProjDataDims, ProjDataVisualisationBackend
 from PyQt5.QtCore import Qt
 from PyQt5.QtWidgets import QGroupBox, QGridLayout, QLabel, QSpinBox, QSlider
 
-from BackendTools.STIRInterface import ProjDataDims, ProjDataVisualisationBackend
+import stir
 
 
 class UIGroupboxProjDataDimensions:
@@ -87,9 +88,8 @@ class UIGroupboxProjDataDimensions:
     def segment_number_refresh(self):
         """ This function is called when the user changes the segment number value.
         Because of the way the STIR segment data is handled, the segment_data needs to change first."""
-        new_segment_num = self.UI_slider_spinboxes[ProjDataDims.SEGMENT_NUM].value()
-        new_timing_pos = self.UI_slider_spinboxes[ProjDataDims.TIMING_POS].value()
-        self.stir_interface.segment_data = self.stir_interface.get_segment_data(new_segment_num, new_timing_pos)
+        self.stir_interface.segment_data = self.stir_interface.projdata.get_segment_by_view(
+            self.get_segment_indices_from_UI())
         self.UI_controller_UI_change_trigger()
 
     def axial_pos_refresh(self):
@@ -106,10 +106,14 @@ class UIGroupboxProjDataDimensions:
 
     def timing_pos_refresh(self):
         """This function is called when the user changes the TOF bin value."""
-        new_segment_num = self.UI_slider_spinboxes[ProjDataDims.SEGMENT_NUM].value()
-        new_timing_pos = self.UI_slider_spinboxes[ProjDataDims.TIMING_POS].value()
-        self.stir_interface.segment_data = self.stir_interface.get_segment_data(new_segment_num, new_timing_pos)
+        self.stir_interface.segment_data = self.stir_interface.projdata.get_segment_by_view(
+            self.get_segment_indices_from_UI())
         self.UI_controller_UI_change_trigger()
+
+    def get_segment_indices_from_UI(self) -> stir.SegmentIndices:
+        """Returns the segment indices from the UI slider and spinboxes."""
+        return stir.SegmentIndices(self.UI_slider_spinboxes[ProjDataDims.SEGMENT_NUM].value(),
+                                   self.UI_slider_spinboxes[ProjDataDims.TIMING_POS].value())
 
     def refresh_sliders_and_spinboxes_ranges(self) -> None:
         """Update the sliders and spinboxes ranges based upon the stir_interface projdata."""
@@ -120,45 +124,31 @@ class UIGroupboxProjDataDimensions:
             limits = self.stir_interface.get_limits(dimension, self.stir_interface.get_current_segment_num())
             self.UI_slider_spinboxes[dimension].update_limits(limits=limits)
 
-    def configure_enable_disable_sliders(self, sinogram_radio_button_state: bool):
-        # Segment slider and scroll box handling
+    def configure_enable_disable_sliders(self, is_sinogram_mode: bool):
+        """Configure the sliders and spinboxes based upon the current mode and the projdata limits in each dimension."""
+
+        self.disable(ProjDataDims.TANGENTIAL_POS)
+
         segment_limits = self.stir_interface.get_limits(ProjDataDims.SEGMENT_NUM,
                                                         self.stir_interface.get_current_segment_num())
-        if self.stir_interface.projdata is not None:
-            if segment_limits[0] == 0 and segment_limits[1] == 0:
-                self.disable(ProjDataDims.SEGMENT_NUM)
-            else:
-                self.enable(ProjDataDims.SEGMENT_NUM)
+        self.update_dimension_state(ProjDataDims.SEGMENT_NUM, segment_limits)
 
-        # Check if sinogram or viewgram is selected and disable the appropriate sliders and spinboxes
-        if sinogram_radio_button_state:
-            # Disable the tangential position slider and spinbox
+        if is_sinogram_mode:
+            # No view number in sinogram mode
             self.disable(ProjDataDims.VIEW_NUMBER)
-            axial_pos_limits = self.stir_interface.get_limits(ProjDataDims.AXIAL_POS,
-                                                              self.stir_interface.get_current_segment_num())
-            if (axial_pos_limits[0] - axial_pos_limits[1]) != 0:
-                self.enable(ProjDataDims.AXIAL_POS)
-            else:
-                self.disable(ProjDataDims.AXIAL_POS)
-
-        elif not sinogram_radio_button_state:
+            axial_limits = self.stir_interface.get_limits(ProjDataDims.AXIAL_POS,
+                                                          self.stir_interface.get_current_segment_num())
+            self.update_dimension_state(ProjDataDims.AXIAL_POS, axial_limits)
+        else:
+            # No axial position in viewgram (not sinogram) mode
             self.disable(ProjDataDims.AXIAL_POS)
-            view_num_limits = self.stir_interface.get_limits(ProjDataDims.VIEW_NUMBER,
-                                                             self.stir_interface.get_current_segment_num())
-            if (view_num_limits[0] - view_num_limits[1]) != 0:
-                self.enable(ProjDataDims.VIEW_NUMBER)
-            else:
-                self.disable(ProjDataDims.VIEW_NUMBER)
-
-        if True:  # Until I work out what to do with tangential position
-            self.disable(ProjDataDims.TANGENTIAL_POS)
+            view_limits = self.stir_interface.get_limits(ProjDataDims.VIEW_NUMBER,
+                                                         self.stir_interface.get_current_segment_num())
+            self.update_dimension_state(ProjDataDims.VIEW_NUMBER, view_limits)
 
         tof_limits = self.stir_interface.get_limits(ProjDataDims.TIMING_POS,
                                                     self.stir_interface.get_current_segment_num())
-        if (tof_limits[0] - tof_limits[1]) != 0:
-            self.enable(ProjDataDims.TIMING_POS)
-        else:
-            self.disable(ProjDataDims.TIMING_POS)
+        self.update_dimension_state(ProjDataDims.TIMING_POS, tof_limits)
 
     def __construct_slider_spinboxes(self, slider_spinbox_configurations: dict) -> dict:
         """
@@ -184,6 +174,13 @@ class UIGroupboxProjDataDimensions:
                                                                connect_method=item[1]['connect_method']
                                                                )
         return UI_slider_spinboxes
+
+    def update_dimension_state(self, dimension, limits):
+        """Updates the state of the slider and spinbox for the given dimension. If limits are equal, disable."""
+        if limits[1] == limits[0]:
+            self.disable(dimension)
+        else:
+            self.enable(dimension)
 
     def enable(self, dimension: ProjDataDims) -> None:
         """Enables the slider and spinbox for the given dimension."""

--- a/examples/python/projdata_visualisation/ProjDataVisualisation.py
+++ b/examples/python/projdata_visualisation/ProjDataVisualisation.py
@@ -64,25 +64,26 @@ class ProjDataVisualisationWidgetGallery(QDialog):
         push_button_load_projdata = QPushButton("Load")
         push_button_load_projdata.clicked.connect(self.load_projdata)
         self.load_projdata_status = QLabel(f"")
+        # Configure Layout
+        FilenameControlGroupBoxLayout = QGridLayout()
+        FilenameControlGroupBoxLayout.addWidget(self.projdata_filename_box, 0, 0, 1, 2)
+        FilenameControlGroupBoxLayout.addWidget(push_button_browse_projdata, 1, 0, 1, 1)
+        FilenameControlGroupBoxLayout.addWidget(push_button_load_projdata, 1, 1, 1, 1)
+        FilenameControlGroupBoxLayout.addWidget(self.load_projdata_status, 2, 0, 1 , 2)
+        self.FilenameControlGroupBox.setLayout(FilenameControlGroupBoxLayout)
 
-        # Sinogram and viewgram radio buttons
-        gramTypeLabel = QLabel(f"Type of 2D data:")
+        # Sinogram and viewgram radio buttons in a groupbox
         self.sinogram_radio_button = QRadioButton("Sinogram")
         self.viewgram_radio_button = QRadioButton("Viewgram")
         self.sinogram_radio_button.setChecked(True)  # Default to sinogram
         self.sinogram_radio_button.toggled.connect(self.refresh_UI_configuration)
         self.viewgram_radio_button.toggled.connect(self.refresh_UI_configuration)
-
         # Configure Layout
-        layout = QGridLayout()
-        layout.addWidget(self.projdata_filename_box, 0, 0, 1, 2)
-        layout.addWidget(push_button_browse_projdata, 1, 0, 1, 1)
-        layout.addWidget(push_button_load_projdata, 1, 1, 1, 1)
-        layout.addWidget(self.load_projdata_status, 2, 0, 1, 2)
-        layout.addWidget(gramTypeLabel, 3, 0, 1, 2)
-        layout.addWidget(self.sinogram_radio_button, 4, 0, 1, 1)
-        layout.addWidget(self.viewgram_radio_button, 4, 1, 1, 1)
-        self.FilenameControlGroupBox.setLayout(layout)
+        ModeSelectionGroupBox = QGroupBox("Data Visualization Mode")
+        ModeSelectionGroupBoxLayout = QVBoxLayout()
+        ModeSelectionGroupBoxLayout.addWidget(self.sinogram_radio_button)
+        ModeSelectionGroupBoxLayout.addWidget(self.viewgram_radio_button)
+        ModeSelectionGroupBox.setLayout(ModeSelectionGroupBoxLayout)
 
 
         # #############################################
@@ -120,18 +121,13 @@ class ProjDataVisualisationWidgetGallery(QDialog):
         # ### Configure Main Layout ###
         # #############################
         topLayout = QHBoxLayout()
-        # topLayout.addStretch(1)
 
         mainLayout = QGridLayout()
         mainLayout.addLayout(topLayout, 0, 0, 1, 5)
         mainLayout.addWidget(self.FilenameControlGroupBox, 2, 0)
+        mainLayout.addWidget(ModeSelectionGroupBox, 3, 0)
         mainLayout.addWidget(self.ProjDataVisualisationGroupBox, 1, 0, 1, 2)
-        # mainLayout.addWidget(self.bottomLeftTabWidget, 2, 0)
-        mainLayout.addWidget(self.UI_groupbox_projdata_dimensions.groupbox, 2, 1)
-        # mainLayout.setRowStretch(1, 1)
-        # mainLayout.setRowStretch(2, 1)
-        # mainLayout.setColumnStretch(0, 1)
-        # mainLayout.setColumnStretch(1, 1)
+        mainLayout.addWidget(self.UI_groupbox_projdata_dimensions.groupbox, 2, 1, 2, 1)
         self.setLayout(mainLayout)
 
         self.change_UI_style('Fusion')

--- a/examples/python/projdata_visualisation/ProjDataVisualisation.py
+++ b/examples/python/projdata_visualisation/ProjDataVisualisation.py
@@ -125,7 +125,7 @@ class ProjDataVisualisationWidgetGallery(QDialog):
         mainLayout = QGridLayout()
         mainLayout.addLayout(topLayout, 0, 0, 1, 5)
         mainLayout.addWidget(self.FilenameControlGroupBox, 2, 0)
-        mainLayout.addWidget(self.ProjDataVisualisationGroupBox, 1, 1)
+        mainLayout.addWidget(self.ProjDataVisualisationGroupBox, 1, 0, 1, 2)
         # mainLayout.addWidget(self.bottomLeftTabWidget, 2, 0)
         mainLayout.addWidget(self.UI_groupbox_projdata_dimensions.groupbox, 2, 1)
         # mainLayout.setRowStretch(1, 1)

--- a/examples/python/projdata_visualisation/ProjDataVisualisation.py
+++ b/examples/python/projdata_visualisation/ProjDataVisualisation.py
@@ -141,7 +141,7 @@ class ProjDataVisualisationWidgetGallery(QDialog):
     def configure_backend(self):
         ### Backend ###
         self.stir_interface = ProjDataVisualisationBackend(sys.argv)
-        self.stir_interface.refresh_segment_data(0)
+        self.stir_interface.load_projdata()
 
     def change_UI_style(self, styleName):
         QApplication.setStyle(QStyleFactory.create(styleName))

--- a/examples/python/projdata_visualisation/ProjDataVisualisation.py
+++ b/examples/python/projdata_visualisation/ProjDataVisualisation.py
@@ -137,7 +137,7 @@ class ProjDataVisualisationWidgetGallery(QDialog):
     def configure_backend(self):
         ### Backend ###
         self.stir_interface = ProjDataVisualisationBackend(sys.argv)
-        self.stir_interface.load_projdata()
+        self.stir_interface.load_projdata_from_file()
 
     def change_UI_style(self, styleName):
         QApplication.setStyle(QStyleFactory.create(styleName))
@@ -246,7 +246,7 @@ class ProjDataVisualisationWidgetGallery(QDialog):
         if filename is not None and filename != "":
             self.projdata_filename_box.setText(filename)
 
-        data_load_successful = self.stir_interface.load_projdata(self.projdata_filename_box.text())
+        data_load_successful = self.stir_interface.load_projdata_from_file(self.projdata_filename_box.text())
 
         if not data_load_successful:
             self.load_projdata_status.setText("STATUS: Failed to load ProjData from file.")

--- a/examples/python/projdata_visualisation/ProjDataVisualisation.py
+++ b/examples/python/projdata_visualisation/ProjDataVisualisation.py
@@ -163,7 +163,7 @@ class ProjDataVisualisationWidgetGallery(QDialog):
         It calls the updateDisplayImage function to update the display image.
         """
         self.UI_groupbox_projdata_dimensions.refresh_sliders_and_spinboxes_ranges()
-        self.UI_groupbox_projdata_dimensions.update_enable_disable(self.sinogram_radio_button.isChecked())
+        self.UI_groupbox_projdata_dimensions.configure_enable_disable_sliders(self.sinogram_radio_button.isChecked())
         self.update_display_image()
 
     def update_display_image(self):

--- a/examples/python/projdata_visualisation/ProjDataVisualisation.py
+++ b/examples/python/projdata_visualisation/ProjDataVisualisation.py
@@ -240,7 +240,7 @@ class ProjDataVisualisationWidgetGallery(QDialog):
         else:
             self.projdata_filename_box.setText(initial)
 
-    def load_projdata(self, filename=None):
+    def load_projdata(self, filename=None) -> None:
         """
         This function loads the projdata file and updates the UI.
         """
@@ -252,12 +252,13 @@ class ProjDataVisualisationWidgetGallery(QDialog):
 
         data_load_successful = self.stir_interface.load_projdata(self.projdata_filename_box.text())
 
-        if data_load_successful:
-            self.load_projdata_status.setText("STATUS: ProjData loaded successfully from file.")
-        else:
+        if not data_load_successful:
             self.load_projdata_status.setText("STATUS: Failed to load ProjData from file.")
-
+            return
+        
+        self.load_projdata_status.setText("STATUS: ProjData loaded successfully from file.")
         self.refresh_UI_configuration()
+            
 
     def set_projdata(self, projdata):
         self.stir_interface.set_projdata(projdata)


### PR DESCRIPTION
## Changes in this pull request
- Fixes a bug with the `segment_num` parameter not being used in the method, instead it was using an internal call to `self.get_current_segment_num()`. This limited the method to the current state of the data, rather than the abstract.
- Expand MLP canvas to full width
- Fix bug when a projdata file cannot be loaded (e.g. missing binary). Previously, the projection data would be updated and fail when loading the segment_data into memory. However, the `stir_interface.projdata` was updated. This lead to errors with slider and reading new data. The PR, uses temporary variables when projdata and segment are loaded.
- Remove `refresh_segment_data` as this was leading to issues with the above and recursive calls to `load_projdata`
- Add formatting to `print_projdata_configuration` and `print_segment_data_configuration`

## Testing performed
Yes

## Related issues
- Partially addresses #1320
- Addresses https://github.com/UCL/STIR/issues/1320#issuecomment-1887725755  regarding loading of projdata error handling
 - As mentioned: https://github.com/UCL/STIR/pull/1319#issuecomment-1887685739, addresses a bug with `segment_number` in `get_limits`


## Checklist before requesting a review
<!--Put an x between the [] when completed. Delete a line if not applicable. -->
  - [x] I have performed a self-review of my code
  - [x] I have added docstrings/doxygen in line with the guidance in the developer guide
  - [x] I have implemented unit tests that cover any new or modified functionality (if applicable)
  - [x] The code builds and runs on my machine
  - [] `documentation/release_XXX.md` has been updated with any functionality change (if applicable)
