### PR TITLE
Remove duplicate `SplitEmptyFunction: false` from `.clang-format`

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -25,8 +25,6 @@ BraceWrapping:
   SplitEmptyFunction: false
   SplitEmptyRecord: true
   SplitEmptyNamespace: true
-  # non-standard GNU
-  SplitEmptyFunction: false
 ColumnLimit:     130
 IndentPPDirectives: AfterHash
 PointerAlignment: Left


### PR DESCRIPTION
## Changes in this pull request
Remove duplicate `SplitEmptyFunction: false` from clang-format that prevented CLion from running formatting 

## Testing performed
NA

## Related issues
Fixes #1343

## Checklist before requesting a review
<!--Put an x between the [] when completed. Delete a line if not applicable. -->
  - [x] I have performed a self-review of my code
  - [x] I have added docstrings/doxygen in line with the guidance in the developer guide
  - [x] The code builds and runs on my machine

