### PR TITLE
remove forward_projector from distributable_sensitivity_computation

### DIFF
--- a/src/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMeanAndProjData.cxx
+++ b/src/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMeanAndProjData.cxx
@@ -1,7 +1,7 @@
 /*
     Copyright (C) 2000 PARAPET partners
     Copyright (C) 2000-2011, Hammersmith Imanet Ltd
-    Copyright (C) 2014, 2016-2023 University College London
+    Copyright (C) 2014, 2016-2024 University College London
     This file is part of STIR.
 
     SPDX-License-Identifier: Apache-2.0 AND License-ref-PARAPET-license
@@ -884,7 +884,7 @@ add_subset_sensitivity(TargetT& sensitivity, const int subset_num) const
 
      this->ensure_norm_is_set_up_for_sensitivity();
 
-     distributable_sensitivity_computation(this->projector_pair_ptr->get_forward_projector_sptr(), 
+     distributable_sensitivity_computation(
                                  this->sens_backprojector_sptr,
                                  this->sens_symmetries_sptr,
                                  *sensitivity_this_subset_sptr, 
@@ -1288,7 +1288,6 @@ void distributable_accumulate_loglikelihood(
 }
 
 void distributable_sensitivity_computation(
-                                            const shared_ptr<ForwardProjectorByBin>& forward_projector_sptr,
                                             const shared_ptr<BackProjectorByBin>& back_projector_sptr,
                                             const shared_ptr<DataSymmetriesForViewSegmentNumbers>& symmetries_sptr,
                                             DiscretisedDensity<3,float>& sensitivity,
@@ -1307,7 +1306,7 @@ void distributable_sensitivity_computation(
                                             )
 
 {
-          distributable_computation(forward_projector_sptr,
+          distributable_computation(0,
                                     back_projector_sptr,
                                     symmetries_sptr,
                                     &sensitivity, &input_image,

--- a/src/recon_buildblock/distributable.cxx
+++ b/src/recon_buildblock/distributable.cxx
@@ -405,8 +405,12 @@ void distributable_computation(
 #endif
   //double total_seq_rpc_time=0.0; //sums up times used for RPC_process_related_viewgrams
 
-  forward_projector_ptr->set_input(*input_image_ptr);
-  if (output_image_ptr != NULL)
+  // the RPC function might not need to do a forward projection, e.g. for sensitivity
+  // so test if it exists before doing anything with it
+  if (input_image_ptr && forward_projector_ptr)
+      forward_projector_ptr->set_input(*input_image_ptr);
+  // same for backprojector
+  if (output_image_ptr && back_projector_ptr)
     back_projector_ptr->start_accumulating_in_new_target();
 
 #ifdef STIR_OPENMP
@@ -518,7 +522,7 @@ void distributable_computation(
     count2 += std::accumulate(local_count2s.begin(), local_count2s.end(), 0);
   }
 #endif
-  if (output_image_ptr != NULL)
+  if (output_image_ptr && back_projector_ptr)
     back_projector_ptr->get_output(*output_image_ptr);
 #ifdef STIR_MPI
   //end of iteration processing


### PR DESCRIPTION
It doesn't need it, and in previous versions, calling forward_projector::set_input could actually do a lot of work (e.g. in the current GPU versions)

fixes #1352 