### PR TITLE
fix Interfile parsing of isotope_name

### DIFF
--- a/src/IO/InterfileHeader.cxx
+++ b/src/IO/InterfileHeader.cxx
@@ -179,7 +179,7 @@ InterfileHeader::InterfileHeader()
   ignore_key("GENERAL IMAGE DATA");
   
   add_key("calibration factor", &calibration_factor); 
-  // deprecated
+  // deprecated, but used by Siemens
   add_key("isotope name", &isotope_name);
   ignore_key("number of radionuclides"); // just always use 1. TODO should check really
   add_vectorised_key("radionuclide name", &radionuclide_name);
@@ -283,7 +283,7 @@ bool InterfileHeader::post_processing()
   // radionuclide
   {
      RadionuclideDB radionuclide_db;
-     const std::string rn_name = !this->radionuclide_name.empty()?
+     const std::string rn_name = !this->radionuclide_name[0].empty()?
        this->radionuclide_name[0] : this->isotope_name;
      auto radionuclide = radionuclide_db.get_radionuclide(exam_info_sptr->imaging_modality, rn_name);
      if (radionuclide.get_half_life(false) < 0)

--- a/src/IO/InterfileHeader.cxx
+++ b/src/IO/InterfileHeader.cxx
@@ -169,7 +169,7 @@ InterfileHeader::InterfileHeader()
 
   radionuclide_name.resize(1);
   radionuclide_half_life.resize(1);
-  radionuclide_half_life[1] = -1.F;
+  radionuclide_half_life[0] = -1.F;
   radionuclide_branching_ratio.resize(1);
   radionuclide_branching_ratio[0] = -1.F;
 
@@ -287,7 +287,7 @@ bool InterfileHeader::post_processing()
        this->radionuclide_name[0] : this->isotope_name;
      auto radionuclide = radionuclide_db.get_radionuclide(exam_info_sptr->imaging_modality, rn_name);
      if (radionuclide.get_half_life(false) < 0)
-       radionuclide = Radionuclide(rn_name,
+       radionuclide = Radionuclide(rn_name.empty() ? "Unknown" : rn_name,
                                    is_spect ? -1.F : 511.F, // TODO handle energy for SPECT
                                    radionuclide_branching_ratio[0], radionuclide_half_life[0], this->exam_info_sptr->imaging_modality);
      this->exam_info_sptr->set_radionuclide(radionuclide);

--- a/src/IO/InterfileHeaderSiemens.cxx
+++ b/src/IO/InterfileHeaderSiemens.cxx
@@ -544,7 +544,6 @@ InterfileListmodeHeaderSiemens::InterfileListmodeHeaderSiemens()
   ignore_key("gantry crystal radius (cm)");
   ignore_key("bin size (cm)");
   ignore_key("septa state");
-  ignore_key("%tof mashing factor");
   ignore_key("%preset type");
   ignore_key("%preset value");
   ignore_key("%preset unit");

--- a/src/IO/InterfileHeaderSiemens.cxx
+++ b/src/IO/InterfileHeaderSiemens.cxx
@@ -158,7 +158,7 @@ void InterfileHeaderSiemens::set_type_of_data()
     }
   else
     {
-      warning("Interfile parsing of Siemens listmode: unexpected 'type of data:=" + type_of_data + "' (expected PET). Continuing");
+      warning("Interfile parsing of Siemens header: unexpected 'type of data:=" + type_of_data + "' (expected PET). Continuing");
     }
 }
 


### PR DESCRIPTION
a bug meant that `isotope name` was always ignored, but it is used by Siemens.

Fixes #1326 