### PR TITLE
Fix of BlocksOnCylindrical projector tests

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -314,7 +314,7 @@ jobs:
           cd ${GITHUB_WORKSPACE}/build
           # don't run all of them in Debug mode as it takes too long
           if test ${BUILD_TYPE} = Debug; then
-              EXCLUDE="-E test_data_processor_projectors|test_export_array|test_ArcCorrection|test_blocks_on_cylindrical_projectors"
+              EXCLUDE="-E test_data_processor_projectors|test_export_array|test_ArcCorrection"
           fi
           ctest --output-on-failure -C ${BUILD_TYPE} ${EXCLUDE}
 

--- a/src/buildblock/ProjDataInfoGenericNoArcCorr.cxx
+++ b/src/buildblock/ProjDataInfoGenericNoArcCorr.cxx
@@ -66,7 +66,9 @@ ProjDataInfoGenericNoArcCorr(const shared_ptr<Scanner> scanner_sptr,
     error("ProjDataInfoGenericNoArcCorr: first argument (scanner_ptr) is zero");
   if (num_tangential_poss > scanner_sptr->get_max_num_non_arccorrected_bins())
     error("ProjDataInfoGenericNoArcCorr: number of tangential positions exceeds the maximum number of non arc-corrected bins set for the scanner.");
-
+  if (scanner_sptr->get_max_num_views() != num_views)
+    error("ProjDataInfoGenericNoArcCorr: view mashing is not supported");
+  
   uncompressed_view_tangpos_to_det1det2_initialised = false;
   det1det2_to_uncompressed_view_tangpos_initialised = false;
 #ifdef STIR_OPENMP_SAFE_BUT_SLOW

--- a/src/recon_buildblock/ForwardProjectorByBin.cxx
+++ b/src/recon_buildblock/ForwardProjectorByBin.cxx
@@ -216,9 +216,9 @@ ForwardProjectorByBin::forward_project(ProjData& proj_data,
         {
           const ViewSegmentNumbers vs=vs_nums_to_process[i];
           if (proj_data.get_proj_data_info_sptr()->is_tof_data())
-            info(boost::format("Processing view %1% of segment %2% of TOF bin %3%") % vs.view_num() % vs.segment_num() % k);
+            info(boost::format("Processing view %1% of segment %2% of TOF bin %3%") % vs.view_num() % vs.segment_num() % k, 3);
     	  else
-            info(boost::format("Processing view %1% of segment %2%") % vs.view_num() % vs.segment_num());
+            info(boost::format("Processing view %1% of segment %2%") % vs.view_num() % vs.segment_num(), 3);
           RelatedViewgrams<float> viewgrams =
             proj_data.get_empty_related_viewgrams(vs, symmetries_sptr, false, k);
           forward_project(viewgrams);

--- a/src/recon_test/test_blocks_on_cylindrical_projectors.cxx
+++ b/src/recon_test/test_blocks_on_cylindrical_projectors.cxx
@@ -69,11 +69,9 @@ public:
 
 private:
   template <class TProjDataInfo>
-  shared_ptr<TProjDataInfo> set_blocks_projdata_info(shared_ptr<Scanner> scanner_sptr, int view_fraction = 1,
-                                                     int bin_fraction = 1);
+  shared_ptr<TProjDataInfo> set_blocks_projdata_info(shared_ptr<Scanner> scanner_sptr, int bin_fraction = 1);
   template <class TProjDataInfo>
-  shared_ptr<TProjDataInfo> set_direct_projdata_info(shared_ptr<Scanner> scanner_sptr, int view_fraction = 4,
-                                                     int bin_fraction = 4);
+  shared_ptr<TProjDataInfo> set_direct_projdata_info(shared_ptr<Scanner> scanner_sptr, int bin_fraction = 4);
 
   void run_symmetry_test(ForwardProjectorByBin& forw_projector1, ForwardProjectorByBin& forw_projector2);
   void run_plane_symmetry_test(ForwardProjectorByBin& forw_projector1, ForwardProjectorByBin& forw_projector2);
@@ -87,7 +85,7 @@ private:
 /*! The following is a function to allow a projdata_info BlocksOnCylindrical to be created from the scanner. */
 template <class TProjDataInfo>
 shared_ptr<TProjDataInfo>
-BlocksTests::set_blocks_projdata_info(shared_ptr<Scanner> scanner_sptr, int view_fraction, int bin_fraction)
+BlocksTests::set_blocks_projdata_info(shared_ptr<Scanner> scanner_sptr, int bin_fraction)
 {
   auto segments = scanner_sptr->get_num_rings() - 1;
   VectorWithOffset<int> num_axial_pos_per_segment(-segments, segments);
@@ -102,7 +100,7 @@ BlocksTests::set_blocks_projdata_info(shared_ptr<Scanner> scanner_sptr, int view
 
   auto proj_data_info_blocks_sptr = std::make_shared<TProjDataInfo>(
       scanner_sptr, num_axial_pos_per_segment, min_ring_diff_v, max_ring_diff_v,
-      scanner_sptr->get_max_num_views() / view_fraction, scanner_sptr->get_max_num_non_arccorrected_bins() / bin_fraction);
+      scanner_sptr->get_max_num_views(), scanner_sptr->get_max_num_non_arccorrected_bins() / bin_fraction);
 
   return proj_data_info_blocks_sptr;
 }
@@ -110,7 +108,7 @@ BlocksTests::set_blocks_projdata_info(shared_ptr<Scanner> scanner_sptr, int view
 /*! Function to generate projection data containing only segment 0. Also allows reducing no. of views and tangential bins. */
 template <class TProjDataInfo>
 shared_ptr<TProjDataInfo>
-BlocksTests::set_direct_projdata_info(shared_ptr<Scanner> scanner_sptr, int view_fraction, int bin_fraction)
+BlocksTests::set_direct_projdata_info(shared_ptr<Scanner> scanner_sptr, int bin_fraction)
 {
   // VectorWithOffset<int> num_axial_pos_per_segment(0, 0);
   // VectorWithOffset<int> min_ring_diff_v(0, 0);
@@ -130,7 +128,7 @@ BlocksTests::set_direct_projdata_info(shared_ptr<Scanner> scanner_sptr, int view
 
   auto proj_data_info_blocks_sptr = std::make_shared<TProjDataInfo>(
       scanner_sptr, num_axial_pos_per_segment, min_ring_diff_v, max_ring_diff_v,
-      scanner_sptr->get_max_num_views() / view_fraction, scanner_sptr->get_max_num_non_arccorrected_bins() / bin_fraction);
+      scanner_sptr->get_max_num_views(), scanner_sptr->get_max_num_non_arccorrected_bins() / bin_fraction);
 
   return proj_data_info_blocks_sptr;
 }
@@ -328,7 +326,7 @@ BlocksTests::run_plane_symmetry_test(ForwardProjectorByBin& forw_projector1, For
   scannerBlocks_sptr->set_up();
 
   auto proj_data_info_blocks_sptr = std::make_shared<ProjDataInfoBlocksOnCylindricalNoArcCorr>();
-  proj_data_info_blocks_sptr = set_direct_projdata_info<ProjDataInfoBlocksOnCylindricalNoArcCorr>(scannerBlocks_sptr, 1);
+  proj_data_info_blocks_sptr = set_direct_projdata_info<ProjDataInfoBlocksOnCylindricalNoArcCorr>(scannerBlocks_sptr);
 
   //    now forward-project image
 
@@ -486,7 +484,7 @@ BlocksTests::run_axial_projection_test(ForwardProjectorByBin& forw_projector, Ba
 
   auto proj_data_info_blocks_sptr = std::make_shared<ProjDataInfoBlocksOnCylindricalNoArcCorr>();
   proj_data_info_blocks_sptr
-      = set_blocks_projdata_info<ProjDataInfoBlocksOnCylindricalNoArcCorr>(scannerBlocks_sptr, 4); //    now forward-project image
+      = set_blocks_projdata_info<ProjDataInfoBlocksOnCylindricalNoArcCorr>(scannerBlocks_sptr); //    now forward-project image
 
   shared_ptr<DiscretisedDensity<3, float>> image_sptr(image.clone());
   shared_ptr<DiscretisedDensity<3, float>> bck_proj_image_sptr(image.clone());
@@ -582,7 +580,7 @@ BlocksTests::run_map_orientation_test(ForwardProjectorByBin& forw_projector1, Fo
   scannerBlocks_sptr->set_up();
 
   auto proj_data_info_blocks_sptr = std::make_shared<ProjDataInfoBlocksOnCylindricalNoArcCorr>();
-  proj_data_info_blocks_sptr = set_direct_projdata_info<ProjDataInfoBlocksOnCylindricalNoArcCorr>(scannerBlocks_sptr, 1, 4);
+  proj_data_info_blocks_sptr = set_direct_projdata_info<ProjDataInfoBlocksOnCylindricalNoArcCorr>(scannerBlocks_sptr, 4);
   Bin bin, bin1, bin2, binR1;
   CartesianCoordinate3D<float> b1, b2, rb1, rb2;
   DetectionPosition<> det_pos, det_pos_ord;
@@ -618,7 +616,7 @@ BlocksTests::run_map_orientation_test(ForwardProjectorByBin& forw_projector1, Fo
   scannerBlocks_reord_sptr->set_up();
 
   auto proj_data_info_blocks_reord_sptr = std::make_shared<ProjDataInfoGenericNoArcCorr>();
-  proj_data_info_blocks_reord_sptr = set_direct_projdata_info<ProjDataInfoGenericNoArcCorr>(scannerBlocks_reord_sptr, 1, 4);
+  proj_data_info_blocks_reord_sptr = set_direct_projdata_info<ProjDataInfoGenericNoArcCorr>(scannerBlocks_reord_sptr, 4);
 
   //    now forward-project images
   // info(boost::format("Test blocks on Cylindrical: Forward projector used: %1%") % forw_projector1.parameter_info());
@@ -906,6 +904,7 @@ BlocksTests::run_tests()
   run_projection_test(forw_projector1, forw_projector1_parallelproj);
   print_time("projection cpu vs. gpu comparison test took: ");
 #endif
+  timer.stop();
 }
 END_NAMESPACE_STIR
 

--- a/src/recon_test/test_blocks_on_cylindrical_projectors.cxx
+++ b/src/recon_test/test_blocks_on_cylindrical_projectors.cxx
@@ -480,6 +480,9 @@ BlocksTests::run_axial_projection_test(ForwardProjectorByBin& forw_projector, Ba
 
   auto scannerBlocks_sptr = std::make_shared<Scanner>(Scanner::SAFIRDualRingPrototype);
   scannerBlocks_sptr->set_scanner_geometry("BlocksOnCylindrical");
+  scannerBlocks_sptr->set_num_axial_crystals_per_block(scannerBlocks_sptr->get_num_axial_crystals_per_block() / 4);
+  scannerBlocks_sptr->set_axial_block_spacing(scannerBlocks_sptr->get_axial_block_spacing() * 4);
+  scannerBlocks_sptr->set_num_rings(scannerBlocks_sptr->get_num_rings() / 4);
   scannerBlocks_sptr->set_up();
 
   auto proj_data_info_blocks_sptr = std::make_shared<ProjDataInfoBlocksOnCylindricalNoArcCorr>();


### PR DESCRIPTION
## Changes in this pull request
Added check for view mashing for generic proj data and fixed the blocks on cylindrical projection teests. Muted excessive logging in forward projector by default (was undone in TOF merge).

## Testing performed
Ran blocks on cylindrical projection test in debug.

## Related issues
fixes https://github.com/UCL/STIR/issues/1335

## Checklist before requesting a review
<!--Put an x between the [] when completed. Delete a line if not applicable. -->
  - [x] I have performed a self-review of my code
  - [] I have added docstrings/doxygen in line with the guidance in the developer guide
  - [] I have implemented unit tests that cover any new or modified functionality (if applicable)
  - [x] The code builds and runs on my machine
  - [] `documentation/release_XXX.md` has been updated with any functionality change (if applicable)
