### PR TITLE
[CMake] install files in versioned locations (breaks backward compatibility for external projects!)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,21 +63,24 @@ set(STIR_VERSION
 
 ####### Installation directories
 # Note: using absolute paths for those variables that are used in STIRConfig.h.in
+set(STIR_VERSION_MM STIR-${VERSION_MAJOR}.${VERSION_MINOR})
 
 # Use BeOS locations as in
 # https://gitlab.kitware.com/cmake/cmake/blob/master/Source/CMakeInstallDestinations.cmake
 # However, use CYGWIN location also elsewhere (as that's what's used in Ubuntu (and others?))
 if(BEOS)
-  set(STIR_DOC_DIR "${CMAKE_INSTALL_PREFIX}/documentation/doc/stir-${VERSION_MAJOR}.${VERSION_MINOR}")
+  set(STIR_DOC_DIR "${CMAKE_INSTALL_PREFIX}/documentation/doc/${STIR_VERSION_MM}")
 else() #if(CYGWIN)
-  set(STIR_DOC_DIR "${CMAKE_INSTALL_PREFIX}/share/doc/stir-${VERSION_MAJOR}.${VERSION_MINOR}")
+  set(STIR_DOC_DIR "${CMAKE_INSTALL_PREFIX}/share/doc/${STIR_VERSION_MM}")
 #else()
-#  set(STIR_DOC_DIR "doc/stir-${VERSION_MAJOR}.${VERSION_MINOR}")
+#  set(STIR_DOC_DIR "doc/${STIR_VERSION_MM}")
 endif()
-# TODO append version numbers
-set(STIR_DATA_DIR "share/stir")
-set(ConfigPackageLocation lib/cmake/)
-set(STIR_CONFIG_DIR "${CMAKE_INSTALL_PREFIX}/share/stir/config" CACHE PATH "") 
+set(STIR_DATA_DIR "share/${STIR_VERSION_MM}")
+set(ConfigPackageLocation "lib/cmake/${STIR_VERSION_MM}")
+# installed json files
+set(STIR_CONFIG_DIR "${CMAKE_INSTALL_PREFIX}/share/${STIR_VERSION_MM}/config")
+# include files
+set(STIR_INCLUDE_INSTALL_DIR "include/${STIR_VERSION_MM}")
 
 ####### External packages
 # Note: we need to have the find_package statements in the top-level CMakeLists.txt
@@ -230,7 +233,7 @@ WRITE_BASIC_PACKAGE_VERSION_FILE(${CMAKE_CURRENT_BINARY_DIR}/STIRConfigVersion.c
 
 # Set STIR_INCLUDE_DIRS before exporting such that it will refer to
 # the installed files, not the source.
-set (STIR_INCLUDE_DIRS "include")
+set (STIR_INCLUDE_DIRS "${STIR_INCLUDE_INSTALL_DIR}")
 
 
 # Older CMake cannot import or export object libraries. So we have to export

--- a/documentation/release_6.0.htm
+++ b/documentation/release_6.0.htm
@@ -9,7 +9,8 @@
 
     <p>This version is 99% backwards compatible with STIR 5.x for the user (see below).
       Developers might need to make code changes as 
-      detailed below.
+      detailed below. Note though that the location of installed files have changed.
+      Developers of other software that uses STIR via CMake will need to adapt (see below).
     </p>
     <h2>Overall summary</h2>
     <p>
@@ -57,6 +58,14 @@
      </li>
      <li>
        (deprecated) support for the AVW format via the (very old) AnalyzeAVW commercial library has been removed.
+     </li>
+     <li>Most installed files are now in versioned directories. The following shows the new and old locations
+       relative to <code>CMAKE_INSTALL_PREFIX</code>, where <tt>V.v</tt> indicates the major.minor version number, e.g. <tt>6.0</tt>:
+       <ul>
+         <li>documentation (including <tt>examples</tt> as subfolder): <tt>share/doc/STIR-V.v</tt> (was <tt>share/doc/stir-V.v</tt>)</li>
+         <li>JSON files with radionuclide database: <tt>share/STIR-V.v/config</tt> (was <tt>share/stir/config</tt>)</li>
+       </ul>
+       Developers also need to check the new location to use for <code>STIR_DIR</code> documented below.
      </li>
     </ul>
 
@@ -131,7 +140,7 @@
       <li>
         <tt>list_lm_events</tt> now has an additional option <tt>--event-bin</tt> which lists the bin
         assigned for the event (according to the "native" projection data, i.e. without any mashing).<br>
-        In addition, the <tt>--event-LOR<tt> option now also works for SPECT (it was disabled by accident).
+        In addition, the <tt>--event-LOR</tt> option now also works for SPECT (it was disabled by accident).
         </li>
     </ul>
 
@@ -213,6 +222,11 @@
         In fact, it is possible that C++-11 still works. If you really need it,
         you can try to modify the main <tt>CMakeLists.txt</tt> accordingly.
       </li>
+      <li><code>STIR_CONFIG_DIR</code> is no longer a CMake cached variable, such that
+        it automatically moves along with <code>CMAKE_INSTALL_PREFIX</code>.
+        However, if you are upgrading an existing STIR build, you might have
+        to delete the cached variable, or it will point to the old location.
+      </li>
     </ul>
 
     <h3>Known problems</h3>
@@ -292,6 +306,19 @@
          </li>
        </ul>
      </li>
+      <li>As mentioned above, installation locations are now versioned. New locations that
+        could affect developers that use STIR as an external project:
+        <ul>
+          <li>include files: <tt>include/STIR-V.v</tt> (was <tt>include</tt>). This should be transparant
+          if you use <code>find_package(STIR)</code>.</li>
+          <li>CMake exported <tt>STIRConfig.cmake</tt> etc: <tt>lib/cmake/STIR-V.v</tt> (was <tt>share/lib</tt>).<br>
+            <strong>The CMake variable <tt>STIR_DIR</tt> should now be set to  <tt>&lt;STIR_CMAKE_INSTALL_PREFIX&gt;/lib/cmake/STIR-V.v</tt></strong>.
+            However, this new location increases chances that <code>find_package</code> finds STIR as it follows conventions better.
+            For instance, STIR can now by found by <code>find_package</code>
+            when setting <code>CMAKE_PREFIX_PATH</code> to what was used for <code>CMAKE_INSTALL_PREFIX</code> when
+            installing STIR (indicated as <tt>STIR_CMAKE_INSTALL_PREFIX</tt> above). Moreover, if you use the same
+            <code>CMAKE_INSTALL_PREFIX</code> for your project as for STIR, you shouldn't need to set <code>STIR_DIR</code> nor <code>CMAKE_PREFIX_PATH</code>.
+         </li>
     </ul>
 
     <h3>New functionality</h3>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -206,11 +206,11 @@ configure_file(
   "${CONF_INCLUDE_DIR}/stir/config.h"
   )
 # add it to the install target
-install(FILES "${CONF_INCLUDE_DIR}/stir/config.h" DESTINATION include/stir)
+install(FILES "${CONF_INCLUDE_DIR}/stir/config.h" DESTINATION "${STIR_INCLUDE_INSTALL_DIR}/stir")
 
 #### install include files
 set (INCLUDE_DIR "${PROJECT_SOURCE_DIR}/src/include")
-install(DIRECTORY "${INCLUDE_DIR}/" DESTINATION include)
+install(DIRECTORY "${INCLUDE_DIR}/" DESTINATION "${STIR_INCLUDE_INSTALL_DIR}")
 
 #### find header files for re-use in stir_exe_targets.cmake and doxygen target
 include(FindAllHeaderFiles)

--- a/src/cmake/stir_lib_target.cmake
+++ b/src/cmake/stir_lib_target.cmake
@@ -16,7 +16,7 @@
 add_library(${dir} ${${dir_LIB_SOURCES}}    )
 target_include_directories(${dir} PUBLIC 
   $<BUILD_INTERFACE:${STIR_INCLUDE_DIR}>
-  $<INSTALL_INTERFACE:include>)
+  $<INSTALL_INTERFACE:${STIR_INCLUDE_INSTALL_DIR}>)
 
 # make sure that if you use STIR, the compiler will be set to at least C++11
 if (${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.8.0")


### PR DESCRIPTION
This breaks backwards compatibility in some sense. New locations are indicated in the release notes. In particular, an external project now needs to set `STIR_DIR` to `/whereever/STIR/was/installed/lib/cmake/STIR-6.0`. 

Unfortunately, this does not yet allow installing different STIR versions in the same location, as the static libraries and executables are unversioned. If you need this, you will need to install using different values for `CMAKE_INSTALL_PREFIX`.

As part of this change, I no longer use `STIR_CONFIG_DIR` as a cached variable, such that it automatically moves along with `CMAKE_INSTALL_PREFIX`. However, if you are upgrading an existing STIR build, you might have to delete the cached variable, or it will point to the old location.

Fixes #945