### PR TITLE
run clang-tidy --modernize-use-override

### DIFF
--- a/documentation/STIR-developers-overview.tex
+++ b/documentation/STIR-developers-overview.tex
@@ -391,14 +391,24 @@ such that a production version of the programs
 is not slowed down. If an assertion is false, the program aborts 
 with info on the file and line number where the assertion failed.
 
-\subsection{\label{ssect:AdvancedCppFeatures}
-Advanced (?) C++ features used}
-
-STIR uses C++-11 an dis compatible with C++-20 to the best of our knowledge.
+\subsection{C++ conventions}
+STIR uses C++-14 and is compatible with C++-20 to the best of our knowledge.
 For legacy reasons, we have some preprocessor 
 macros (see \textit{stir/common.h}) that were used isolate work-arounds for older 
 compilers. Ideally, all these \#ifdefs should disappear at a 
 later development stage of the library.
+
+We use \texttt{override} for virtual functions in derived classes. This is clearer,
+less error-prone and avoids compiler warnings.
+
+STIR has a very long history. Lots of code was written pre-C++-11. We gradually simplify
+code when editing. This is definitely visible for code using iterators, which could be
+simplified by using \texttt{auto} as in this guide. It is a long term project to
+remove all compiler warnings from the code. Please help.
+
+\subsection{\label{ssect:AdvancedCppFeatures}
+Advanced (?) C++ features used}
+
 
 This section describes some C++ features used in STIR that might not be so familiar to
 non-C++ programmers.
@@ -1024,7 +1034,7 @@ following example.
 
     int number; float a;
 
-    void initialise_keymap()
+    void initialise_keymap() override
     {
       base_type::initialise_keymap();
       this->parser.add_start_key("My Class Parameters");
@@ -1033,14 +1043,14 @@ following example.
       this->parser.add_stop_key("END My Class Parameters");
     }
 
-    void set_defaults()
+    void set_defaults() override
     {
       base_type::set_defaults();
       // specify defaults for the parameters in case they are not set.
       number = 1;
       a = 2.4F;
     }
-    bool post_processing() // will be renamed to post_parsing()
+    bool post_processing() override // will be renamed to post_parsing()
     {
       // do some checks and handle some extra variables
       return false; // everything was ok
@@ -1122,11 +1132,9 @@ We currently have no easy way to copy all data across from one \texttt{ProjData}
 object to another. You will have to write an explicit loop over segments.
 
 \subsection{Dynamic or gated data}
-STIR 2.0 does not provide any direct facilities for reading 4D data (aside from
-the ECAT conversion utilities). Basic support should come in version 2.1.
-In the mean time, there is some preliminary functionality via the 
-\texttt{TimeFrameDefinitions} class and the \texttt{get\_time\_frame\_info}
-utility.
+Data should have an \texttt{ExamInfo} with a \texttt{TimeFrameDefinitions} object.
+You can also use the \texttt{get\_time\_frame\_info} utility.
+There is no equivalenet yet for gating fractions.
 
 
 \section{

--- a/documentation/release_6.0.htm
+++ b/documentation/release_6.0.htm
@@ -399,6 +399,9 @@
         <code>STIR_NO_NAMESPACES</code>, <code>STIR_NO_MUTABLE</code>, <code>BOOST_NO_TEMPLATE_SPECIALIZATION</code>,
         <code>BOOST_NO_STRINGSTREAM</code> and various items specifically for VC 6.0.
       </li>
+      <li>
+        Consistently use <code>override</code> in derived classes, via <tt>clang-tidy --modernize-use-override</tt>.
+      </li>
     </ul>
 </body>
 

--- a/scripts/maintenance/clang-tidy-modernize.md
+++ b/scripts/maintenance/clang-tidy-modernize.md
@@ -1,0 +1,23 @@
+Credit: https://www.kdab.com/clang-tidy-part-1-modernize-source-code-using-c11c14/ and Max Ahnen (Positrigo).
+See https://github.com/UCL/STIR/issues/827
+
+Note that using the CMake settings did no twork for KT, possibly because not using clang then.
+
+0. Best to make a build using clang. I had to disable OpenMP and therefore parallelproj
+   ```
+   CC=clang CXX=clang++ ccmake -DCMAKE_PREFIX_PATH=~/devel/build/SIRF-SuperBuild/INSTALL/ -DDISABLE_parallelproj=ON -B build -S sources/STIR
+   ```
+1. run CMake to output `compile_commands.json` in the build folder.
+   ```
+   cmake -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+   ```
+
+2. Run `clang-tidy` like this:
+   ```
+   run-clang-tidy -p build/ -header-filter=.* -checks='-*,modernize-use-override' -fix
+   ```
+
+3. check and commit
+   ```
+   git commit -a --author="stir_maintenance <noreply@github.com>"
+   ```

--- a/src/include/stir/Array.h
+++ b/src/include/stir/Array.h
@@ -136,7 +136,7 @@ public:
 #endif
   
   //! virtual destructor, frees up any allocated memory
-  inline virtual ~Array();
+  inline ~Array() override;
 
   /*! @name functions returning full_iterators*/
   //@{
@@ -322,7 +322,7 @@ public:
   inline Array(const NumericVectorWithOffset<elemT,elemT> &il);
   
   //! virtual destructor
-  inline virtual ~Array();
+  inline ~Array() override;
 
   /*! @name functions returning full_iterators*/
   //@{
@@ -350,13 +350,13 @@ public:
   inline virtual void grow(const IndexRange<1>& range);
   
   // Array::grow initialises new elements to 0
-  inline virtual void grow(const int min_index, const int max_index);
+  inline void grow(const int min_index, const int max_index) override;
   
   //! Array::resize initialises new elements to 0
   inline virtual void resize(const IndexRange<1>& range);
   
   // Array::resize initialises new elements to 0
-  inline virtual void resize(const int min_index, const int max_index);
+  inline void resize(const int min_index, const int max_index) override;
   
   //! return sum of all elements
   inline elemT sum() const;

--- a/src/include/stir/ArrayFilter1DUsingConvolution.h
+++ b/src/include/stir/ArrayFilter1DUsingConvolution.h
@@ -91,20 +91,20 @@ public:
   /*! 
     trivial means, either the kernel has 0 length, or length 1 and its only element is 1
     */
-  bool is_trivial() const;
+  bool is_trivial() const override;
 
-  virtual Succeeded 
+  Succeeded 
     get_influencing_indices(IndexRange<1>& influencing_indices, 
-                            const IndexRange<1>& output_indices) const;
+                            const IndexRange<1>& output_indices) const override;
 
-  virtual Succeeded 
+  Succeeded 
     get_influenced_indices(IndexRange<1>& influenced_indices, 
-                           const IndexRange<1>& input_indices) const;
+                           const IndexRange<1>& input_indices) const override;
 
 private:
   VectorWithOffset< elemT> filter_coefficients;
   BoundaryConditions::BC _bc;
-  void do_it(Array<1,elemT>& out_array, const Array<1,elemT>& in_array) const;
+  void do_it(Array<1,elemT>& out_array, const Array<1,elemT>& in_array) const override;
 
 };
 

--- a/src/include/stir/ArrayFilter1DUsingConvolutionSymmetricKernel.h
+++ b/src/include/stir/ArrayFilter1DUsingConvolutionSymmetricKernel.h
@@ -62,11 +62,11 @@ public:
   /*! 
     trivial means, either the kernel has 0 length, or length 1 and its only element is 1
     */
-  bool is_trivial() const;
+  bool is_trivial() const override;
 
 private:
   VectorWithOffset< elemT> filter_coefficients;
-  void do_it(Array<1,elemT>& out_array, const Array<1,elemT>& in_array) const;
+  void do_it(Array<1,elemT>& out_array, const Array<1,elemT>& in_array) const override;
 
 };
 

--- a/src/include/stir/ArrayFilter2DUsingConvolution.h
+++ b/src/include/stir/ArrayFilter2DUsingConvolution.h
@@ -40,7 +40,7 @@ public:
 
   ArrayFilter2DUsingConvolution(const Array <2, float>& filter_kernel);
   
-  bool is_trivial() const;
+  bool is_trivial() const override;
 
  virtual Succeeded 
     get_influencing_indices(IndexRange<1>& influencing_indices, 
@@ -52,7 +52,7 @@ public:
 
 private:
   Array <2, float>  filter_coefficients;
-  void do_it(Array<2,elemT>& out_array, const Array<2,elemT>& in_array) const;
+  void do_it(Array<2,elemT>& out_array, const Array<2,elemT>& in_array) const override;
 
 };
 

--- a/src/include/stir/ArrayFilter3DUsingConvolution.h
+++ b/src/include/stir/ArrayFilter3DUsingConvolution.h
@@ -40,7 +40,7 @@ public:
 
   ArrayFilter3DUsingConvolution(const Array <3, float>& filter_kernel);
   
-  bool is_trivial() const;
+  bool is_trivial() const override;
 
  virtual Succeeded 
     get_influencing_indices(IndexRange<1>& influencing_indices, 
@@ -52,7 +52,7 @@ public:
 
 private:
   Array <3, float>  filter_coefficients;
-  void do_it(Array<3,elemT>& out_array, const Array<3,elemT>& in_array) const;
+  void do_it(Array<3,elemT>& out_array, const Array<3,elemT>& in_array) const override;
   void do_it_2d(Array<2,elemT>& out_array, const Array<2,elemT>& in_array) const;
 
 };

--- a/src/include/stir/ArrayFilterUsingRealDFTWithPadding.h
+++ b/src/include/stir/ArrayFilterUsingRealDFTWithPadding.h
@@ -99,7 +99,7 @@ public:
   /*! 
     trivial means, either the kernel has 0 length, or length 1 and its only element is 1
     */
-  bool is_trivial() const;
+  bool is_trivial() const override;
 
 protected:
 
@@ -111,7 +111,7 @@ protected:
       using wrap-around to/from
       an array with the same dimensions as the 'real' kernel.
   */
-  void do_it(Array<num_dimensions, elemT>& out_array, const Array<num_dimensions, elemT>& in_array) const;
+  void do_it(Array<num_dimensions, elemT>& out_array, const Array<num_dimensions, elemT>& in_array) const override;
 private:
   IndexRange<num_dimensions> padding_range;
   BasicCoordinate<num_dimensions,int> padded_sizes;

--- a/src/include/stir/ArrayFunctionObject_1ArgumentImplementation.h
+++ b/src/include/stir/ArrayFunctionObject_1ArgumentImplementation.h
@@ -45,14 +45,14 @@ class ArrayFunctionObject_1ArgumentImplementation :
   public ArrayFunctionObject<num_dimensions,elemT>
 {
 public:
-  virtual void operator() (Array<num_dimensions,elemT>& array) const
+  void operator() (Array<num_dimensions,elemT>& array) const override
   {
     do_it(array);
   }
 
   //! result stored in another array, implemented inline
-  virtual void inline operator() (Array<num_dimensions,elemT>& out_array, 
-                           const Array<num_dimensions,elemT>& in_array) const
+  void inline operator() (Array<num_dimensions,elemT>& out_array, 
+                           const Array<num_dimensions,elemT>& in_array) const override
   {
     assert(out_array.get_index_range() == in_array.get_index_range());
     out_array = in_array;

--- a/src/include/stir/ArrayFunctionObject_2ArgumentImplementation.h
+++ b/src/include/stir/ArrayFunctionObject_2ArgumentImplementation.h
@@ -44,14 +44,14 @@ class ArrayFunctionObject_2ArgumentImplementation :
 {
 public:
   //! in-place modification of array, implemented inline
-  virtual inline void operator() (Array<num_dimensions,elemT>& array) const
+  inline void operator() (Array<num_dimensions,elemT>& array) const override
   {
    Array<num_dimensions,elemT> copy_array( array);
    (*this)(array, copy_array);
   }
 
-  virtual void operator() (Array<num_dimensions,elemT>& out_array, 
-                           const Array<num_dimensions,elemT>& in_array) const
+  void operator() (Array<num_dimensions,elemT>& out_array, 
+                           const Array<num_dimensions,elemT>& in_array) const override
   {
     do_it(out_array, in_array);
   }

--- a/src/include/stir/CPUTimer.h
+++ b/src/include/stir/CPUTimer.h
@@ -96,7 +96,7 @@ START_NAMESPACE_STIR
 class CPUTimer : public Timer
 {
 private:
-  virtual inline double get_current_value() const;
+  inline double get_current_value() const override;
 };
 
 

--- a/src/include/stir/ChainedDataProcessor.h
+++ b/src/include/stir/ChainedDataProcessor.h
@@ -92,13 +92,13 @@ private:
   shared_ptr<DataProcessor<DataT> > apply_first;
   shared_ptr<DataProcessor<DataT> > apply_second;
   
-  virtual void set_defaults();
-  virtual void initialise_keymap();
+  void set_defaults() override;
+  void initialise_keymap() override;
   
-  Succeeded virtual_set_up(const DataT& data);
+  Succeeded virtual_set_up(const DataT& data) override;
 
-  void  virtual_apply(DataT& out_data, const DataT& in_data) const;
-  void  virtual_apply(DataT& data) const ;
+  void  virtual_apply(DataT& out_data, const DataT& in_data) const override;
+  void  virtual_apply(DataT& data) const override ;
   
 };
 

--- a/src/include/stir/DiscretisedDensityOnCartesianGrid.h
+++ b/src/include/stir/DiscretisedDensityOnCartesianGrid.h
@@ -70,9 +70,9 @@ public:
 
 
 protected:
-  virtual inline bool
+  inline bool
     actual_has_same_characteristics(DiscretisedDensity<num_dimensions, elemT> const&, 
-				    std::string& explanation) const;
+				    std::string& explanation) const override;
 
   //! Return the relative coordinates of the centre of the basis-function corresponding to \c indices. 
   /*! The return value is relative to the origin. 
@@ -83,9 +83,9 @@ protected:
 
       \todo cope with non-standard orientations
   */
-  virtual inline
+  inline
     CartesianCoordinate3D<float> 
-    actual_get_relative_coordinates_for_indices(const BasicCoordinate<num_dimensions,float>& indices) const;
+    actual_get_relative_coordinates_for_indices(const BasicCoordinate<num_dimensions,float>& indices) const override;
  
   //! Return the indices of the basis-function closest to the given point. 
   /*! The input argument should be relative to the origin. 
@@ -96,9 +96,9 @@ protected:
 
       \todo cope with non-standard orientations
   */  
-  virtual inline
+  inline
     BasicCoordinate<num_dimensions,float> 
-    actual_get_index_coordinates_for_relative_coordinates(const CartesianCoordinate3D<float>& coords) const; 
+    actual_get_index_coordinates_for_relative_coordinates(const CartesianCoordinate3D<float>& coords) const override; 
 
 private:
   BasicCoordinate<num_dimensions,float> grid_spacing;

--- a/src/include/stir/HUToMuImageProcessor.h
+++ b/src/include/stir/HUToMuImageProcessor.h
@@ -122,16 +122,16 @@ protected:
   //! sets default values
   /*! Sets \c manufacturer_name to "GENERIC", \c kilovoltage_peak to 120.F, \c target_photon_energy to 511.F
    */
-  virtual void set_defaults();
-  virtual void initialise_keymap();
-  virtual bool post_processing();
+  void set_defaults() override;
+  void initialise_keymap() override;
+  bool post_processing() override;
 
   //! just checks if all variables are set
   /*! \todo could get manufacturer name, kVp from the image later on, when these become available */
-  Succeeded virtual_set_up(const TargetT& image);
+  Succeeded virtual_set_up(const TargetT& image) override;
 
-  void  virtual_apply(TargetT& out_density, const TargetT& in_density) const;
-  void  virtual_apply(TargetT& density) const ;
+  void  virtual_apply(TargetT& out_density, const TargetT& in_density) const override;
+  void  virtual_apply(TargetT& density) const override ;
 
 private:
   std::string filename;

--- a/src/include/stir/IO/ECAT8_32bitListmodeInputFileFormat.h
+++ b/src/include/stir/IO/ECAT8_32bitListmodeInputFileFormat.h
@@ -36,15 +36,15 @@ class ECAT8_32bitListmodeInputFileFormat :
 public InputFileFormat<ListModeData >
 {
  public:
-  virtual const std::string
-    get_name() const
+  const std::string
+    get_name() const override
   {  return "ECAT8_32bit"; }
 
  protected:
-  virtual 
+  
     bool 
     actual_can_read(const FileSignature& signature,
-		    std::istream& input) const
+		    std::istream& input) const override
   {
         if(!is_interfile_signature(signature.get_signature()))
                 return false;
@@ -56,16 +56,16 @@ public InputFileFormat<ListModeData >
     }
 
  public:
-  virtual unique_ptr<data_type>
-    read_from_file(std::istream& input) const
+  unique_ptr<data_type>
+    read_from_file(std::istream& input) const override
   {
     error("read_from_file for ECAT8_32bit listmode data with istream not implemented %s:%s. Sorry",
 	  __FILE__, __LINE__);
     return
       unique_ptr<data_type>();
   }
-  virtual unique_ptr<data_type>
-    read_from_file(const std::string& filename) const
+  unique_ptr<data_type>
+    read_from_file(const std::string& filename) const override
   {	
     return unique_ptr<data_type>(new CListModeDataECAT8_32bit(filename)); 
   }

--- a/src/include/stir/IO/GEHDF5ListmodeInputFileFormat.h
+++ b/src/include/stir/IO/GEHDF5ListmodeInputFileFormat.h
@@ -40,15 +40,15 @@ namespace RDF_HDF5
 class GEHDF5ListmodeInputFileFormat : public InputFileFormat<ListModeData>
 {
 public:
-  virtual const std::string get_name() const override { return "GEHDF5"; }
+  const std::string get_name() const override { return "GEHDF5"; }
 
 protected:
-  virtual bool actual_can_read(const FileSignature& signature, std::istream& input) const override;
-  virtual bool can_read(const FileSignature& signature, const std::string& filename) const override;
+  bool actual_can_read(const FileSignature& signature, std::istream& input) const override;
+  bool can_read(const FileSignature& signature, const std::string& filename) const override;
 
 public:
-  virtual unique_ptr<data_type> read_from_file(std::istream& input) const override;
-  virtual unique_ptr<data_type> read_from_file(const std::string& filename) const override;
+  unique_ptr<data_type> read_from_file(std::istream& input) const override;
+  unique_ptr<data_type> read_from_file(const std::string& filename) const override;
 };
 
 } // namespace RDF_HDF5

--- a/src/include/stir/IO/ITKImageInputFileFormat.h
+++ b/src/include/stir/IO/ITKImageInputFileFormat.h
@@ -48,31 +48,31 @@ public InputFileFormat<STIRImageType>
  public:
 
   //! This function always returns \c false as ITK cannot read from istream
-  virtual bool
+  bool
     can_read(const FileSignature& signature,
-	std::istream& input) const;
+	std::istream& input) const override;
   //! Use ITK reader to check if it can read the file (by seeing if it throws an exception or not)
-  virtual bool 
+  bool 
     can_read(const FileSignature& signature,
-	     const std::string& filename) const;
+	     const std::string& filename) const override;
  
-  virtual const std::string
-    get_name() const
+  const std::string
+    get_name() const override
   {  return "ITK"; }
 
  protected:
-  virtual 
+  
     bool 
     actual_can_read(const FileSignature& signature,
-		    std::istream& input) const;
+		    std::istream& input) const override;
 
   //! This function always calls error() as ITK cannot read from istream
-  virtual unique_ptr<STIRImageType>
-    read_from_file(std::istream& input) const;
+  unique_ptr<STIRImageType>
+    read_from_file(std::istream& input) const override;
 
   //! This function uses ITK for reading and does the translation to STIR
-  virtual unique_ptr<STIRImageType>
-    read_from_file(const std::string& filename) const;
+  unique_ptr<STIRImageType>
+    read_from_file(const std::string& filename) const override;
 
 };
 END_NAMESPACE_STIR

--- a/src/include/stir/IO/ITKOutputFileFormat.h
+++ b/src/include/stir/IO/ITKOutputFileFormat.h
@@ -76,16 +76,16 @@ public :
                    const ByteOrder& = ByteOrder::native);
 
 
-  virtual ByteOrder set_byte_order(const ByteOrder&, const bool warn = false);
+  ByteOrder set_byte_order(const ByteOrder&, const bool warn = false) override;
  protected:
-  virtual Succeeded  
+  Succeeded  
     actual_write_to_file(std::string& output_filename,
-		  const DiscretisedDensity<3,float>& density) const;
+		  const DiscretisedDensity<3,float>& density) const override;
 
 
-  virtual void set_defaults();
-  virtual void initialise_keymap();
-  virtual bool post_processing();
+  void set_defaults() override;
+  void initialise_keymap() override;
+  bool post_processing() override;
 
 };
 

--- a/src/include/stir/IO/InputStreamFromROOTFile.h
+++ b/src/include/stir/IO/InputStreamFromROOTFile.h
@@ -81,7 +81,7 @@ public:
                             int offset_dets);
 #endif
 
-    virtual ~InputStreamFromROOTFile() {}
+    ~InputStreamFromROOTFile() override {}
     //!  \details Returns the next record in the ROOT file.
     //!  The code is adapted from Sadek A. Nehmeh and CR Schmidtlein,
     //! downloaded from <a href="http://www.opengatecollaboration.org/STIR">here</a>
@@ -173,9 +173,9 @@ public:
 
  protected:
 
-    virtual void set_defaults();
-    virtual void initialise_keymap();
-    virtual bool post_processing();
+    void set_defaults() override;
+    void initialise_keymap() override;
+    bool post_processing() override;
 
     //! Input data file name
     std::string filename;

--- a/src/include/stir/IO/InputStreamFromROOTFileForCylindricalPET.h
+++ b/src/include/stir/IO/InputStreamFromROOTFileForCylindricalPET.h
@@ -99,28 +99,28 @@ public:
                                              int offset_dets);
 #endif
 
-    virtual ~InputStreamFromROOTFileForCylindricalPET() {}
+    ~InputStreamFromROOTFileForCylindricalPET() override {}
 
-    virtual
-    Succeeded get_next_record(CListRecordROOT& record);
+    
+    Succeeded get_next_record(CListRecordROOT& record) override;
     //! Must be called before calling for the first event.
-    virtual Succeeded set_up(const std::string & header_path);
+    Succeeded set_up(const std::string & header_path) override;
 
     //! gives method information
     virtual std::string method_info() const;
 
     //! Calculate the number of rings based on the crystal, module, submodule repeaters
-    inline virtual int get_num_rings() const;
+    inline int get_num_rings() const override;
     //! Calculate the number of detectors per ring based on the crystal, module, submodule repeaters
-    inline virtual int get_num_dets_per_ring() const;
+    inline int get_num_dets_per_ring() const override;
     //! Get the number of axial modules
-    inline virtual int get_num_axial_blocks_per_bucket_v() const;
+    inline int get_num_axial_blocks_per_bucket_v() const override;
     //! Get the number of transaxial modules
-    inline virtual int get_num_transaxial_blocks_per_bucket_v() const;
+    inline int get_num_transaxial_blocks_per_bucket_v() const override;
     //! Calculate the number of axial crystals per singles unit based on the repeaters numbers and the readout deptth
-    inline virtual int get_num_axial_crystals_per_singles_unit() const;
+    inline int get_num_axial_crystals_per_singles_unit() const override;
     //! Calculate the number of trans crystals per singles unit based on the repeaters numbers and the readout deptth
-    inline virtual int get_num_trans_crystals_per_singles_unit() const;
+    inline int get_num_trans_crystals_per_singles_unit() const override;
 
     inline void set_submodule_repeater_x(int);
     inline void set_submodule_repeater_y(int);
@@ -132,9 +132,9 @@ public:
 
 protected:
 
-    virtual void set_defaults();
-    virtual void initialise_keymap();
-    virtual bool post_processing();
+    void set_defaults() override;
+    void initialise_keymap() override;
+    bool post_processing() override;
 
     //! \name TBranches for Cylindrical PET
     //@{

--- a/src/include/stir/IO/InputStreamFromROOTFileForECATPET.h
+++ b/src/include/stir/IO/InputStreamFromROOTFileForECATPET.h
@@ -92,28 +92,28 @@ public:
                                       int offset_dets);
 #endif
 
-    virtual ~InputStreamFromROOTFileForECATPET() {}
+    ~InputStreamFromROOTFileForECATPET() override {}
 
-    virtual
-    Succeeded get_next_record(CListRecordROOT& record);
+    
+    Succeeded get_next_record(CListRecordROOT& record) override;
 
     //! gives method information
     virtual std::string method_info() const;
     //! Must be called before calling for the first event.
-    virtual Succeeded set_up(const std::string & header_path);
+    Succeeded set_up(const std::string & header_path) override;
 
     //! Calculate the number of rings based on the crystals and blocks
-    inline virtual int get_num_rings() const;
+    inline int get_num_rings() const override;
     //! Calculate the number of detectors per ring based on the crystals blocks
-    inline virtual int get_num_dets_per_ring() const;
+    inline int get_num_dets_per_ring() const override;
     //! Get the number of axial blocks
-    inline virtual int get_num_axial_blocks_per_bucket_v() const;
+    inline int get_num_axial_blocks_per_bucket_v() const override;
     //! Get the number of transaxial blocks
-    inline virtual int get_num_transaxial_blocks_per_bucket_v() const;
+    inline int get_num_transaxial_blocks_per_bucket_v() const override;
     //! Get the number of crystals per block
-    inline virtual int get_num_axial_crystals_per_singles_unit() const;
+    inline int get_num_axial_crystals_per_singles_unit() const override;
     //! Get the number of crystals per block
-    inline virtual int get_num_trans_crystals_per_singles_unit() const;
+    inline int get_num_trans_crystals_per_singles_unit() const override;
 
     inline void set_block_repeater_y(int);
     inline void set_block_repeater_z(int);
@@ -121,9 +121,9 @@ public:
 
 protected:
 
-    virtual void set_defaults();
-    virtual void initialise_keymap();
-    virtual bool post_processing();
+    void set_defaults() override;
+    void initialise_keymap() override;
+    bool post_processing() override;
 
     //! \name TBranches for ECAT PET
     //@{

--- a/src/include/stir/IO/InterfileDynamicDiscretisedDensityInputFileFormat.h
+++ b/src/include/stir/IO/InterfileDynamicDiscretisedDensityInputFileFormat.h
@@ -37,22 +37,22 @@ class InterfileDynamicDiscretisedDensityInputFileFormat :
 public InputFileFormat<DynamicDiscretisedDensity>
 {
  public:
-  virtual const std::string
-    get_name() const
+  const std::string
+    get_name() const override
   {  return "Interfile"; }
 
  protected:
-  virtual 
+  
     bool 
     actual_can_read(const FileSignature& signature,
-		    std::istream&) const
+		    std::istream&) const override
   {
     //. todo should check if it's an image
     return is_interfile_signature(signature.get_signature());
   }
 
-  virtual unique_ptr<data_type>
-    read_from_file(std::istream&) const
+  unique_ptr<data_type>
+    read_from_file(std::istream&) const override
   {
     // needs more arguments, so we just give up (TODO?)
     unique_ptr<data_type> ret;//(read_interfile_dynamic_image(input));
@@ -62,8 +62,8 @@ public InputFileFormat<DynamicDiscretisedDensity>
       }
     return ret;
   }
-  virtual unique_ptr<data_type>
-    read_from_file(const std::string& filename) const
+  unique_ptr<data_type>
+    read_from_file(const std::string& filename) const override
   {
     unique_ptr<data_type> ret(read_interfile_dynamic_image(filename));
     if (is_null_ptr(ret))

--- a/src/include/stir/IO/InterfileDynamicDiscretisedDensityOutputFileFormat.h
+++ b/src/include/stir/IO/InterfileDynamicDiscretisedDensityOutputFileFormat.h
@@ -53,16 +53,16 @@ public :
   InterfileDynamicDiscretisedDensityOutputFileFormat(const NumericType& = NumericType::FLOAT, 
                    const ByteOrder& = ByteOrder::native);
 
-  virtual ByteOrder set_byte_order(const ByteOrder&, const bool warn = false);
+  ByteOrder set_byte_order(const ByteOrder&, const bool warn = false) override;
  protected:
-  virtual Succeeded  
+  Succeeded  
     actual_write_to_file(std::string& output_filename,
-		  const DynamicDiscretisedDensity& density) const;
+		  const DynamicDiscretisedDensity& density) const override;
 
 
-  virtual void set_defaults();
-  virtual void initialise_keymap();
-  virtual bool post_processing();
+  void set_defaults() override;
+  void initialise_keymap() override;
+  bool post_processing() override;
 
 };
 

--- a/src/include/stir/IO/InterfileHeader.h
+++ b/src/include/stir/IO/InterfileHeader.h
@@ -54,7 +54,7 @@ class MinimalInterfileHeader : public KeyParser
     static const double double_value_not_set;
     MinimalInterfileHeader();
 
-    virtual ~MinimalInterfileHeader() {}
+    ~MinimalInterfileHeader() override {}
   protected:
     shared_ptr<ExamInfo> exam_info_sptr;
 
@@ -97,7 +97,7 @@ class InterfileHeader : public MinimalInterfileHeader
 public:
   InterfileHeader();
   // Returns false if OK, true if not.
-  virtual bool post_processing();
+  bool post_processing() override;
 
 private:
 
@@ -137,7 +137,7 @@ private:
   
  protected:
   //! Overload with specifics for STIR3.0 for backwards compatibility
-  virtual void set_version_specific_keys();
+  void set_version_specific_keys() override;
   virtual void read_matrix_info();
   virtual void read_num_energy_windows();
   void read_frames_info();
@@ -216,16 +216,16 @@ public:
   std::vector<std::string> image_data_type_description;
 
 protected:
-  virtual void read_matrix_info();
+  void read_matrix_info() override;
   //! Returns false if OK, true if not.
-  virtual bool post_processing();
+  bool post_processing() override;
   /// Read image data types
   void read_image_data_types();
   //!
   //! \brief Get the number of datasets
   //! \details no. time frames * no. data types (kinetic params) * no. gates
   //! Currently, this is only implemented for either multiple time frames OR multiple data types (gates not considered).
-  virtual int get_num_datasets() const { return num_time_frames*num_image_data_types; }
+  int get_num_datasets() const override { return num_time_frames*num_image_data_types; }
 
 };
 
@@ -242,7 +242,7 @@ public:
 protected:
 
   //! Returns false if OK, true if not.
-  virtual bool post_processing();
+  bool post_processing() override;
 
 public:
  

--- a/src/include/stir/IO/InterfileHeaderSiemens.h
+++ b/src/include/stir/IO/InterfileHeaderSiemens.h
@@ -47,11 +47,11 @@ public:
 
   InterfileHeaderSiemens();
 
-  virtual ~InterfileHeaderSiemens() {}
+  ~InterfileHeaderSiemens() override {}
 
 protected:
   // Returns false if OK, true if not.
-  virtual bool post_processing();
+  bool post_processing() override;
   //! ignore multiple GMT times
   /*!
   Siemens uses keywords like
@@ -126,7 +126,7 @@ class InterfileRawDataHeaderSiemens : public InterfileHeaderSiemens
   protected:
 
     //! Returns false if OK, true if not.
-    virtual bool post_processing();
+    bool post_processing() override;
     // need this to be false for the listmode data
     bool is_arccorrected;
   public:
@@ -171,7 +171,7 @@ class InterfilePDFSHeaderSiemens : public InterfileRawDataHeaderSiemens
   protected:
 
     //! Returns false if OK, true if not.
-    virtual bool post_processing();
+    bool post_processing() override;
 
   public:
 
@@ -208,7 +208,7 @@ class InterfileListmodeHeaderSiemens : public InterfileRawDataHeaderSiemens
   protected:
 
     //! Returns false if OK, true if not.
-    virtual bool post_processing();
+    bool post_processing() override;
 
   public:
     //! Get axial compression
@@ -241,7 +241,7 @@ class InterfileNormHeaderSiemens : public InterfileRawDataHeaderSiemens
   protected:
 
     //! Returns false if OK, true if not.
-    virtual bool post_processing() override;
+    bool post_processing() override;
 
   public:
     float calib_factor;

--- a/src/include/stir/IO/InterfileImageInputFileFormat.h
+++ b/src/include/stir/IO/InterfileImageInputFileFormat.h
@@ -36,22 +36,22 @@ class InterfileImageInputFileFormat :
 public InputFileFormat<DiscretisedDensity<3,float> >
 {
  public:
-  virtual const std::string
-    get_name() const
+  const std::string
+    get_name() const override
   {  return "Interfile"; }
 
  protected:
-  virtual 
+  
     bool 
     actual_can_read(const FileSignature& signature,
-		    std::istream& input) const
+		    std::istream& input) const override
   {
     //. todo should check if it's an image
     return is_interfile_signature(signature.get_signature());
   }
 
-  virtual unique_ptr<data_type>
-    read_from_file(std::istream& input) const
+  unique_ptr<data_type>
+    read_from_file(std::istream& input) const override
   {
     unique_ptr<data_type> ret(read_interfile_image(input));
     if (is_null_ptr(ret))
@@ -60,8 +60,8 @@ public InputFileFormat<DiscretisedDensity<3,float> >
       }
     return ret;
   }
-  virtual unique_ptr<data_type>
-    read_from_file(const std::string& filename) const
+  unique_ptr<data_type>
+    read_from_file(const std::string& filename) const override
   {
     unique_ptr<data_type> ret(read_interfile_image(filename));
     if (is_null_ptr(ret))

--- a/src/include/stir/IO/InterfileOutputFileFormat.h
+++ b/src/include/stir/IO/InterfileOutputFileFormat.h
@@ -54,16 +54,16 @@ public :
                    const ByteOrder& = ByteOrder::native);
 
 
-  virtual ByteOrder set_byte_order(const ByteOrder&, const bool warn = false);
+  ByteOrder set_byte_order(const ByteOrder&, const bool warn = false) override;
  protected:
-  virtual Succeeded  
+  Succeeded  
     actual_write_to_file(std::string& output_filename,
-		  const DiscretisedDensity<3,float>& density) const;
+		  const DiscretisedDensity<3,float>& density) const override;
 
 
-  virtual void set_defaults();
-  virtual void initialise_keymap();
-  virtual bool post_processing();
+  void set_defaults() override;
+  void initialise_keymap() override;
+  bool post_processing() override;
 
 };
 

--- a/src/include/stir/IO/InterfilePDFSHeaderSPECT.h
+++ b/src/include/stir/IO/InterfilePDFSHeaderSPECT.h
@@ -40,7 +40,7 @@ public:
 protected:
 
   //! Returns false if OK, true if not.
-  virtual bool post_processing();
+  bool post_processing() override;
 
  private:
 

--- a/src/include/stir/IO/InterfileParametricDiscretisedDensityInputFileFormat.h
+++ b/src/include/stir/IO/InterfileParametricDiscretisedDensityInputFileFormat.h
@@ -37,22 +37,22 @@ class InterfileParametricDiscretisedDensityInputFileFormat :
 public InputFileFormat<ParametricVoxelsOnCartesianGrid>
 {
  public:
-  virtual const std::string
-    get_name() const
+  const std::string
+    get_name() const override
   {  return "Interfile"; }
 
  protected:
-  virtual 
+  
     bool 
     actual_can_read(const FileSignature& signature,
-		    std::istream&) const
+		    std::istream&) const override
   {
     //. todo should check if it's an image
     return is_interfile_signature(signature.get_signature());
   }
 
-  virtual unique_ptr<data_type>
-    read_from_file(std::istream&) const
+  unique_ptr<data_type>
+    read_from_file(std::istream&) const override
   {
     // needs more arguments, so we just give up (TODO?)
     unique_ptr<data_type> ret;//(read_interfile_dynamic_image(input));
@@ -62,8 +62,8 @@ public InputFileFormat<ParametricVoxelsOnCartesianGrid>
       }
     return ret;
   }
-  virtual unique_ptr<data_type>
-    read_from_file(const std::string& filename) const
+  unique_ptr<data_type>
+    read_from_file(const std::string& filename) const override
   {
     unique_ptr<data_type> ret(read_interfile_parametric_image(filename));
     if (is_null_ptr(ret))

--- a/src/include/stir/IO/InterfileParametricDiscretisedDensityOutputFileFormat.h
+++ b/src/include/stir/IO/InterfileParametricDiscretisedDensityOutputFileFormat.h
@@ -72,16 +72,16 @@ public :
                    const ByteOrder& = ByteOrder::native);
 
 
-  virtual ByteOrder set_byte_order(const ByteOrder&, const bool warn = false);
+  ByteOrder set_byte_order(const ByteOrder&, const bool warn = false) override;
  protected:
-  virtual Succeeded  
+  Succeeded  
     actual_write_to_file(std::string& output_filename,
-		  const ParametricDiscretisedDensity<DiscDensityT>& density) const;
+		  const ParametricDiscretisedDensity<DiscDensityT>& density) const override;
 
 
-  virtual void set_defaults();
-  virtual void initialise_keymap();
-  virtual bool post_processing();
+  void set_defaults() override;
+  void initialise_keymap() override;
+  bool post_processing() override;
 
 };
 

--- a/src/include/stir/IO/MultiDynamicDiscretisedDensityInputFileFormat.h
+++ b/src/include/stir/IO/MultiDynamicDiscretisedDensityInputFileFormat.h
@@ -40,15 +40,15 @@ class MultiDynamicDiscretisedDensityInputFileFormat :
 public InputFileFormat<DynamicDiscretisedDensity>
 {
  public:
-  virtual const std::string
-    get_name() const
+  const std::string
+    get_name() const override
   {  return "Multi"; }
 
  protected:
-  virtual 
+  
     bool 
     actual_can_read(const FileSignature& signature,
-		    std::istream&) const
+		    std::istream&) const override
   {
     //. todo should check if it's an image
     // checking for "multi :"
@@ -61,8 +61,8 @@ public InputFileFormat<DynamicDiscretisedDensity>
             standardise_interfile_keyword("multi"));
   }
 
-  virtual unique_ptr<data_type>
-    read_from_file(std::istream&) const
+  unique_ptr<data_type>
+    read_from_file(std::istream&) const override
   {
     // needs more arguments, so we just give up (TODO?)
     unique_ptr<data_type> ret;
@@ -72,8 +72,8 @@ public InputFileFormat<DynamicDiscretisedDensity>
       }
     return ret;
   }
-  virtual unique_ptr<data_type>
-    read_from_file(const std::string& filename) const
+  unique_ptr<data_type>
+    read_from_file(const std::string& filename) const override
   {
     MultipleDataSetHeader header;
     if (header.parse(filename.c_str()) == false)

--- a/src/include/stir/IO/MultiDynamicDiscretisedDensityOutputFileFormat.h
+++ b/src/include/stir/IO/MultiDynamicDiscretisedDensityOutputFileFormat.h
@@ -56,16 +56,16 @@ public :
   MultiDynamicDiscretisedDensityOutputFileFormat(const NumericType& = NumericType::FLOAT, 
                    const ByteOrder& = ByteOrder::native);
 
-  virtual ByteOrder set_byte_order(const ByteOrder&, const bool warn = false);
+  ByteOrder set_byte_order(const ByteOrder&, const bool warn = false) override;
  protected:
-  virtual Succeeded  
+  Succeeded  
     actual_write_to_file(std::string& output_filename,
-		  const DynamicDiscretisedDensity& density) const;
+		  const DynamicDiscretisedDensity& density) const override;
 
 
-  virtual void set_defaults();
-  virtual void initialise_keymap();
-  virtual bool post_processing();
+  void set_defaults() override;
+  void initialise_keymap() override;
+  bool post_processing() override;
   
   /// Output type for the individual images
   shared_ptr<OutputFileFormat<DiscretisedDensity<3,float> > > individual_output_type_sptr;

--- a/src/include/stir/IO/MultiParametricDiscretisedDensityInputFileFormat.h
+++ b/src/include/stir/IO/MultiParametricDiscretisedDensityInputFileFormat.h
@@ -41,15 +41,15 @@ class MultiParametricDiscretisedDensityInputFileFormat :
 public InputFileFormat<ParametricVoxelsOnCartesianGrid>
 {
  public:
-  virtual const std::string
-    get_name() const
+  const std::string
+    get_name() const override
   {  return "Multi"; }
 
  protected:
-  virtual 
+  
     bool 
     actual_can_read(const FileSignature& signature,
-		    std::istream&) const
+		    std::istream&) const override
   {
     //. todo should check if it's an image
     // checking for "multi :"
@@ -62,8 +62,8 @@ public InputFileFormat<ParametricVoxelsOnCartesianGrid>
             standardise_interfile_keyword("multi"));
   }
 
-  virtual unique_ptr<data_type>
-    read_from_file(std::istream&) const
+  unique_ptr<data_type>
+    read_from_file(std::istream&) const override
   {
     // needs more arguments, so we just give up (TODO?)
     unique_ptr<data_type> ret;
@@ -73,8 +73,8 @@ public InputFileFormat<ParametricVoxelsOnCartesianGrid>
       }
     return ret;
   }
-  virtual unique_ptr<data_type>
-    read_from_file(const std::string& filename) const
+  unique_ptr<data_type>
+    read_from_file(const std::string& filename) const override
   {
     MultipleDataSetHeader header;
     if (header.parse(filename.c_str()) == false)

--- a/src/include/stir/IO/MultiParametricDiscretisedDensityOutputFileFormat.h
+++ b/src/include/stir/IO/MultiParametricDiscretisedDensityOutputFileFormat.h
@@ -55,16 +55,16 @@ public :
                    const ByteOrder& = ByteOrder::native);
 
 
-  virtual ByteOrder set_byte_order(const ByteOrder&, const bool warn = false);
+  ByteOrder set_byte_order(const ByteOrder&, const bool warn = false) override;
  protected:
-  virtual Succeeded  
+  Succeeded  
     actual_write_to_file(std::string& output_filename,
-		  const ParametricDiscretisedDensity<DiscDensityT>& density) const;
+		  const ParametricDiscretisedDensity<DiscDensityT>& density) const override;
 
 
-  virtual void set_defaults();
-  virtual void initialise_keymap();
-  virtual bool post_processing();
+  void set_defaults() override;
+  void initialise_keymap() override;
+  bool post_processing() override;
 
   /// Output type for the individual images
   using DiscretisedDensityType = typename ParametricDiscretisedDensity<DiscDensityT>::SingleDiscretisedDensityType::hierarchy_base_type;

--- a/src/include/stir/IO/OutputFileFormat.h
+++ b/src/include/stir/IO/OutputFileFormat.h
@@ -168,16 +168,16 @@ protected:
 
   //! sets value for output data type
   /*! Has to be called by set_defaults() in the leaf-class */
-  virtual void set_defaults();
+  void set_defaults() override;
   //! sets keys for output data type for parsing
   /*! Has to be called by initialise_keymap() in the leaf-class */
-  virtual void initialise_keymap();
+  void initialise_keymap() override;
   //! Checks if parameters have sensible values after parsing
   /*! Has to be called by post_processing() in the leaf-class */
-  virtual bool post_processing();
+  bool post_processing() override;
   //! overloaded member for ParsingObject::set_key_values()
   /*! Has to be called by set_key_values() in the leaf-class (if it redefines it) */
-  virtual void set_key_values();
+  void set_key_values() override;
 
 private:
   static shared_ptr<OutputFileFormat<DataT> > _default_sptr;

--- a/src/include/stir/IO/ROOTListmodeInputFileFormat.h
+++ b/src/include/stir/IO/ROOTListmodeInputFileFormat.h
@@ -29,16 +29,16 @@ class ROOTListmodeInputFileFormat :
         public InputFileFormat<ListModeData >
 {
 public:
-    virtual const std::string
-    get_name() const
+    const std::string
+    get_name() const override
     {  return "ROOT"; }
 
 protected:
 
-    virtual
+    
     bool
     actual_can_read(const FileSignature& signature,
-                    std::istream& input) const
+                    std::istream& input) const override
     {
         return this->is_root_signature(signature.get_signature());
     }
@@ -56,16 +56,16 @@ protected:
     }
 
 public:
-    virtual unique_ptr<data_type>
-    read_from_file(std::istream& input) const
+    unique_ptr<data_type>
+    read_from_file(std::istream& input) const override
     {
         error("read_from_file for ROOT listmode data with istream not implemented %s:%s. Sorry",
                 __FILE__, __LINE__);
         return unique_ptr<data_type>();
     }
 
-    virtual unique_ptr<data_type>
-    read_from_file(const std::string& filename) const
+    unique_ptr<data_type>
+    read_from_file(const std::string& filename) const override
     {
         return unique_ptr<data_type>(new CListModeDataROOT(filename));
     }

--- a/src/include/stir/IO/SAFIRCListmodeInputFileFormat.h
+++ b/src/include/stir/IO/SAFIRCListmodeInputFileFormat.h
@@ -78,19 +78,19 @@ class SAFIRCListmodeInputFileFormat : public InputFileFormat<ListModeData>, publ
 {
 public:
 	SAFIRCListmodeInputFileFormat() {}
-	virtual const std::string get_name() const
+	const std::string get_name() const override
 	{
 		return "SAFIR Coincidence Listmode File Format";
 	}
 	
 	//! Checks in binary data file for correct signature.
-	virtual bool can_read(const FileSignature& signature, std::istream& input ) const
+	bool can_read(const FileSignature& signature, std::istream& input ) const override
 	{
 		return false; // cannot read from istream
 	}
 
 	//! Checks in binary data file for correct signature (can be either "SAFIR CListModeData", "NeuroLF CListModeData" or "MUPET CListModeData").
-	virtual bool can_read( const FileSignature& signature, const std::string& filename) const
+	bool can_read( const FileSignature& signature, const std::string& filename) const override
 	{
 		// Looking for the right key in the parameter file
 		std::ifstream par_file(filename.c_str());
@@ -124,15 +124,15 @@ public:
 		return cr;
 	}
 	
-	virtual std::unique_ptr<data_type>
-	read_from_file(std::istream& input) const
+	std::unique_ptr<data_type>
+	read_from_file(std::istream& input) const override
 	{
 		error("read_from_file for SAFIRCListmodeData with istream not implemented %s:%d. Sorry",__FILE__, __LINE__);
 		return unique_ptr<data_type>();
 	}
 
-	virtual std::unique_ptr<data_type> 
-	read_from_file(const std::string& filename) const
+	std::unique_ptr<data_type> 
+	read_from_file(const std::string& filename) const override
 	{
 		info("SAFIRCListmodeInputFileFormat: read_from_file(" + std::string(filename) + ")");
 		actual_do_parsing(filename);
@@ -146,11 +146,11 @@ protected:
 	mutable std::string template_proj_data_filename;
 	mutable double lor_randomization_sigma;
 
-	virtual bool actual_can_read(const FileSignature &signature, std::istream &input) const {
+	bool actual_can_read(const FileSignature &signature, std::istream &input) const override {
 		return false; // cannot read from istream
 	}
 
-	void initialise_keymap() {
+	void initialise_keymap() override {
 		base_type::initialise_keymap();
 		this->parser.add_start_key("CListModeDataSAFIR Parameters");
 		this->parser.add_key("listmode data filename", &listmode_filename);
@@ -160,7 +160,7 @@ protected:
 		this->parser.add_stop_key("END CListModeDataSAFIR Parameters");
 	}
 
-	void set_defaults() {
+	void set_defaults() override {
 		base_type::set_defaults();
 		crystal_map_filename = "";
 		template_proj_data_filename = "";
@@ -176,7 +176,7 @@ protected:
 		else return false;
 	}
 
-	bool post_processing() {
+	bool post_processing() override {
 		if( !file_exists(listmode_filename) ) return true;
 		else if( !file_exists(template_proj_data_filename) ) return true;
 		else {

--- a/src/include/stir/IO/test/test_IO.h
+++ b/src/include/stir/IO/test/test_IO.h
@@ -71,7 +71,7 @@ class IOTests : public RunTests
 public:
     IOTests(std::istream& in);
 
-    void run_tests();
+    void run_tests() override;
 protected:
 
     void         set_up();

--- a/src/include/stir/KOSMAPOSL/KOSMAPOSLReconstruction.h
+++ b/src/include/stir/KOSMAPOSL/KOSMAPOSLReconstruction.h
@@ -191,7 +191,7 @@ public:
   //@}
 
   //! prompts the user to enter parameter values manually
-  virtual void ask_parameters();
+  void ask_parameters() override;
  protected:
   //! Filename with input projection data
   std::string input_filename,kernelised_output_filename_prefix;
@@ -214,9 +214,9 @@ public:
   BasicCoordinate<3,int> min_ind, max_ind;
   shared_ptr<TargetT> iterative_kernel_image_frozen_sptr;
 
-  virtual void set_defaults();
-  virtual void initialise_keymap();
-  virtual bool post_processing();
+  void set_defaults() override;
+  void initialise_keymap() override;
+  bool post_processing() override;
 
 
   //! Function that applies the kernel to the image_to_kernelise
@@ -228,10 +228,10 @@ private:
   friend void do_sensitivity(const char * const par_filename);
 
   //! operations prior to the iterations
-  virtual Succeeded set_up(shared_ptr <TargetT > const& target_image_sptr);
+  Succeeded set_up(shared_ptr <TargetT > const& target_image_sptr) override;
  
   //! the principal operations for updating the image iterates at each iteration
-  virtual void update_estimate (TargetT& current_image_estimate);
+  void update_estimate (TargetT& current_image_estimate) override;
   
   //!  check whether the iterative kernel still needs to be updated
   bool still_updating_iterative_kernel();

--- a/src/include/stir/LORCoordinates.h
+++ b/src/include/stir/LORCoordinates.h
@@ -189,7 +189,7 @@ class LORInCylinderCoordinates : public LOR<coordT>
   /*! In this class, this currently always return \c false. You can swap the points if
       you want to swap the direction of the LOR.
   */
-  bool is_swapped() const
+  bool is_swapped() const override
     {
       return false;
     }
@@ -247,22 +247,22 @@ class LORInCylinderCoordinates : public LOR<coordT>
   self_type* clone() const override
   { return new self_type(*this); }
 
-  virtual
+  
     Succeeded
     change_representation(LORInCylinderCoordinates<coordT>&,
-			     const double radius) const;
-  virtual
+			     const double radius) const override;
+  
     Succeeded
     change_representation(LORInAxialAndNoArcCorrSinogramCoordinates<coordT>&,
-						   const double radius) const;
-  virtual
+						   const double radius) const override;
+  
     Succeeded
     change_representation(LORInAxialAndSinogramCoordinates<coordT>&,
-				       const double radius) const;
-  virtual
+				       const double radius) const override;
+  
     Succeeded
     get_intersections_with_cylinder(LORAs2Points<coordT>&,
-				    const double radius) const;
+				    const double radius) const override;
 
  private:
   PointOnCylinder<coordT> _p1;
@@ -309,7 +309,7 @@ class LORAs2Points : public LOR<coordT>
   /*! In this class, this currently always return \c false. You can swap the points if
   you want to swap the direction of the LOR.
   */
-  bool is_swapped() const
+  bool is_swapped() const override
     {
       return false;
     }
@@ -317,22 +317,22 @@ class LORAs2Points : public LOR<coordT>
   self_type* clone() const override
   { return new self_type(*this); }
 
-  virtual
+  
     Succeeded
     change_representation(LORInCylinderCoordinates<coordT>&,
-			     const double radius) const;
-  virtual
+			     const double radius) const override;
+  
     Succeeded
     change_representation(LORInAxialAndNoArcCorrSinogramCoordinates<coordT>&,
-						   const double radius) const;
-  virtual
+						   const double radius) const override;
+  
     Succeeded
     change_representation(LORInAxialAndSinogramCoordinates<coordT>&,
-						   const double radius) const;
-  virtual
+						   const double radius) const override;
+  
     Succeeded
     get_intersections_with_cylinder(LORAs2Points<coordT>&,
-				    const double radius) const;
+				    const double radius) const override;
  
  //! Calculate intersections with block. Used in: ProjDataInfoBlocksOnCylindrical::get_LOR
   Succeeded
@@ -381,7 +381,7 @@ class LORInAxialAndSinogramCoordinates
   coordT& s()           { check_state(); return _s; }
 
   coordT beta() const   { check_state(); return asin(_s/private_base_type::_radius); }
-  bool is_swapped() const { check_state(); return _swapped; }
+  bool is_swapped() const override { check_state(); return _swapped; }
   bool is_swapped() { check_state(); return _swapped; }
   inline explicit
   LORInAxialAndSinogramCoordinates(const coordT radius = 1);
@@ -434,22 +434,22 @@ class LORInAxialAndSinogramCoordinates
     }
     
 
-  virtual
+  
     Succeeded
     change_representation(LORInCylinderCoordinates<coordT>&,
-			     const double radius) const;
-  virtual
+			     const double radius) const override;
+  
     Succeeded
     change_representation(LORInAxialAndNoArcCorrSinogramCoordinates<coordT>&,
-						   const double radius) const;
-  virtual
+						   const double radius) const override;
+  
     Succeeded
     change_representation(LORInAxialAndSinogramCoordinates<coordT>&,
-				       const double radius) const;
-  virtual
+				       const double radius) const override;
+  
     Succeeded
     get_intersections_with_cylinder(LORAs2Points<coordT>&,
-				    const double radius) const;
+				    const double radius) const override;
 
  private:
   coordT _phi;
@@ -492,7 +492,7 @@ class LORInAxialAndNoArcCorrSinogramCoordinates
   coordT& phi()         { check_state(); return _phi; }
   coordT beta() const   { check_state(); return _beta; }
   coordT& beta()        { check_state(); return _beta; }
-  bool is_swapped() const { check_state(); return _swapped; }
+  bool is_swapped() const override { check_state(); return _swapped; }
   bool is_swapped() { check_state(); return _swapped; }
 
   coordT s() const      { check_state(); return private_base_type::_radius*sin(_beta); }
@@ -547,22 +547,22 @@ class LORInAxialAndNoArcCorrSinogramCoordinates
   self_type* clone() const override
   { return new self_type(*this); }
 
-  virtual
+  
     Succeeded
     change_representation(LORInCylinderCoordinates<coordT>&,
-			     const double radius) const;
-  virtual
+			     const double radius) const override;
+  
     Succeeded
     change_representation(LORInAxialAndNoArcCorrSinogramCoordinates<coordT>&,
-						   const double radius) const;
-  virtual
+						   const double radius) const override;
+  
     Succeeded
     change_representation(LORInAxialAndSinogramCoordinates<coordT>&,
-				       const double radius) const;
-  virtual
+				       const double radius) const override;
+  
     Succeeded
     get_intersections_with_cylinder(LORAs2Points<coordT>&,
-				    const double radius) const;
+				    const double radius) const override;
 
  private:
   coordT _phi;

--- a/src/include/stir/ML_norm.h
+++ b/src/include/stir/ML_norm.h
@@ -81,7 +81,7 @@ public:
     float find_max() const;
     float find_min() const;
     int get_num_detectors() const;
-    void grow(const IndexRange<2>&);
+    void grow(const IndexRange<2>&) override;
     
 private:
     typedef Array<2,float> base_type;
@@ -144,7 +144,7 @@ class GeoData3D : public Array<4,float>
 public:
     GeoData3D();
     GeoData3D(const int num_axial_crystals_per_block, const int half_num_transaxial_crystals_per_block, const int num_rings, const int num_detectors_per_ring);
-    virtual  ~GeoData3D();
+     ~GeoData3D() override;
     GeoData3D& operator=(const GeoData3D&);
 
     
@@ -187,7 +187,7 @@ public:
     
     FanProjData();
     FanProjData(const int num_rings, const int num_detectors_per_ring, const int max_ring_diff, const int fan_size);
-    virtual ~FanProjData();
+    ~FanProjData() override;
     FanProjData& operator=(const FanProjData&);
     
     float& operator()(const int ra, const int a, const int rb, const int b);

--- a/src/include/stir/MaximalArrayFilter3D.h
+++ b/src/include/stir/MaximalArrayFilter3D.h
@@ -52,14 +52,14 @@ class MaximalArrayFilter3D: public ArrayFunctionObject_2ArgumentImplementation<3
  public:
   explicit MaximalArrayFilter3D (const Coordinate3D<int>& mask_radius);
   MaximalArrayFilter3D ();    
-  bool is_trivial() const;
+  bool is_trivial() const override;
   
  private:
   int mask_radius_x;
   int mask_radius_y;
   int mask_radius_z;
   
-  virtual void do_it(Array<3,elemT>& out_array, const Array<3,elemT>& in_array) const;
+  void do_it(Array<3,elemT>& out_array, const Array<3,elemT>& in_array) const override;
 
   //! extract all neighbours and put them in a 1D array
   /*! \return the number of neighbours within the image range

--- a/src/include/stir/MaximalImageFilter3D.h
+++ b/src/include/stir/MaximalImageFilter3D.h
@@ -71,12 +71,12 @@ private:
   int mask_radius_z;
 
 
-  virtual void set_defaults();
-  virtual void initialise_keymap();
+  void set_defaults() override;
+  void initialise_keymap() override;
 
-  Succeeded virtual_set_up (const DiscretisedDensity< 3,elemT>& density);
-  void virtual_apply(DiscretisedDensity<3,elemT>& density, const DiscretisedDensity<3,elemT>& in_density) const; 
-  void virtual_apply(DiscretisedDensity<3,elemT>& density) const; 
+  Succeeded virtual_set_up (const DiscretisedDensity< 3,elemT>& density) override;
+  void virtual_apply(DiscretisedDensity<3,elemT>& density, const DiscretisedDensity<3,elemT>& in_density) const override; 
+  void virtual_apply(DiscretisedDensity<3,elemT>& density) const override; 
 };
 
 

--- a/src/include/stir/MedianArrayFilter3D.h
+++ b/src/include/stir/MedianArrayFilter3D.h
@@ -55,14 +55,14 @@ class MedianArrayFilter3D: public ArrayFunctionObject_2ArgumentImplementation<3,
 public:
   explicit MedianArrayFilter3D (const Coordinate3D<int>& mask_radius);    
   MedianArrayFilter3D ();    
-  bool is_trivial() const;
+  bool is_trivial() const override;
   
 private:
   int mask_radius_x;
   int mask_radius_y;
   int mask_radius_z;
   
-  virtual void do_it(Array<3,elemT>& out_array, const Array<3,elemT>& in_array) const;
+  void do_it(Array<3,elemT>& out_array, const Array<3,elemT>& in_array) const override;
 
   //! extract all neighbours and put them in a 1D array
   /*! \return the number of neighbours within the image range

--- a/src/include/stir/MedianImageFilter3D.h
+++ b/src/include/stir/MedianImageFilter3D.h
@@ -73,12 +73,12 @@ private:
   int mask_radius_z;
 
 
-  virtual void set_defaults();
-  virtual void initialise_keymap();
+  void set_defaults() override;
+  void initialise_keymap() override;
 
-  Succeeded virtual_set_up (const DiscretisedDensity< 3,elemT>& density);
-  void virtual_apply(DiscretisedDensity<3,elemT>& density, const DiscretisedDensity<3,elemT>& in_density) const; 
-  void virtual_apply(DiscretisedDensity<3,elemT>& density) const; 
+  Succeeded virtual_set_up (const DiscretisedDensity< 3,elemT>& density) override;
+  void virtual_apply(DiscretisedDensity<3,elemT>& density, const DiscretisedDensity<3,elemT>& in_density) const override; 
+  void virtual_apply(DiscretisedDensity<3,elemT>& density) const override; 
 };
 
 

--- a/src/include/stir/MinimalArrayFilter3D.h
+++ b/src/include/stir/MinimalArrayFilter3D.h
@@ -53,14 +53,14 @@ class MinimalArrayFilter3D: public ArrayFunctionObject_2ArgumentImplementation<3
 public:
   explicit MinimalArrayFilter3D (const Coordinate3D<int>& mask_radius);
   MinimalArrayFilter3D ();    
-  bool is_trivial() const;
+  bool is_trivial() const override;
   
 private:
   int mask_radius_x;
   int mask_radius_y;
   int mask_radius_z;
   
-  virtual void do_it(Array<3,elemT>& out_array, const Array<3,elemT>& in_array) const;
+  void do_it(Array<3,elemT>& out_array, const Array<3,elemT>& in_array) const override;
 
   //! extract all neighbours and put them in a 1D array
   /*! \return the number of neighbours within the image range

--- a/src/include/stir/MinimalImageFilter3D.h
+++ b/src/include/stir/MinimalImageFilter3D.h
@@ -72,12 +72,12 @@ private:
   int mask_radius_z;
 
 
-  virtual void set_defaults();
-  virtual void initialise_keymap();
+  void set_defaults() override;
+  void initialise_keymap() override;
 
-  Succeeded virtual_set_up (const DiscretisedDensity< 3,elemT>& density);
-  void virtual_apply(DiscretisedDensity<3,elemT>& density, const DiscretisedDensity<3,elemT>& in_density) const; 
-  void virtual_apply(DiscretisedDensity<3,elemT>& density) const; 
+  Succeeded virtual_set_up (const DiscretisedDensity< 3,elemT>& density) override;
+  void virtual_apply(DiscretisedDensity<3,elemT>& density, const DiscretisedDensity<3,elemT>& in_density) const override; 
+  void virtual_apply(DiscretisedDensity<3,elemT>& density) const override; 
 };
 
 

--- a/src/include/stir/MultipleDataSetHeader.h
+++ b/src/include/stir/MultipleDataSetHeader.h
@@ -59,7 +59,7 @@ virtual void set_defaults();
 //! Initialise keymap
 virtual void initialise_keymap();
 //! Post process
-virtual bool post_processing();
+bool post_processing() override;
 
 int _num_data_sets;
 std::vector<std::string> _filenames;

--- a/src/include/stir/NonseparableConvolutionUsingRealDFTImageFilter.h
+++ b/src/include/stir/NonseparableConvolutionUsingRealDFTImageFilter.h
@@ -101,14 +101,14 @@ private:
   shared_ptr<ArrayFilterUsingRealDFTWithPadding<num_dimensions,elemT> > _array_filter_sptr; // ChT::float
   Array<num_dimensions,elemT> _filter_coefficients;
 
-  virtual void set_defaults();
-  virtual void initialise_keymap();
-  virtual bool post_processing();
+  void set_defaults() override;
+  void initialise_keymap() override;
+  bool post_processing() override;
   
-  Succeeded virtual_set_up(const DiscretisedDensity<num_dimensions,elemT>& image);
+  Succeeded virtual_set_up(const DiscretisedDensity<num_dimensions,elemT>& image) override;
   void  virtual_apply(DiscretisedDensity<num_dimensions,elemT>& out_density, 
-		      const DiscretisedDensity<num_dimensions,elemT>& in_density) const;
-  void  virtual_apply(DiscretisedDensity<num_dimensions,elemT>& density) const ;
+		      const DiscretisedDensity<num_dimensions,elemT>& in_density) const override;
+  void  virtual_apply(DiscretisedDensity<num_dimensions,elemT>& density) const override ;
   
 };
 

--- a/src/include/stir/OSMAPOSL/OSMAPOSLReconstruction.h
+++ b/src/include/stir/OSMAPOSL/OSMAPOSLReconstruction.h
@@ -109,7 +109,7 @@ public:
     {return *this;}
 
   //! gives method information
-  virtual std::string method_info() const;
+  std::string method_info() const override;
 
   //! Return current objective function
   /* Overloading IterativeReconstruction::get_objective_function()
@@ -146,13 +146,13 @@ public:
   //@}
 
   //! prompts the user to enter parameter values manually
-  virtual void ask_parameters();
+  void ask_parameters() override;
 
   //! operations prior to the iterations
-  virtual Succeeded set_up(shared_ptr <TargetT > const& target_image_ptr);
+  Succeeded set_up(shared_ptr <TargetT > const& target_image_ptr) override;
 
   //! the principal operations for updating the image iterates at each iteration
-  virtual void update_estimate (TargetT& current_image_estimate);
+  void update_estimate (TargetT& current_image_estimate) override;
 
  protected:
 
@@ -188,11 +188,11 @@ public:
   //! should be either additive or multiplicative
   std::string MAP_model; 
 
-  virtual void set_defaults();
-  virtual void initialise_keymap();
+  void set_defaults() override;
+  void initialise_keymap() override;
 
   //! used to check acceptable parameter ranges, etc...
-  virtual bool post_processing();
+  bool post_processing() override;
 
   virtual void compute_sub_gradient_without_penalty_plus_sensitivity(
     TargetT& gradient, const TargetT &current_estimate, const int subset_num);

--- a/src/include/stir/OSSPS/OSSPSReconstruction.h
+++ b/src/include/stir/OSSPS/OSSPSReconstruction.h
@@ -113,7 +113,7 @@ public:
     OSSPSReconstruction(const std::string& parameter_filename);
 
   //! prompts the user to enter parameter values manually
-  virtual void ask_parameters();
+  void ask_parameters() override;
   //! accessor for the external parameters
   OSSPSReconstruction& get_parameters(){return *this;}
 
@@ -122,7 +122,7 @@ public:
     {return *this;}
 
   //! gives method information
-  virtual std::string method_info() const;
+  std::string method_info() const override;
 
   //! Precompute the data-dependent part of the denominator for the preconditioner
 /*!
@@ -143,10 +143,10 @@ public:
 
 
   //! operations prior to the iterations
-  virtual Succeeded set_up(shared_ptr <TargetT > const& target_image_ptr);
+  Succeeded set_up(shared_ptr <TargetT > const& target_image_ptr) override;
 
   //! the principal operations for updating the image iterates at each iteration
-  virtual void update_estimate(TargetT &current_image_estimate);
+  void update_estimate(TargetT &current_image_estimate) override;
  
 
  protected: // could be private, but this way the doxygen comments are always listed
@@ -172,10 +172,10 @@ public:
   //! parameter determining how fast relaxation goes down  (see class documentation)
   float relaxation_gamma;
 
-  virtual void set_defaults();
-  virtual void initialise_keymap();
+  void set_defaults() override;
+  void initialise_keymap() override;
   //! used to check acceptable parameter ranges, etc...
-  virtual bool post_processing();
+  bool post_processing() override;
 
 private:
 

--- a/src/include/stir/PixelsOnCartesianGrid.h
+++ b/src/include/stir/PixelsOnCartesianGrid.h
@@ -78,19 +78,19 @@ DiscretisedDensity<2,elemT>*
 #else
 PixelsOnCartesianGrid<elemT>*
 #endif
- get_empty_copy() const;
+ get_empty_copy() const override;
 
 //! Like get_empty_discretised_density, but returning a pointer to a PixelsOnCartesianGrid
 PixelsOnCartesianGrid<elemT>* get_empty_pixels_on_cartesian_grid() const;
 
 //TODO covariant return types
-virtual
+
 #ifdef STIR_NO_COVARIANT_RETURN_TYPES
 DiscretisedDensity<2,elemT>*
 #else
 PixelsOnCartesianGrid<elemT>*
 #endif
-clone() const;
+clone() const override;
     
 inline int get_x_size() const;
 

--- a/src/include/stir/PostFiltering.h
+++ b/src/include/stir/PostFiltering.h
@@ -36,7 +36,7 @@ public:
     //! Default constructor
     PostFiltering();
 
-    virtual ~PostFiltering(){}
+    ~PostFiltering() override{}
 
     void set_filter_sptr(shared_ptr<DataProcessor< DataT > > filter_sptr);
     Succeeded process_data(DataT& arg);
@@ -45,9 +45,9 @@ public:
     bool is_filter_null();
 
 protected:
-    virtual void set_defaults();
-    virtual void initialise_keymap();
-    virtual bool post_processing();
+    void set_defaults() override;
+    void initialise_keymap() override;
+    bool post_processing() override;
 
 private:
     shared_ptr<DataProcessor< DataT > > filter_sptr;

--- a/src/include/stir/ProjData.h
+++ b/src/include/stir/ProjData.h
@@ -118,7 +118,7 @@ public:
 #endif
 
   //! Destructor
-  virtual ~ProjData() {}
+  ~ProjData() override {}
   //! Get shared pointer to proj data info
   inline shared_ptr<const ProjDataInfo>
     get_proj_data_info_sptr() const;

--- a/src/include/stir/ProjDataFromStream.h
+++ b/src/include/stir/ProjDataFromStream.h
@@ -126,28 +126,28 @@ public:
   //! Get & set viewgram 
   Viewgram<float> get_viewgram(const int view_num, const int segment_num,
                                const bool make_num_tangential_poss_odd=false,
-                               const int timing_pos=0) const;
-  Succeeded set_viewgram(const Viewgram<float>& v);
+                               const int timing_pos=0) const override;
+  Succeeded set_viewgram(const Viewgram<float>& v) override;
     
   //! Get & set sinogram 
   Sinogram<float> get_sinogram(const int ax_pos_num, const int segment_num,
                                const bool make_num_tangential_poss_odd=false,
-                               const int timing_pos=0) const;
+                               const int timing_pos=0) const override;
 
-  Succeeded set_sinogram(const Sinogram<float>& s);
+  Succeeded set_sinogram(const Sinogram<float>& s) override;
     
   //! Get all sinograms for the given segment
   SegmentBySinogram<float> get_segment_by_sinogram(const int segment_num,
-                                                   const int timing_num = 0) const;
+                                                   const int timing_num = 0) const override;
   //! Get all viewgrams for the given segment
   SegmentByView<float> get_segment_by_view(const int segment_num,
-                                           const int timing_pos = 0) const;
+                                           const int timing_pos = 0) const override;
     
     
   //! Set all sinograms for the given segment
-  Succeeded set_segment(const SegmentBySinogram<float>&);
+  Succeeded set_segment(const SegmentBySinogram<float>&) override;
   //! Set all viewgrams for the given segment
-  Succeeded set_segment(const SegmentByView<float>&);
+  Succeeded set_segment(const SegmentByView<float>&) override;
 
   //! Get scale factor
   float get_scale_factor() const;  

--- a/src/include/stir/ProjDataGEHDF5.h
+++ b/src/include/stir/ProjDataGEHDF5.h
@@ -55,15 +55,15 @@ private:
 
     unsigned int find_segment_offset(const int segment_num) const;
     //! Set Viewgram<float>
-    Succeeded set_viewgram(const Viewgram<float>& v);
+    Succeeded set_viewgram(const Viewgram<float>& v) override;
     //! Set Sinogram<float>
-    Succeeded set_sinogram(const Sinogram<float>& s);
+    Succeeded set_sinogram(const Sinogram<float>& s) override;
     //! Get Viewgram<float>
     Viewgram<float> get_viewgram(const int view_num, const int segment_num,const bool make_num_tangential_poss_odd=false,
-                                 const int timing_pos = 0) const;
+                                 const int timing_pos = 0) const override;
     //! Get Sinogram<float>
     Sinogram<float> get_sinogram(const int ax_pos_num, const int sergment_num,const bool make_num_tangential_poss_odd=false,
-                                 const int timing_pos = 0) const;
+                                 const int timing_pos = 0) const override;
     //! Get the segment sequence
     std::vector<int> get_segment_sequence_in_hdf5() const;
     std::vector< unsigned int > seg_ax_offset;

--- a/src/include/stir/ProjDataInMemory.h
+++ b/src/include/stir/ProjDataInMemory.h
@@ -62,7 +62,7 @@ public:
                                , const int timing_pos=0
 #endif
                                ) const override;
-  Succeeded set_viewgram(const Viewgram<float>& v);
+  Succeeded set_viewgram(const Viewgram<float>& v) override;
 
   Sinogram<float> get_sinogram(const int ax_pos_num, const int segment_num,
                                const bool make_num_tangential_poss_odd=false
@@ -93,17 +93,17 @@ public:
 
   //! set all bins to the same value
   /*! will call error() if setting failed */
-  virtual void fill(const float value);
+  void fill(const float value) override;
 
   //! set all bins from another ProjData object
   /*! will call error() if setting failed or if the 'source' proj_data is not compatible.
     The current check requires at least the same segment numbers (but the source can have more),
     all other geometric parameters have to be the same.
  */
-  virtual void fill(const ProjData&);
+  void fill(const ProjData&) override;
 
   //! destructor deallocates all memory the object owns
-  virtual ~ProjDataInMemory();
+  ~ProjDataInMemory() override;
  
   //! Returns a  value of a bin
   float get_bin_value(Bin& bin);
@@ -111,30 +111,30 @@ public:
   void set_bin_value(const Bin &bin);
     
   //! \deprecated a*x+b*y (use xapyb)
-  STIR_DEPRECATED virtual void axpby(const float a, const ProjData& x,
-                                     const float b, const ProjData& y);
+  STIR_DEPRECATED void axpby(const float a, const ProjData& x,
+                                     const float b, const ProjData& y) override;
 
   //! set values of the array to x*a+y*b, where a and b are scalar, and x and y are ProjData.
   /// This implementation requires that x and y are ProjDataInMemory
   /// (else falls back on general method)
-  virtual void xapyb(const ProjData& x, const float a,
-                     const ProjData& y, const float b);
+  void xapyb(const ProjData& x, const float a,
+                     const ProjData& y, const float b) override;
 
   //! set values of the array to x*a+y*b, where a, b, x and y are ProjData.
   /// This implementation requires that a, b, x and y are ProjDataInMemory
   /// (else falls back on general method)
-  virtual void xapyb(const ProjData& x, const ProjData& a,
-                     const ProjData& y, const ProjData& b);
+  void xapyb(const ProjData& x, const ProjData& a,
+                     const ProjData& y, const ProjData& b) override;
 
   //! set values of the array to self*a+y*b where a and b are scalar, y is ProjData
   /// This implementation requires that a, b and y are ProjDataInMemory
   /// (else falls back on general method)  
-  virtual void sapyb(const float a, const ProjData& y, const float b);
+  void sapyb(const float a, const ProjData& y, const float b) override;
 
   //! set values of the array to self*a+y*b where a, b and y are ProjData
    /// This implementation requires that a, b and y are ProjDataInMemory
   /// (else falls back on general method)   
-  virtual void sapyb(const ProjData& a, const ProjData& y, const ProjData& b);
+  void sapyb(const ProjData& a, const ProjData& y, const ProjData& b) override;
 
   /** @name iterator typedefs
    *  iterator typedefs

--- a/src/include/stir/ProjDataInfoBlocksOnCylindricalNoArcCorr.h
+++ b/src/include/stir/ProjDataInfoBlocksOnCylindricalNoArcCorr.h
@@ -92,11 +92,11 @@ public:
     const  VectorWithOffset<int>& max_ring_diff_v,
     const int num_views,const int num_tangential_poss);
 
-  ProjDataInfo* clone() const;
+  ProjDataInfo* clone() const override;
 
   bool operator==(const self_type&) const;
 
-  virtual std::string parameter_info() const;
+  std::string parameter_info() const override;
 
   //! \name set of obsolete functions to go between bins<->LORs (will disappear!)
   //@{
@@ -111,7 +111,7 @@ public:
 
 private:
 
-  virtual bool blindly_equals(const root_type * const) const;
+  bool blindly_equals(const root_type * const) const override;
 
 };
 

--- a/src/include/stir/ProjDataInfoCylindrical.h
+++ b/src/include/stir/ProjDataInfoCylindrical.h
@@ -72,11 +72,11 @@ public:
     const VectorWithOffset<int>& max_ring_diff,
     const int num_views,const int num_tangential_poss);
 
-  inline virtual float get_tantheta(const Bin&) const; 
+  inline float get_tantheta(const Bin&) const override; 
 		       
-  inline float get_phi(const Bin&) const; 
+  inline float get_phi(const Bin&) const override; 
  
-  inline float get_t(const Bin&) const;
+  inline float get_t(const Bin&) const override;
 
   //! Return z-coordinate of the middle of the LOR
   /*!
@@ -85,11 +85,11 @@ public:
     \warning Current implementation assumes that the axial positions are always 'centred',
     i.e. get_m(Bin(..., min_axial_pos_num,...)) == - get_m(Bin(..., max_axial_pos_num,...))
   */  
-  inline float get_m(const Bin&) const;
+  inline float get_m(const Bin&) const override;
 
-  virtual void
+  void
     get_LOR(LORInAxialAndNoArcCorrSinogramCoordinates<float>& lor,
-	    const Bin& bin) const;
+	    const Bin& bin) const override;
 #if 0
   // KT disabled these as untested (and unused)
 
@@ -128,17 +128,17 @@ public:
       the first view returns the same \c get_phi. Depending on what you want, you
       might have to call \c set_azimuthal_angle_offset() as well.
   */
-  virtual void
-    set_num_views(const int new_num_views);
+  void
+    set_num_views(const int new_num_views) override;
 
-  virtual void set_tof_mash_factor(const int new_num);
+  void set_tof_mash_factor(const int new_num) override;
 
   //! Get azimuthal angle offset (in radians)
   inline float get_azimuthal_angle_offset() const;
   //! Get the azimuthal sampling (in radians)
   inline float get_azimuthal_angle_sampling() const;
-  virtual inline float get_sampling_in_t(const Bin&) const;
-  virtual inline float get_sampling_in_m(const Bin&) const;
+  inline float get_sampling_in_t(const Bin&) const override;
+  inline float get_sampling_in_m(const Bin&) const override;
 
   //! Get the axial sampling (e.g in z_direction)
   /*! 
@@ -165,10 +165,10 @@ public:
   //! Set maximum ring difference
   void set_max_ring_difference(int max_ring_diff_v, int segment_num);
 
-  virtual void set_num_axial_poss_per_segment(const VectorWithOffset<int>& num_axial_poss_per_segment); 
-  virtual void set_min_axial_pos_num(const int min_ax_pos_num, const int segment_num);
-  virtual void set_max_axial_pos_num(const int max_ax_pos_num, const int segment_num);
-  virtual void reduce_segment_range(const int min_segment_num, const int max_segment_num);
+  void set_num_axial_poss_per_segment(const VectorWithOffset<int>& num_axial_poss_per_segment) override; 
+  void set_min_axial_pos_num(const int min_ax_pos_num, const int segment_num) override;
+  void set_max_axial_pos_num(const int max_ax_pos_num, const int segment_num) override;
+  void reduce_segment_range(const int min_segment_num, const int max_segment_num) override;
 
   //! Set detector ring radius for all views
   inline void set_ring_radii_for_all_views(const VectorWithOffset<float>& new_ring_radius);
@@ -266,7 +266,7 @@ public:
 					    const int segment_num,
                                             const int axial_pos_num) const;
 
-  virtual std::string parameter_info() const;
+  std::string parameter_info() const override;
 
 protected:
 
@@ -289,7 +289,7 @@ protected:
   bool sampling_corresponds_to_physical_rings;
   
 protected:
-  virtual bool blindly_equals(const root_type * const) const = 0;
+  bool blindly_equals(const root_type * const) const override = 0;
 
 private:
   float azimuthal_angle_offset;

--- a/src/include/stir/ProjDataInfoCylindricalArcCorr.h
+++ b/src/include/stir/ProjDataInfoCylindricalArcCorr.h
@@ -57,28 +57,28 @@ public:
     const int num_views,const int num_tangential_poss,
     const int tof_mash_factor = 0);
 
-  ProjDataInfo* clone() const;
+  ProjDataInfo* clone() const override;
   
   bool operator==(const self_type&) const;
 
-  inline virtual float get_s(const Bin&) const;
+  inline float get_s(const Bin&) const override;
   //! Set tangential sampling
   void set_tangential_sampling(const float bin_size);
   //! Get tangential sampling
   inline float get_tangential_sampling() const;
-  virtual float get_sampling_in_s(const Bin&) const
+  float get_sampling_in_s(const Bin&) const override
   {return bin_size; }
 
-  virtual 
+  
     Bin
-    get_bin(const LOR<float>&, const double delta_time = 0.0) const;
+    get_bin(const LOR<float>&, const double delta_time = 0.0) const override;
 
-  virtual std::string parameter_info() const;
+  std::string parameter_info() const override;
 private:
   
   float bin_size;
 
-  virtual bool blindly_equals(const root_type * const) const;
+  bool blindly_equals(const root_type * const) const override;
 
 };
 

--- a/src/include/stir/ProjDataInfoCylindricalNoArcCorr.h
+++ b/src/include/stir/ProjDataInfoCylindricalNoArcCorr.h
@@ -113,7 +113,7 @@ public:
     const int num_views,const int num_tangential_poss,
     const int tof_mash_factor = 0);
 
-  ProjDataInfo* clone() const;
+  ProjDataInfo* clone() const override;
 
   bool operator==(const self_type&) const;
 
@@ -122,12 +122,12 @@ public:
     This does \c not take the 'interleaving' into account which is 
     customarily applied to raw PET data.
   */
-  inline virtual float get_s(const Bin&) const;
+  inline float get_s(const Bin&) const override;
 
   //! Gets angular increment (in radians)
   inline float get_angular_increment() const;
 
-  virtual std::string parameter_info() const;
+  std::string parameter_info() const override;
 
   //! \name Functions that convert between bins and detection positions
   //@{ 
@@ -262,9 +262,9 @@ public:
 
   //@}
 
-  virtual 
+  
     Bin
-    get_bin(const LOR<float>&,const double delta_time) const;
+    get_bin(const LOR<float>&,const double delta_time) const override;
 
 
   //! \name set of obsolete functions to go between bins<->LORs (will disappear!)
@@ -321,7 +321,7 @@ private:
   //! build look-up table unless already done before
   inline void initialise_det1det2_to_uncompressed_view_tangpos_if_not_done_yet() const;
 
-  virtual bool blindly_equals(const root_type * const) const;
+  bool blindly_equals(const root_type * const) const override;
 
 };
 

--- a/src/include/stir/ProjDataInfoGeneric.h
+++ b/src/include/stir/ProjDataInfoGeneric.h
@@ -73,27 +73,27 @@ public:
     const VectorWithOffset<int>& max_ring_diff,
     const int num_views,const int num_tangential_poss);
 
-  inline virtual float get_tantheta(const Bin&) const;
+  inline float get_tantheta(const Bin&) const override;
 
-  inline float get_phi(const Bin&) const;
+  inline float get_phi(const Bin&) const override;
 
-  inline float get_t(const Bin&) const;
+  inline float get_t(const Bin&) const override;
 
   //! Return z-coordinate of the middle of the LOR
   /*!
   The 0 of the z-axis is chosen in the middle of the scanner.
   */
-  inline float get_m(const Bin&) const;
+  inline float get_m(const Bin&) const override;
 
-  virtual void
-    get_LOR(LORInAxialAndNoArcCorrSinogramCoordinates<float>& lor, const Bin& bin) const;
+  void
+    get_LOR(LORInAxialAndNoArcCorrSinogramCoordinates<float>& lor, const Bin& bin) const override;
 
   void set_azimuthal_angle_offset(const float angle) = delete;
   void set_azimuthal_angle_sampling(const float angle) = delete;
 
   //! set new number of views (currently calls error() unless nothing changes)
-  virtual void
-    set_num_views(const int new_num_views);
+  void
+    set_num_views(const int new_num_views) override;
 
   float get_azimuthal_angle_sampling() const = delete;
   float get_azimuthal_angle_offset() const = delete;
@@ -105,13 +105,13 @@ public:
   //TODOBLOCK what does this mean in a generic case?
   inline float get_ring_spacing() const;
 
-  virtual inline float get_sampling_in_t(const Bin&) const;
-  virtual inline float get_sampling_in_m(const Bin&) const;
+  inline float get_sampling_in_t(const Bin&) const override;
+  inline float get_sampling_in_m(const Bin&) const override;
 
   inline float get_axial_sampling(int segment_num) const override;
   inline bool axial_sampling_is_uniform() const override;
 
-  virtual std::string parameter_info() const;
+  std::string parameter_info() const override;
 
 private:
   //! to be used in get LOR

--- a/src/include/stir/ProjDataInfoGenericNoArcCorr.h
+++ b/src/include/stir/ProjDataInfoGenericNoArcCorr.h
@@ -89,7 +89,7 @@ public:
     const  VectorWithOffset<int>& max_ring_diff_v,
     const int num_views,const int num_tangential_poss);
 
-  ProjDataInfo* clone() const;
+  ProjDataInfo* clone() const override;
 
   bool operator==(const self_type&) const;
 
@@ -98,9 +98,9 @@ public:
     This does \c not take the 'interleaving' into account which is
     customarily applied to raw PET data.
   */
-  inline virtual float get_s(const Bin&) const;
+  inline float get_s(const Bin&) const override;
 
-  virtual std::string parameter_info() const;
+  std::string parameter_info() const override;
 
   //! \name Functions that convert between bins and detection positions
   //@{
@@ -226,9 +226,9 @@ public:
 
   //@}
 
-  virtual
+  
     Bin
-    get_bin(const LOR<float>&, const double delta_time = 0.0) const;
+    get_bin(const LOR<float>&, const double delta_time = 0.0) const override;
 
 
   //! \name set of obsolete functions to go between bins<->LORs (will disappear!)
@@ -239,9 +239,9 @@ public:
     \obsolete
   */
 
-  virtual void find_cartesian_coordinates_of_detection(CartesianCoordinate3D<float>& coord_1,
+  void find_cartesian_coordinates_of_detection(CartesianCoordinate3D<float>& coord_1,
 					       CartesianCoordinate3D<float>& coord_2,
-					       const Bin& bin) const;
+					       const Bin& bin) const override;
 
   virtual void find_cartesian_coordinates_given_scanner_coordinates (CartesianCoordinate3D<float>& coord_1,
 							     CartesianCoordinate3D<float>& coord_2,
@@ -270,7 +270,7 @@ private:
   //! build look-up table unless already done before
   inline void initialise_det1det2_to_uncompressed_view_tangpos_if_not_done_yet() const;
  protected:
-  virtual bool blindly_equals(const root_type * const) const;
+  bool blindly_equals(const root_type * const) const override;
 };
 
 END_NAMESPACE_STIR

--- a/src/include/stir/ProjDataInfoSubsetByView.h
+++ b/src/include/stir/ProjDataInfoSubsetByView.h
@@ -54,7 +54,7 @@ public:
   bool contains_full_data() const;
 
   //! Get the view numbers of the original ProjDataInfo
-  std::vector<int> get_original_view_nums() const;
+  std::vector<int> get_original_view_nums() const override;
 
   //! Get the Bin of the original ProjDataInfo corresponding to a Bin for this subset
   Bin get_original_bin(const Bin& bin) const;

--- a/src/include/stir/RegisteredObjectBase.h
+++ b/src/include/stir/RegisteredObjectBase.h
@@ -40,7 +40,7 @@ START_NAMESPACE_STIR
 class RegisteredObjectBase : public ParsingObject
 {
 public:
-  virtual ~RegisteredObjectBase() {}
+  ~RegisteredObjectBase() override {}
 
   /*! \brief Returns the name of the type of the object.
 

--- a/src/include/stir/RegisteredParsingObject.h
+++ b/src/include/stir/RegisteredParsingObject.h
@@ -89,9 +89,9 @@ public:
 inline static Base* read_from_stream(std::istream*); 
 
   //! Returns  Derived::registered_name
-  inline std::string get_registered_name() const;
+  inline std::string get_registered_name() const override;
   //! Returns a string with all parameters and their values, in a form suitable for parsing again
-  inline std::string parameter_info();
+  inline std::string parameter_info() override;
 
 public:
 

--- a/src/include/stir/SegmentBySinogram.h
+++ b/src/include/stir/SegmentBySinogram.h
@@ -84,25 +84,25 @@ public:
   //! Conversion from 1 storage order to the other
   SegmentBySinogram (const SegmentByView<elemT>& );
   //! Get storage order 
-  inline StorageOrder get_storage_order() const;
+  inline StorageOrder get_storage_order() const override;
   //! Get number of axial positions
-  inline int get_num_axial_poss() const;
+  inline int get_num_axial_poss() const override;
   //! Get number of views
-  inline int get_num_views() const;
+  inline int get_num_views() const override;
   //! Get number of tangential positions
-  inline int get_num_tangential_poss() const;
+  inline int get_num_tangential_poss() const override;
   //! Get minimum axial position number
-  inline int get_min_axial_pos_num() const;
+  inline int get_min_axial_pos_num() const override;
   //! Get maximum axial position number
-  inline int get_max_axial_pos_num() const;
+  inline int get_max_axial_pos_num() const override;
   //! Get minimum view number
-  inline int get_min_view_num() const;
+  inline int get_min_view_num() const override;
   //! Get maximum view number
-  inline int get_max_view_num() const;
+  inline int get_max_view_num() const override;
   //! Get minimum tangetial position number
-  inline int get_min_tangential_pos_num()  const;
+  inline int get_min_tangential_pos_num()  const override;
   //! Get maximum tangential position number
-  inline int get_max_tangential_pos_num()  const;
+  inline int get_max_tangential_pos_num()  const override;
   using Segment<elemT>::get_sinogram;
   using Segment<elemT>::get_viewgram;
   //! Get sinogram
@@ -120,7 +120,7 @@ public:
   //! Overloading Array::resize
   void resize(const IndexRange<3>& range) override;
 
-  virtual bool operator ==(const Segment<elemT>&) const override;
+  bool operator ==(const Segment<elemT>&) const override;
 };
 
 END_NAMESPACE_STIR

--- a/src/include/stir/SegmentByView.h
+++ b/src/include/stir/SegmentByView.h
@@ -86,25 +86,25 @@ public:
   
   //TODO ? how to declare a conversion routine that works for any Segment ?
   //! Get storage order
-  inline StorageOrder get_storage_order() const;
+  inline StorageOrder get_storage_order() const override;
   //! Get view number 
-  inline int get_num_views() const;
+  inline int get_num_views() const override;
   //! Get number of axial positions
-  inline int get_num_axial_poss() const;
+  inline int get_num_axial_poss() const override;
   //! Get number of tangetial positions
-  inline int get_num_tangential_poss()  const;
+  inline int get_num_tangential_poss()  const override;
   //! Get minimum view number
-  inline int get_min_view_num() const;
+  inline int get_min_view_num() const override;
   //! Get maximum view number
-  inline int get_max_view_num() const;
+  inline int get_max_view_num() const override;
   //! Get minimum axial position number
-  inline int get_min_axial_pos_num() const;
+  inline int get_min_axial_pos_num() const override;
   //! Get maximum axial positin number
-  inline int get_max_axial_pos_num() const;
+  inline int get_max_axial_pos_num() const override;
   //! Get minimum tangential position
-  inline int get_min_tangential_pos_num() const;
+  inline int get_min_tangential_pos_num() const override;
   //! Get maximum tangetial position number
-  inline int get_max_tangential_pos_num() const;
+  inline int get_max_tangential_pos_num() const override;
   
   using Segment<elemT>::get_sinogram;
   using Segment<elemT>::get_viewgram;
@@ -124,7 +124,7 @@ public:
   //! Overloading Array::resize
   void resize(const IndexRange<3>& range) override;
 
-  virtual bool operator ==(const Segment<elemT>&) const override;
+  bool operator ==(const Segment<elemT>&) const override;
 };
 
 END_NAMESPACE_STIR

--- a/src/include/stir/SeparableArrayFunctionObject.h
+++ b/src/include/stir/SeparableArrayFunctionObject.h
@@ -56,12 +56,12 @@ public:
    */
   SeparableArrayFunctionObject (const VectorWithOffset< shared_ptr<ArrayFunctionObject<1,elemT> > >&); 
 
-  bool is_trivial() const;
+  bool is_trivial() const override;
 
 protected:
  
   VectorWithOffset< shared_ptr<ArrayFunctionObject<1,elemT> > > all_1d_array_filters;
-  virtual void do_it(Array<num_dimensions,elemT>& array) const;
+  void do_it(Array<num_dimensions,elemT>& array) const override;
 
 };
 

--- a/src/include/stir/SeparableCartesianMetzImageFilter.h
+++ b/src/include/stir/SeparableCartesianMetzImageFilter.h
@@ -97,13 +97,13 @@ private:
   
   SeparableMetzArrayFilter<num_dimensions,elemT> metz_filter;
 
-  virtual void set_defaults();
-  virtual void initialise_keymap();
+  void set_defaults() override;
+  void initialise_keymap() override;
   
-  Succeeded virtual_set_up(const DiscretisedDensity<num_dimensions,elemT>& image);
+  Succeeded virtual_set_up(const DiscretisedDensity<num_dimensions,elemT>& image) override;
   // new
-  void  virtual_apply(DiscretisedDensity<num_dimensions,elemT>& out_density, const DiscretisedDensity<num_dimensions,elemT>& in_density) const;
-  void  virtual_apply(DiscretisedDensity<num_dimensions,elemT>& density) const ;
+  void  virtual_apply(DiscretisedDensity<num_dimensions,elemT>& out_density, const DiscretisedDensity<num_dimensions,elemT>& in_density) const override;
+  void  virtual_apply(DiscretisedDensity<num_dimensions,elemT>& density) const override ;
   
 };
 

--- a/src/include/stir/SeparableConvolutionImageFilter.h
+++ b/src/include/stir/SeparableConvolutionImageFilter.h
@@ -128,14 +128,14 @@ private:
      
   SeparableArrayFunctionObject<num_dimensions,elemT> filter;
 
-  virtual void set_defaults();
-  virtual void initialise_keymap();
-  virtual bool post_processing();
+  void set_defaults() override;
+  void initialise_keymap() override;
+  bool post_processing() override;
   
-  Succeeded virtual_set_up(const DiscretisedDensity<num_dimensions,elemT>& image);
+  Succeeded virtual_set_up(const DiscretisedDensity<num_dimensions,elemT>& image) override;
   void  virtual_apply(DiscretisedDensity<num_dimensions,elemT>& out_density, 
-		      const DiscretisedDensity<num_dimensions,elemT>& in_density) const;
-  void  virtual_apply(DiscretisedDensity<num_dimensions,elemT>& density) const ;
+		      const DiscretisedDensity<num_dimensions,elemT>& in_density) const override;
+  void  virtual_apply(DiscretisedDensity<num_dimensions,elemT>& density) const override ;
   
 };
 

--- a/src/include/stir/SeparableGaussianImageFilter.h
+++ b/src/include/stir/SeparableGaussianImageFilter.h
@@ -90,15 +90,15 @@ protected:
   
   SeparableGaussianArrayFilter<num_dimensions,elemT> gaussian_filter;
 
-  virtual void set_defaults();
-  virtual void initialise_keymap();
+  void set_defaults() override;
+  void initialise_keymap() override;
 
   //virtual bool post_processing();
   
-  Succeeded virtual_set_up(const DiscretisedDensity<num_dimensions,elemT>& image);
+  Succeeded virtual_set_up(const DiscretisedDensity<num_dimensions,elemT>& image) override;
   // new
-  void  virtual_apply(DiscretisedDensity<num_dimensions,elemT>& out_density, const DiscretisedDensity<num_dimensions,elemT>& in_density) const;
-  void  virtual_apply(DiscretisedDensity<num_dimensions,elemT>& density) const ;
+  void  virtual_apply(DiscretisedDensity<num_dimensions,elemT>& out_density, const DiscretisedDensity<num_dimensions,elemT>& in_density) const override;
+  void  virtual_apply(DiscretisedDensity<num_dimensions,elemT>& density) const override ;
 };
 
 #undef num_dimensions

--- a/src/include/stir/Shape/Box3D.h
+++ b/src/include/stir/Shape/Box3D.h
@@ -70,20 +70,20 @@ public RegisteredParsingObject<Box3D, Shape3D, Shape3DWithOrientation>
 	 const CartesianCoordinate3D<float>& centre,
 	 const Array<2,float>& direction_vectors = diagonal_matrix(3,1.F));
 
-  float get_geometric_volume() const;
+  float get_geometric_volume() const override;
   // float get_geometric_area() const;
   
-  bool is_inside_shape(const CartesianCoordinate3D<float>& coord) const;
+  bool is_inside_shape(const CartesianCoordinate3D<float>& coord) const override;
   
-  Shape3D* clone() const;
+  Shape3D* clone() const override;
 
   //! Compare boxes
   /*! Uses a tolerance determined by the smallest dimension of the object divided by 1000.*/
   bool
     operator==(const Box3D&) const;
 
-  virtual bool
-    operator==(const Shape3D& shape) const;
+  bool
+    operator==(const Shape3D& shape) const override;
   
  protected:
   //! Length in x-direction if the shape is not rotated
@@ -93,9 +93,9 @@ public RegisteredParsingObject<Box3D, Shape3D, Shape3DWithOrientation>
   //! Length in z-direction if the shape is not rotated
   float length_z;
  private:
-  virtual void set_defaults();  
-  virtual void initialise_keymap();
-  virtual bool post_processing();
+  void set_defaults() override;  
+  void initialise_keymap() override;
+  bool post_processing() override;
   
 };
 

--- a/src/include/stir/Shape/DiscretisedShape3D.h
+++ b/src/include/stir/Shape/DiscretisedShape3D.h
@@ -75,16 +75,16 @@ public:
 
   //! Compare shapes
   /*! \todo currently not implemented (will call error() */
-  virtual bool
-    operator==(const Shape3D&) const
+  bool
+    operator==(const Shape3D&) const override
   { error("DiscretisedShape3D::operator== not implemented. Sorry"); return false;}
 
   //! set origin of the shape
-  virtual void set_origin(const CartesianCoordinate3D<float>&);
+  void set_origin(const CartesianCoordinate3D<float>&) override;
 
   //! Scale shape
   /*! \todo Not implemented (will call error()) */
-  virtual void scale(const CartesianCoordinate3D<float>& scale3D) 
+  void scale(const CartesianCoordinate3D<float>& scale3D) override 
   { error ("TODO: DiscretisedShape3D::scale not implemented. Sorry.");}
 
   //! determine if a point is inside a non-zero voxel or not
@@ -97,7 +97,7 @@ public:
     cannot be used to find the voxel_weight. So, we have to redefine 
     get_voxel_weight() in the present class.
     */
-  bool is_inside_shape(const CartesianCoordinate3D<float>& index) const;
+  bool is_inside_shape(const CartesianCoordinate3D<float>& index) const override;
 
   //! get weight for a voxel centred around \a coord
   /*! 
@@ -109,10 +109,10 @@ public:
     If get_label_index() >= 0, the weight will be 1 for those voxels whose value is equal to the label_index and zero otherwise.
     If get_label_index() < 0 (default), the weight will be the actual voxel value.
   */
- virtual float get_voxel_weight(
+ float get_voxel_weight(
    const CartesianCoordinate3D<float>& coord,
    const CartesianCoordinate3D<float>& voxel_size, 
-   const CartesianCoordinate3D<int>& num_samples) const;
+   const CartesianCoordinate3D<int>& num_samples) const override;
 
  //! Construct a new image from the underlying density
  /*! 
@@ -122,11 +122,11 @@ public:
 
    The argument \a num_samples is ignored.
   */
-  void construct_volume(VoxelsOnCartesianGrid<float> &image, const CartesianCoordinate3D<int>& num_samples) const;
+  void construct_volume(VoxelsOnCartesianGrid<float> &image, const CartesianCoordinate3D<int>& num_samples) const override;
  //void construct_slice(PixelsOnCartesianGrid<float> &plane, const CartesianCoordinate3D<int>& num_samples) const;
  
  
- virtual Shape3D* clone() const;
+ Shape3D* clone() const override;
 
  //! provide access to the underlying density
  DiscretisedDensity<3,float>& get_discretised_density();
@@ -149,14 +149,14 @@ private:
   //! \name Parsing functions
   //@{
   //! Sets defaults i.e. label index=-1 and reset density_sptr
-  virtual void set_defaults();  
-  virtual void initialise_keymap();
+  void set_defaults() override;  
+  void initialise_keymap() override;
   //! Checks validity of parameters
   /*! As currently there are 2 origin parameters (in Shape3D and
       DiscretisedDensity), this function checks for consistency.
       However, the origin in Shape3D will be ignored.
   */
-  virtual bool post_processing();
+  bool post_processing() override;
   //@}
   std::string filename;
 };

--- a/src/include/stir/Shape/Ellipsoid.h
+++ b/src/include/stir/Shape/Ellipsoid.h
@@ -61,23 +61,23 @@ public:
 	     const CartesianCoordinate3D<float>& centre,
 	     const Array<2,float>& direction_vectors = diagonal_matrix(3,1.F));
   //! get volume
-  float get_geometric_volume() const;
+  float get_geometric_volume() const override;
 #if 0
   //! Get approximate geometric area
   float get_geometric_area() const;
 #endif
 
-  bool is_inside_shape(const CartesianCoordinate3D<float>& coord) const;
+  bool is_inside_shape(const CartesianCoordinate3D<float>& coord) const override;
 
-  Shape3D* clone() const;
+  Shape3D* clone() const override;
 
   //! Compare cylinders
   /*! Uses a tolerance determined by the smallest dimension of the object divided by 1000.*/
   bool
     operator==(const Ellipsoid&) const;
 
-  virtual bool
-    operator==(const Shape3D& shape) const;
+  bool
+    operator==(const Shape3D& shape) const override;
 
   inline float get_radius_x() const
     { return radii.x(); }
@@ -96,9 +96,9 @@ protected:
 
   //! set defaults before parsing
   /*! sets radii to 0 and calls Shape3DWithOrientation::set_defaults() */
-  virtual void set_defaults();  
-  virtual void initialise_keymap();
-  virtual bool post_processing();
+  void set_defaults() override;  
+  void initialise_keymap() override;
+  bool post_processing() override;
   
 };
 

--- a/src/include/stir/Shape/EllipsoidalCylinder.h
+++ b/src/include/stir/Shape/EllipsoidalCylinder.h
@@ -95,24 +95,24 @@ public:
                       const CartesianCoordinate3D<float>& centre,
 		      const Array<2,float>& direction_vectors = diagonal_matrix(3,1.F));
 
-  Shape3D* clone() const; 
+  Shape3D* clone() const override; 
 
   //! Compare cylinders
   /*! Uses a tolerance determined by the smallest dimension of the object divided by 1000.*/
   bool
     operator==(const EllipsoidalCylinder& cylinder) const;
 
-  virtual bool
-    operator==(const Shape3D& shape) const;
+  bool
+    operator==(const Shape3D& shape) const override;
 
   //! get volume
-  float get_geometric_volume() const;
+  float get_geometric_volume() const override;
 #if 0
   //! Get approximate geometric area
   float get_geometric_area() const;
 #endif
 
-  bool is_inside_shape(const CartesianCoordinate3D<float>& coord) const;
+  bool is_inside_shape(const CartesianCoordinate3D<float>& coord) const override;
   
   inline float get_length() const
     { return length; }
@@ -140,9 +140,9 @@ protected:
 
   //! set defaults before parsing
   /*! sets radii and length to 0, theta_1=0, theta_2=360 and calls Shape3DWithOrientation::set_defaults() */
-  virtual void set_defaults();  
-  virtual void initialise_keymap();    
-  virtual bool post_processing();
+  void set_defaults() override;  
+  void initialise_keymap() override;    
+  bool post_processing() override;
 };
 
 END_NAMESPACE_STIR

--- a/src/include/stir/Shape/GenerateImage.h
+++ b/src/include/stir/Shape/GenerateImage.h
@@ -140,7 +140,7 @@ private:
 
     virtual void set_defaults();
     virtual void initialise_keymap();
-    virtual bool post_processing();
+    bool post_processing() override;
     void set_imaging_modality();
     shared_ptr<ExamInfo> exam_info_sptr;
     std::string imaging_modality_as_string;

--- a/src/include/stir/Shape/Shape3D.h
+++ b/src/include/stir/Shape/Shape3D.h
@@ -68,7 +68,7 @@ class Shape3D :
 public:
 
   
-  virtual ~Shape3D() {}
+  ~Shape3D() override {}
   
   //! Compare shapes
   /*!
@@ -187,7 +187,7 @@ public:
   
 
   // need to overload this to avoid ambiguity between Object::parameter_info and ParsingObject::parameter_info()
-  virtual std::string parameter_info();
+  std::string parameter_info() override;
 
 protected:
   inline Shape3D();
@@ -195,8 +195,8 @@ protected:
 
   //! \name Parsing functions
   //@{
-  virtual void set_defaults();  
-  virtual void initialise_keymap();
+  void set_defaults() override;  
+  void initialise_keymap() override;
   //@}
 private:
   //! origin of the shape

--- a/src/include/stir/Shape/Shape3DWithOrientation.h
+++ b/src/include/stir/Shape/Shape3DWithOrientation.h
@@ -62,7 +62,7 @@ class Shape3DWithOrientation: public Shape3D
 public:
 
   bool operator==(const Shape3DWithOrientation& s) const;
-  virtual void scale(const CartesianCoordinate3D<float>& scale3D);
+  void scale(const CartesianCoordinate3D<float>& scale3D) override;
 
   //! get direction vectors currently in use
   /*! Index offsets will always be 1 */
@@ -117,10 +117,10 @@ protected:
 
   //! sets defaults for parsing
   /*! sets direction vectors to the normal unit vectors. */
-  virtual void set_defaults();  
-  virtual void initialise_keymap();
-  virtual bool post_processing();
-  virtual void set_key_values();
+  void set_defaults() override;  
+  void initialise_keymap() override;
+  bool post_processing() override;
+  void set_key_values() override;
 
 private:
 #if 0

--- a/src/include/stir/Sinogram.h
+++ b/src/include/stir/Sinogram.h
@@ -109,9 +109,9 @@ public:
   inline Sinogram get_empty_copy(void) const;
  
   //! Overloading Array::grow
-  void grow(const IndexRange<2>& range);
+  void grow(const IndexRange<2>& range) override;
   //! Overloading Array::resize
-  void resize(const IndexRange<2>& range);
+  void resize(const IndexRange<2>& range) override;
 
   //! Get shared pointer to proj data info
   inline shared_ptr<const ProjDataInfo>

--- a/src/include/stir/TextWriter.h
+++ b/src/include/stir/TextWriter.h
@@ -31,7 +31,7 @@ public:
 				_stream = 2;
 		}
 	}
-	virtual void write(const char* text) const {
+	void write(const char* text) const override {
 		switch (_stream) {
 		case 1:
 			std::cout << text;
@@ -51,7 +51,7 @@ class TextWriter : public aTextWriter {
 public:
 	std::ostream* out;
 	TextWriter(std::ostream* os = 0) : out(os) {}
-	virtual void write(const char* text) const {
+	void write(const char* text) const override {
 		if (out) {
 			(*out) << text;
 			(*out).flush();

--- a/src/include/stir/ThresholdMinToSmallPositiveValueDataProcessor.h
+++ b/src/include/stir/ThresholdMinToSmallPositiveValueDataProcessor.h
@@ -78,13 +78,13 @@ private:
   
   int rim_truncation_image;
   
-  virtual void set_defaults();
-  virtual void initialise_keymap();
+  void set_defaults() override;
+  void initialise_keymap() override;
   
-  Succeeded virtual_set_up(const DataT&);
+  Succeeded virtual_set_up(const DataT&) override;
 
-  void  virtual_apply(DataT& out_data, const DataT& in_data) const;
-  void  virtual_apply(DataT& data) const ;
+  void  virtual_apply(DataT& out_data, const DataT& in_data) const override;
+  void  virtual_apply(DataT& data) const override ;
   
 };
 

--- a/src/include/stir/TrivialDataSymmetriesForViewSegmentNumbers.h
+++ b/src/include/stir/TrivialDataSymmetriesForViewSegmentNumbers.h
@@ -38,7 +38,7 @@ class TrivialDataSymmetriesForViewSegmentNumbers : public DataSymmetriesForViewS
 {
 public:
 
-  virtual inline DataSymmetriesForViewSegmentNumbers * clone() const;
+  inline DataSymmetriesForViewSegmentNumbers * clone() const override;
 
 
 #if 0
@@ -48,22 +48,22 @@ public:
     get_basic_view_segment_index_range() const;
 #endif
 
-  virtual inline void
-    get_related_view_segment_numbers(std::vector<ViewSegmentNumbers>&, const ViewSegmentNumbers& v_s) const;
+  inline void
+    get_related_view_segment_numbers(std::vector<ViewSegmentNumbers>&, const ViewSegmentNumbers& v_s) const override;
 
-  virtual inline int
-    num_related_view_segment_numbers(const ViewSegmentNumbers& v_s) const;
+  inline int
+    num_related_view_segment_numbers(const ViewSegmentNumbers& v_s) const override;
 
   /*! \brief given an arbitrary view/segment, find the basic view/segment
   
   in this class, \a v_s is unchanged, and the return value is always false.
   'v_s' is changed (i.e. it was NOT a basic view/segment).
   */  
-  virtual inline bool
-    find_basic_view_segment_numbers(ViewSegmentNumbers& v_s) const;
+  inline bool
+    find_basic_view_segment_numbers(ViewSegmentNumbers& v_s) const override;
 
 private:
-  virtual bool blindly_equals(const root_type * const) const;
+  bool blindly_equals(const root_type * const) const override;
 
 };
 

--- a/src/include/stir/TruncateToCylindricalFOVImageProcessor.h
+++ b/src/include/stir/TruncateToCylindricalFOVImageProcessor.h
@@ -87,13 +87,13 @@ private:
   bool _strictly_less_than_radius;
   int _truncate_rim;
 
-  virtual void set_defaults();
-  virtual void initialise_keymap();
+  void set_defaults() override;
+  void initialise_keymap() override;
   
-  Succeeded virtual_set_up(const DiscretisedDensity<3,elemT>& image);
+  Succeeded virtual_set_up(const DiscretisedDensity<3,elemT>& image) override;
   // new
-  void  virtual_apply(DiscretisedDensity<3,elemT>& out_density, const DiscretisedDensity<3,elemT>& in_density) const;
-  void  virtual_apply(DiscretisedDensity<3,elemT>& density) const ;
+  void  virtual_apply(DiscretisedDensity<3,elemT>& out_density, const DiscretisedDensity<3,elemT>& in_density) const override;
+  void  virtual_apply(DiscretisedDensity<3,elemT>& density) const override ;
   
 };
 

--- a/src/include/stir/Viewgram.h
+++ b/src/include/stir/Viewgram.h
@@ -110,9 +110,9 @@ public:
   inline  Viewgram get_empty_copy(void) const;
 
   //! Overloading Array::grow
-  void grow(const IndexRange<2>& range);
+  void grow(const IndexRange<2>& range) override;
   //! Overloading Array::resize
-  void resize(const IndexRange<2>& range);
+  void resize(const IndexRange<2>& range) override;
 
   //! Get shared pointer to proj data info
   inline shared_ptr<const ProjDataInfo>

--- a/src/include/stir/VoxelsOnCartesianGrid.h
+++ b/src/include/stir/VoxelsOnCartesianGrid.h
@@ -138,7 +138,7 @@ DiscretisedDensity<3,elemT>*
 #else
 VoxelsOnCartesianGrid<elemT>*
 #endif
- get_empty_copy() const;
+ get_empty_copy() const override;
 
 //! Like get_empty_copy, but returning a pointer to a VoxelsOnCartesianGrid
 VoxelsOnCartesianGrid<elemT>* get_empty_voxels_on_cartesian_grid() const;
@@ -146,9 +146,9 @@ VoxelsOnCartesianGrid<elemT>* get_empty_voxels_on_cartesian_grid() const;
 #ifdef STIR_NO_COVARIANT_RETURN_TYPES
 virtual DiscretisedDensity<3,elemT>*
 #else
-virtual VoxelsOnCartesianGrid<elemT>*
+VoxelsOnCartesianGrid<elemT>*
 #endif
-clone() const;
+clone() const override;
 
 //! Extract a single plane
 PixelsOnCartesianGrid<elemT> get_plane(const int z) const;

--- a/src/include/stir/analytic/FBP2D/FBP2DReconstruction.h
+++ b/src/include/stir/analytic/FBP2D/FBP2DReconstruction.h
@@ -122,11 +122,11 @@ public:
 		      const int num_segments_to_combine=-1
 		      );
   
-  virtual std::string method_info() const;
+  std::string method_info() const override;
 
   virtual void ask_parameters();
 
-  virtual Succeeded set_up(shared_ptr <TargetT > const& target_data_sptr);
+  Succeeded set_up(shared_ptr <TargetT > const& target_data_sptr) override;
 
  protected: // make parameters protected such that doc shows always up in doxygen
   // parameters used for parsing
@@ -150,13 +150,13 @@ public:
    */
   int display_level;
  private:
-  Succeeded actual_reconstruct(shared_ptr<DiscretisedDensity<3,float> > const & target_image_ptr);
+  Succeeded actual_reconstruct(shared_ptr<DiscretisedDensity<3,float> > const & target_image_ptr) override;
 
   shared_ptr<BackProjectorByBin> back_projector_sptr;
 
-  virtual void set_defaults();
-  virtual void initialise_keymap();
-  virtual bool post_processing(); 
+  void set_defaults() override;
+  void initialise_keymap() override;
+  bool post_processing() override; 
 };
 
 

--- a/src/include/stir/analytic/FBP3DRP/ColsherFilter.h
+++ b/src/include/stir/analytic/FBP3DRP/ColsherFilter.h
@@ -93,7 +93,7 @@ public:
 
   virtual std::string parameter_info() const;
   
-  ~ColsherFilter() {}
+  ~ColsherFilter() override {}
 
 
   private:

--- a/src/include/stir/analytic/FBP3DRP/FBP3DRPReconstruction.h
+++ b/src/include/stir/analytic/FBP3DRP/FBP3DRPReconstruction.h
@@ -118,13 +118,13 @@ public:
   // the shared_ptr<DiscretisedDensity<3,float> > destructor with gcc.
   // Otherwise, gcc will complain if you didn't include DiscretisedDensity.h
   // because it doesn't know ~DiscretisedDensity.
-  ~FBP3DRPReconstruction();
+  ~FBP3DRPReconstruction() override;
 
 //! This method returns the type of the reconstruction algorithm during the reconstruction, here it is FBP3DRP
-  virtual std::string method_info() const;
+  std::string method_info() const override;
 
   Succeeded
-    set_up(shared_ptr <DiscretisedDensity<3,float> > const& target_image_sptr);
+    set_up(shared_ptr <DiscretisedDensity<3,float> > const& target_image_sptr) override;
 
 protected:
 /*!
@@ -135,7 +135,7 @@ protected:
   and returns the output reconstructed image
 */
 
-   virtual Succeeded actual_reconstruct(shared_ptr<DiscretisedDensity<3,float> > const&);
+   Succeeded actual_reconstruct(shared_ptr<DiscretisedDensity<3,float> > const&) override;
     
 //! Best fit of forward projected sinograms
     void do_best_fit(const Sinogram<float> &sino_measured, const Sinogram<float> &sino_calculated);
@@ -243,8 +243,8 @@ protected:
   int fit_projections; 
 private:
 
-  virtual void set_defaults();
-  virtual void initialise_keymap();
+  void set_defaults() override;
+  void initialise_keymap() override;
 
 
   //! access to input proj_data_info cast to cylindrical type

--- a/src/include/stir/data/SinglesRates.h
+++ b/src/include/stir/data/SinglesRates.h
@@ -130,7 +130,7 @@ class SinglesRates : public RegisteredObject<SinglesRates>
 {
 public: 
 
-  virtual ~SinglesRates () {}
+  ~SinglesRates () override {}
   //! Get the (average) singles rate for a particular singles unit and a frame with the specified start and end times.
   /*! The behaviour of this function is specified by the derived classes.
     \warning Currently might return -1 if the \a start_time, \a end_time

--- a/src/include/stir/data/SinglesRatesForTimeFrames.h
+++ b/src/include/stir/data/SinglesRatesForTimeFrames.h
@@ -59,7 +59,7 @@ public:
         does not correspond to a time frame.
     */
     float get_singles(const int singles_bin_index,
-                      const double start_time, const double end_time) const;
+                      const double start_time, const double end_time) const override;
     
     //! Generate a FramesSinglesRate - containing the average rates
     //  for a frame begining at start_time and ending at end_time.

--- a/src/include/stir/data/SinglesRatesForTimeSlices.h
+++ b/src/include/stir/data/SinglesRatesForTimeSlices.h
@@ -45,9 +45,9 @@ public:
  SinglesRatesForTimeSlices();
 
  // implementation of pure virtual in SinglesRates
- virtual float
+ float
    get_singles(const int singles_bin_index,
-               const double start_time, const double end_time) const;
+               const double start_time, const double end_time) const override;
 
 
  //! Generate a FramesSinglesRate - containing the average rates

--- a/src/include/stir/data/SinglesRatesFromGEHDF5.h
+++ b/src/include/stir/data/SinglesRatesFromGEHDF5.h
@@ -66,9 +66,9 @@ private:
  
  std::string _rdf_filename;
 
- virtual void set_defaults();
- virtual void initialise_keymap();
- virtual bool post_processing();
+ void set_defaults() override;
+ void initialise_keymap() override;
+ bool post_processing() override;
  
 };
 

--- a/src/include/stir/listmode/CListEventScannerWithDiscreteDetectors.h
+++ b/src/include/stir/listmode/CListEventScannerWithDiscreteDetectors.h
@@ -52,7 +52,7 @@ public:
   /*! Overrides the default implementation to use get_detection_position()
     which should be faster.
   */
-  inline virtual LORAs2Points<float> get_LOR() const;
+  inline LORAs2Points<float> get_LOR() const override;
 
   //! find bin for this event
   /*! Overrides the default implementation to use get_detection_position()
@@ -62,14 +62,14 @@ public:
     type ProjDataInfoT. However, because of efficiency reasons
     this is only checked in debug mode (NDEBUG not defined).
   */
-  inline virtual void get_bin(Bin& bin, const ProjDataInfo& proj_data_info) const;
+  inline void get_bin(Bin& bin, const ProjDataInfo& proj_data_info) const override;
 
   //! This method checks if the template is valid for LmToProjData
   /*! Used before the actual processing of the data (see issue #61), before calling get_bin()
    *  Most scanners have listmode data that correspond to non arc-corrected data and
    *  this check avoids a crash when an unsupported template is used as input.
    */
-  inline virtual bool is_valid_template(const ProjDataInfo&) const;
+  inline bool is_valid_template(const ProjDataInfo&) const override;
 
  protected:
    shared_ptr<const ProjDataInfoT>

--- a/src/include/stir/listmode/CListModeData.h
+++ b/src/include/stir/listmode/CListModeData.h
@@ -60,16 +60,16 @@ public:
     Succeeded get_next_record(CListRecord& event) const = 0;
 
   //! Return if the file stores delayed events as well (as opposed to prompts)
-  virtual bool has_delayeds() const = 0;
+  bool has_delayeds() const override = 0;
 
 protected:
-  virtual shared_ptr<ListRecord> get_empty_record_helper_sptr() const
+  shared_ptr<ListRecord> get_empty_record_helper_sptr() const override
   {
         shared_ptr<CListRecord> sptr(this->get_empty_record_sptr());
         shared_ptr<ListRecord> sptr1(static_pointer_cast<ListRecord>(sptr));
         return sptr1;}
 
-  virtual Succeeded get_next(ListRecord& event) const
+  Succeeded get_next(ListRecord& event) const override
   {return this->get_next_record((CListRecord&)(event));}
 };
 

--- a/src/include/stir/listmode/CListModeDataECAT8_32bit.h
+++ b/src/include/stir/listmode/CListModeDataECAT8_32bit.h
@@ -44,27 +44,27 @@ public:
   //! Construct fron the filename of the Interfile header
   CListModeDataECAT8_32bit(const std::string& listmode_filename_prefix);
 
-  virtual std::string
-    get_name() const;
+  std::string
+    get_name() const override;
 
-  virtual 
-    shared_ptr <CListRecord> get_empty_record_sptr() const;
+  
+    shared_ptr <CListRecord> get_empty_record_sptr() const override;
 
-  virtual 
-    Succeeded get_next_record(CListRecord& record) const;
+  
+    Succeeded get_next_record(CListRecord& record) const override;
 
-  virtual 
-    Succeeded reset();
+  
+    Succeeded reset() override;
 
-  virtual
-    SavedPosition save_get_position();
+  
+    SavedPosition save_get_position() override;
 
-  virtual
-    Succeeded set_get_position(const SavedPosition&);
+  
+    Succeeded set_get_position(const SavedPosition&) override;
 
   //! returns \c true, as ECAT listmode data stores delayed events (and prompts)
   /*! \todo this might depend on the acquisition parameters */
-  virtual bool has_delayeds() const { return true; }
+  bool has_delayeds() const override { return true; }
 
 private:
   typedef CListRecordECAT8_32bit CListRecordT;

--- a/src/include/stir/listmode/CListModeDataGEHDF5.h
+++ b/src/include/stir/listmode/CListModeDataGEHDF5.h
@@ -41,30 +41,30 @@ public:
   //! Constructor taking a filename
   CListModeDataGEHDF5(const std::string& listmode_filename);
 
-  virtual std::string
-    get_name() const;
+  std::string
+    get_name() const override;
 
   virtual
     std::time_t get_scan_start_time_in_secs_since_1970() const;
 
-  virtual 
-    shared_ptr <CListRecord> get_empty_record_sptr() const;
+  
+    shared_ptr <CListRecord> get_empty_record_sptr() const override;
 
-  virtual 
-    Succeeded get_next_record(CListRecord& record) const;
+  
+    Succeeded get_next_record(CListRecord& record) const override;
 
-  virtual 
-    Succeeded reset();
+  
+    Succeeded reset() override;
 
-  virtual
-    SavedPosition save_get_position();
+  
+    SavedPosition save_get_position() override;
 
-  virtual
-    Succeeded set_get_position(const SavedPosition&);
+  
+    Succeeded set_get_position(const SavedPosition&) override;
 
   //! returns \c false, as GEHDF5 listmode data does not store delayed events (and prompts)
   /*! \todo this depends on the acquisition parameters */
-  virtual bool has_delayeds() const { return false; }
+  bool has_delayeds() const override { return false; }
 
 private:
 

--- a/src/include/stir/listmode/CListModeDataROOT.h
+++ b/src/include/stir/listmode/CListModeDataROOT.h
@@ -110,32 +110,32 @@ public:
     CListModeDataROOT(const std::string& hroot_filename_prefix);
 
     //! returns the header filename
-    virtual std::string
-    get_name() const;
+    std::string
+    get_name() const override;
     //! Set private members default values;
     void set_defaults();
 
-    virtual
-    shared_ptr <CListRecord> get_empty_record_sptr() const;
+    
+    shared_ptr <CListRecord> get_empty_record_sptr() const override;
 
-    virtual
-    Succeeded get_next_record(CListRecord& record) const;
+    
+    Succeeded get_next_record(CListRecord& record) const override;
 
-    virtual
-    Succeeded reset();
+    
+    Succeeded reset() override;
 
-    virtual
-    SavedPosition save_get_position();
+    
+    SavedPosition save_get_position() override;
 
-    virtual
-    Succeeded set_get_position(const SavedPosition&);
+    
+    Succeeded set_get_position(const SavedPosition&) override;
 
-    virtual
-    bool has_delayeds() const { return true; }
+    
+    bool has_delayeds() const override { return true; }
 
-    virtual inline
+    inline
     unsigned long int
-    get_total_number_of_events() const ;
+    get_total_number_of_events() const override ;
 
 private:
     //! Check if the hroot contains a full scanner description

--- a/src/include/stir/listmode/CListModeDataSAFIR.h
+++ b/src/include/stir/listmode/CListModeDataSAFIR.h
@@ -65,26 +65,26 @@ public:
 	CListModeDataSAFIR( const std::string& listmode_filename, const std::string& crystal_map_filename, const std::string& template_proj_data_filename, const double lor_randomization_sigma = 0.0);
 	CListModeDataSAFIR(const std::string& listmode_filename, const shared_ptr<const ProjDataInfo>& proj_data_info_sptr);
 	
-	virtual std::string get_name() const;
-	virtual shared_ptr <CListRecord> get_empty_record_sptr() const;
-	virtual Succeeded get_next_record(CListRecord& record_of_general_type) const;
-	virtual Succeeded reset();
+	std::string get_name() const override;
+	shared_ptr <CListRecord> get_empty_record_sptr() const override;
+	Succeeded get_next_record(CListRecord& record_of_general_type) const override;
+	Succeeded reset() override;
 	
 	/*!
 	This function should save the position in input file. This is not implemented but disabled.
 	Returns 0 in the moement.
 	\todo Maybe provide real implementation?
 	*/
-	virtual SavedPosition save_get_position()
+	SavedPosition save_get_position() override
 	{ return static_cast<SavedPosition>(current_lm_data_ptr->save_get_position()); }
-	virtual Succeeded set_get_position(const SavedPosition& pos)
+	Succeeded set_get_position(const SavedPosition& pos) override
 	{ return current_lm_data_ptr->set_get_position(pos); }
 
 	/*! 
 	Returns just false in the moment.
 	\todo Implement this properly to check for delayed events in LM files.
 	*/
-	virtual bool has_delayeds() const { return false; }
+	bool has_delayeds() const override { return false; }
 	
 private:
 	std::string listmode_filename;

--- a/src/include/stir/listmode/CListRecordECAT8_32bit.h
+++ b/src/include/stir/listmode/CListRecordECAT8_32bit.h
@@ -80,10 +80,10 @@ class CListEventECAT8_32bit : public CListEventCylindricalScannerWithDiscreteDet
   CListEventECAT8_32bit(const shared_ptr<const ProjDataInfo>& proj_data_info_sptr);
 
  //! This routine returns the corresponding detector pair   
-  virtual void get_detection_position(DetectionPositionPair<>&) const;
+  void get_detection_position(DetectionPositionPair<>&) const override;
 
   //! This routine sets in a coincidence event from detector "indices"
-  virtual void set_detection_position(const DetectionPositionPair<>&);
+  void set_detection_position(const DetectionPositionPair<>&) override;
 
   Succeeded init_from_data_ptr(const void * const ptr)
     {
@@ -91,8 +91,8 @@ class CListEventECAT8_32bit : public CListEventCylindricalScannerWithDiscreteDet
       std::copy(data_ptr, data_ptr+sizeof(this->raw), reinterpret_cast<char *>(&this->raw));
       return Succeeded::yes;
     }
-  inline bool is_prompt() const { return this->data.delayed == 1; }
-  inline Succeeded set_prompt(const bool prompt = true) 
+  inline bool is_prompt() const override { return this->data.delayed == 1; }
+  inline Succeeded set_prompt(const bool prompt = true) override 
   { if (prompt) this->data.delayed=1; else this->data.delayed=0; return Succeeded::yes; }
 
  private:
@@ -168,9 +168,9 @@ class CListTimeECAT8_32bit : public ListTime
     }
   bool is_time() const
   { return this->data.type == 1U && this->data.deadtimeetc == 0U; }
-  inline unsigned long get_time_in_millisecs() const
+  inline unsigned long get_time_in_millisecs() const override
   { return static_cast<unsigned long>(this->data.time);  }
-  inline Succeeded set_time_in_millisecs(const unsigned long time_in_millisecs)
+  inline Succeeded set_time_in_millisecs(const unsigned long time_in_millisecs) override
   { 
     this->data.time = ((1U<<30)-1) & static_cast<unsigned>(time_in_millisecs); 
     // TODO return more useful value
@@ -200,21 +200,21 @@ class CListTimeECAT8_32bit : public ListTime
 
   //public:
 
-  bool is_time() const
+  bool is_time() const override
   { return this->any_data.is_time(); }
   /*
   bool is_gating_input() const
   { return this->is_time(); }
   */
-  bool is_event() const
+  bool is_event() const override
   { return this->any_data.is_event(); }
-  virtual CListEventECAT8_32bit&  event() 
+  CListEventECAT8_32bit&  event() override 
     { return this->event_data; }
-  virtual const CListEventECAT8_32bit&  event() const
+  const CListEventECAT8_32bit&  event() const override
     { return this->event_data; }
-  virtual CListTimeECAT8_32bit&   time()
+  CListTimeECAT8_32bit&   time() override
     { return this->time_data; }
-  virtual const CListTimeECAT8_32bit&   time() const
+  const CListTimeECAT8_32bit&   time() const override
     { return this->time_data; }
 
   bool operator==(const CListRecord& e2) const

--- a/src/include/stir/listmode/CListRecordGEHDF5.h
+++ b/src/include/stir/listmode/CListRecordGEHDF5.h
@@ -205,7 +205,7 @@ class CListRecordGEHDF5 : public CListRecord, public ListTime, // public CListGa
     first_time_stamp(first_time_stamp)
     {}
 
-  bool is_time() const
+  bool is_time() const override
   { 
     return this->time_data.is_time();
   }
@@ -216,15 +216,15 @@ class CListRecordGEHDF5 : public CListRecord, public ListTime, // public CListGa
   }
 #endif
 
-  bool is_event() const
+  bool is_event() const override
   { return this->event_data.is_event(); }
-  virtual CListEvent&  event()
+  CListEvent&  event() override
     { return *this; }
-  virtual const CListEvent&  event() const
+  const CListEvent&  event() const override
     { return *this; }
-  virtual ListTime&   time()
+  ListTime&   time() override
     { return *this; }
-  virtual const ListTime&   time() const
+  const ListTime&   time() const override
     { return *this; }
 #if 0
   virtual CListGatingInput&  gating_input()
@@ -244,10 +244,10 @@ dynamic_cast<CListRecordGEHDF5 const *>(&e2) != 0 &&
   }
 
   // time 
-  inline unsigned long get_time_in_millisecs() const 
+  inline unsigned long get_time_in_millisecs() const override 
     { return time_data.get_time_in_millisecs() - first_time_stamp; }
 
-  inline Succeeded set_time_in_millisecs(const unsigned long time_in_millisecs)
+  inline Succeeded set_time_in_millisecs(const unsigned long time_in_millisecs) override
     { return time_data.set_time_in_millisecs(time_in_millisecs); }
 #if 0
   inline unsigned int get_gating() const
@@ -256,11 +256,11 @@ dynamic_cast<CListRecordGEHDF5 const *>(&e2) != 0 &&
     { return gating_data.set_gating(g); }
 #endif
   // event
-  inline bool is_prompt() const { return event_data.is_prompt(); }
-  inline Succeeded set_prompt(const bool prompt = true)
+  inline bool is_prompt() const override { return event_data.is_prompt(); }
+  inline Succeeded set_prompt(const bool prompt = true) override
   { return event_data.set_prompt(prompt); }
 
-  virtual void get_detection_position(DetectionPositionPair<>& det_pos) const
+  void get_detection_position(DetectionPositionPair<>& det_pos) const override
   {
     det_pos.pos1().tangential_coord() = this->get_uncompressed_proj_data_info_sptr()->get_scanner_sptr()->get_num_detectors_per_ring() - 1 - event_data.loXtalTransAxID;
     det_pos.pos1().axial_coord() = event_data.loXtalAxialID;
@@ -270,7 +270,7 @@ dynamic_cast<CListRecordGEHDF5 const *>(&e2) != 0 &&
   }
 
   //! This routine sets in a coincidence event from detector "indices"
-  virtual void set_detection_position(const DetectionPositionPair<>&)
+  void set_detection_position(const DetectionPositionPair<>&) override
   {
     error("TODO");
   }

--- a/src/include/stir/listmode/CListRecordROOT.h
+++ b/src/include/stir/listmode/CListRecordROOT.h
@@ -38,17 +38,17 @@ public:
     CListEventROOT(const shared_ptr<const ProjDataInfo>& proj_data_info);
 
     //! This routine returns the corresponding detector pair
-    virtual void get_detection_position(DetectionPositionPair<>&) const;
+    void get_detection_position(DetectionPositionPair<>&) const override;
 
     //! This routine sets in a coincidence event from detector "indices"
-    virtual void set_detection_position(const DetectionPositionPair<>&);
+    void set_detection_position(const DetectionPositionPair<>&) override;
 
     //! \details This is the main function which transform GATE coordinates to STIR
     void init_from_data(const int &_ring1, const int &_ring2,
                              const int &crystal1, const int &crystal2,
                         const double& _delta_time);
 
-    inline bool is_prompt() const
+    inline bool is_prompt() const override
     { return true; }
 
     double get_delta_time() const { return delta_time; }
@@ -87,9 +87,9 @@ public:
     { return true; }
     //! Returns the detection time of the first photon
     //! in milliseconds.
-    inline unsigned long  get_time_in_millisecs() const
+    inline unsigned long  get_time_in_millisecs() const override
     { return static_cast<unsigned long> (timeA * 1e3); }
-    inline Succeeded set_time_in_millisecs(const unsigned long time_in_millisecs)
+    inline Succeeded set_time_in_millisecs(const unsigned long time_in_millisecs) override
     {
         warning("set_time_in_millisecs: Not implemented for ROOT files. Aborting.");
         return Succeeded::no;
@@ -108,26 +108,26 @@ class CListRecordROOT : public CListRecord // currently no gating yet
 {
 public:
     //! Returns always true
-    bool inline is_time() const;
+    bool inline is_time() const override;
     //! Returns always true
-    bool inline is_event() const;
+    bool inline is_event() const override;
 
-    virtual CListEventROOT&  event()
+    CListEventROOT&  event() override
     {
         return this->event_data;
     }
 
-    virtual const CListEventROOT& event() const
+    const CListEventROOT& event() const override
     {
         return this->event_data;
     }
 
-    virtual CListTimeROOT& time()
+    CListTimeROOT& time() override
     {
         return this->time_data;
     }
 
-    virtual const CListTimeROOT& time() const
+    const CListTimeROOT& time() const override
     {
         return this->time_data;
     }

--- a/src/include/stir/listmode/CListRecordSAFIR.h
+++ b/src/include/stir/listmode/CListRecordSAFIR.h
@@ -77,21 +77,21 @@ public:
 	inline CListEventSAFIR( ) {}
 
 	//! Returns LOR corresponding to the given event.
-	inline virtual LORAs2Points<float> get_LOR() const;
+	inline LORAs2Points<float> get_LOR() const override;
 	
   //! Override the default implementation
-  inline virtual void get_bin(Bin& bin, const ProjDataInfo& proj_data_info) const;
+  inline void get_bin(Bin& bin, const ProjDataInfo& proj_data_info) const override;
   
   //! This method checks if the template is valid for LmToProjData
   /*! Used before the actual processing of the data (see issue #61), before calling get_bin()
    *  Most scanners have listmode data that correspond to non arc-corrected data and
    *  this check avoids a crash when an unsupported template is used as input.
    */
-	inline virtual bool is_valid_template(const ProjDataInfo&) const {return true;}
+	inline bool is_valid_template(const ProjDataInfo&) const override {return true;}
 
 	//! Returns 0 if event is prompt and 1 if delayed
 	inline bool is_prompt()
-		const { return !(static_cast<const Derived*>(this)->is_prompt()); }
+		const override { return !(static_cast<const Derived*>(this)->is_prompt()); }
 	//! Function to set map for detector indices to coordinates.
 	/*! Use a null pointer to disable the mapping functionality */
 	inline void set_map_sptr( shared_ptr<const DetectorCoordinateMap> new_map_sptr ) { map_sptr = new_map_sptr; }
@@ -243,18 +243,18 @@ public:
 
 	CListRecordSAFIR() : CListEventSAFIR<CListRecordSAFIR<DataType>>() {}
 
-	virtual ~CListRecordSAFIR() {}
+	~CListRecordSAFIR() override {}
 
-	virtual bool is_time() const
+	bool is_time() const override
 	{ return time_data.is_time(); }
 
-	virtual bool is_event() const
+	bool is_event() const override
 	{ return !time_data.is_time(); }
 
-	virtual CListEvent&  event()
+	CListEvent&  event() override
 	{ return *this; }
 
-	virtual const CListEvent&  event() const
+	const CListEvent&  event() const override
 	{ return *this; }
 
 	virtual CListEventSAFIR<CListRecordSAFIR<DataType>>&  event_SAFIR()
@@ -263,10 +263,10 @@ public:
 	virtual const CListEventSAFIR<CListRecordSAFIR<DataType>>&  event_SAFIR() const
 	{ return *this; }
 
-    virtual ListTime&   time()
+    ListTime&   time() override
 	{ return *this; }
 
-    virtual const ListTime&   time() const
+    const ListTime&   time() const override
 	{ return *this; }
 
 	virtual bool operator==(const CListRecord& e2) const
@@ -275,13 +275,13 @@ public:
 				raw == static_cast<CListRecordSAFIR<DataType> const &>(e2).raw;
 	}
 
-	inline unsigned long get_time_in_millisecs() const
+	inline unsigned long get_time_in_millisecs() const override
 	{ return time_data.get_time_in_millisecs(); }
 
-	inline Succeeded set_time_in_millisecs(const unsigned long time_in_millisecs)
+	inline Succeeded set_time_in_millisecs(const unsigned long time_in_millisecs) override
 	{ return time_data.set_time_in_millisecs(time_in_millisecs); }
 
-	inline bool is_prompt() const { return event_data.is_prompt(); }
+	inline bool is_prompt() const override { return event_data.is_prompt(); }
 
 	Succeeded
 	init_from_data_ptr(const char * const data_ptr,

--- a/src/include/stir/listmode/ListModeData.h
+++ b/src/include/stir/listmode/ListModeData.h
@@ -129,8 +129,8 @@ public:
   //! Default constructor
   ListModeData();
 
-  virtual
-    ~ListModeData();
+  
+    ~ListModeData() override;
 
   //! Returns the name of the list mode data
   /*! This name is not necessarily unique, and might be empty. However, it is expected

--- a/src/include/stir/listmode/ListModeData_dummy.h
+++ b/src/include/stir/listmode/ListModeData_dummy.h
@@ -51,42 +51,42 @@ public:
         this->proj_data_info_sptr = proj_data_info;
     }
 
-    virtual std::string get_name() const
+    std::string get_name() const override
     {
         return std::string("ListModeData_dummy");
     }
 
-    virtual Succeeded reset()
+    Succeeded reset() override
     {
         error("ListModeData_dummy does not have reset()");
         return Succeeded::no;
     }
 
-    virtual SavedPosition save_get_position()
+    SavedPosition save_get_position() override
     {
         error("ListModeData_dummy does not have save_get_position()");
         return 0;
     }
 
-    virtual Succeeded set_get_position(const SavedPosition&)
+    Succeeded set_get_position(const SavedPosition&) override
     {
         error("ListModeData_dummy does not have set_get_position()");
         return Succeeded::no;
     }
 
-    virtual bool has_delayeds() const
+    bool has_delayeds() const override
     {
         error("ListModeData_dummy does not have has_delayeds()");
         return false;
     }
 
 protected:
-    virtual shared_ptr <ListRecord> get_empty_record_helper_sptr() const
+    shared_ptr <ListRecord> get_empty_record_helper_sptr() const override
     {
         error("ListModeData_dummy does not have get_empty_record_helper_sptr()");
         return nullptr;
     }
-    virtual Succeeded get_next(ListRecord& event) const
+    Succeeded get_next(ListRecord& event) const override
     {
         error("ListModeData_dummy does not have get_next()");
         return Succeeded::no;

--- a/src/include/stir/listmode/LmToProjData.h
+++ b/src/include/stir/listmode/LmToProjData.h
@@ -214,12 +214,12 @@ public:
 
   //! Perform various checks
   /*! Note: this is currently called by post_processing(). This will change in version 5.0 */
-  virtual Succeeded set_up();
+  Succeeded set_up() override;
 
   //! This function does the actual work
   //! N.E: In order to keep the ToF functions separate from the non-TOF
   //! STIR this function just call the appropriate actual_process_data_with(out)_tof().
-  virtual void process_data();
+  void process_data() override;
 
 #if 0
   //! A test function for time-of-flight data. At this moment we lack a lot of infrastructure in
@@ -260,9 +260,9 @@ protected:
 
   //! \name parsing functions
   //@{
-  virtual void set_defaults();
-  virtual void initialise_keymap();
-  virtual bool post_processing();
+  void set_defaults() override;
+  void initialise_keymap() override;
+  bool post_processing() override;
   //@}
 
   //! \name parsing variables

--- a/src/include/stir/listmode/LmToProjDataAbstract.h
+++ b/src/include/stir/listmode/LmToProjDataAbstract.h
@@ -40,7 +40,7 @@ class LmToProjDataAbstract : public ParsingObject
 public:
 
     /// Destructor
-    virtual ~LmToProjDataAbstract() {}
+    ~LmToProjDataAbstract() override {}
 
     /// Set up
     virtual Succeeded set_up() { return Succeeded::yes; }

--- a/src/include/stir/listmode/LmToProjDataBootstrap.h
+++ b/src/include/stir/listmode/LmToProjDataBootstrap.h
@@ -77,13 +77,13 @@ public:
   /*! The \a seed argument will override any value found in the par file */
   LmToProjDataBootstrap(const char * const par_filename, const unsigned int seed);
 
-  virtual Succeeded set_up();
+  Succeeded set_up() override;
 protected:
   //! will be called when a new time frame starts
   /*! Initialises a vector with the number of times each event has to be replicated */
-  virtual void start_new_time_frame(const unsigned int new_frame_num);
+  void start_new_time_frame(const unsigned int new_frame_num) override;
 
-  virtual void get_bin_from_event(Bin& bin, const ListEvent&) const;
+  void get_bin_from_event(Bin& bin, const ListEvent&) const override;
 
 
   // \name parsing variables
@@ -100,9 +100,9 @@ private:
 
   replication_type num_times_to_replicate;
   mutable replication_type::const_iterator num_times_to_replicate_iter;
-  virtual void set_defaults();
-  virtual void initialise_keymap();
-  virtual bool post_processing();
+  void set_defaults() override;
+  void initialise_keymap() override;
+  bool post_processing() override;
 
   
 };

--- a/src/include/stir/listmode/LmToProjDataWithRandomRejection.h
+++ b/src/include/stir/listmode/LmToProjDataWithRandomRejection.h
@@ -81,13 +81,13 @@ public:
   //void set_seed(const unsigned int seed);
   float set_reject_if_above(const float);
 
-  virtual Succeeded set_up();
+  Succeeded set_up() override;
 protected:
   //! will be called when a new time frame starts
   /*! Initialises a vector with the number of times each event has to be replicated */
-  virtual void start_new_time_frame(const unsigned int new_frame_num);
+  void start_new_time_frame(const unsigned int new_frame_num) override;
 
-  virtual void get_bin_from_event(Bin& bin, const ListEvent&) const;
+  void get_bin_from_event(Bin& bin, const ListEvent&) const override;
 
 
   // \name parsing variables
@@ -104,9 +104,9 @@ private:
   random_generator_type random_generator;    
 
 
-  virtual void set_defaults();
-  virtual void initialise_keymap();
-  virtual bool post_processing();
+  void set_defaults() override;
+  void initialise_keymap() override;
+  bool post_processing() override;
 
   
 };

--- a/src/include/stir/modelling/KineticModel.h
+++ b/src/include/stir/modelling/KineticModel.h
@@ -41,7 +41,7 @@ public:
   KineticModel();
 
   //! default destructor
-  virtual ~KineticModel();
+  ~KineticModel() override;
 
   //  virtual float get_compartmental_activity_at_time(const int param_num, const int sample_num) const;
   //  virtual float get_total_activity_at_time(const int sample_num) const;

--- a/src/include/stir/modelling/ParametricDiscretisedDensity.h
+++ b/src/include/stir/modelling/ParametricDiscretisedDensity.h
@@ -148,10 +148,10 @@ public DiscDensT
     { return this->end_all_densel_const(); }
 
   //! Allocate a new object with same characteristics as the current one.
-  virtual ParametricDiscretisedDensity* get_empty_copy() const;
+  ParametricDiscretisedDensity* get_empty_copy() const override;
 
   //! Allocate a new object which is a copy of the current one.
-  virtual ParametricDiscretisedDensity* clone() const;
+  ParametricDiscretisedDensity* clone() const override;
 
   //! construct a single image by applying a function object on each KineticParameter 
   template <class KPFunctionObject>

--- a/src/include/stir/modelling/PatlakPlot.h
+++ b/src/include/stir/modelling/PatlakPlot.h
@@ -75,7 +75,7 @@ class PatlakPlot : public RegisteredParsingObject<PatlakPlot, KineticModel>
   static const char * const registered_name; 
 
    PatlakPlot();   //!< Default constructor (calls set_defaults())
-   ~PatlakPlot();   //!< default destructor
+   ~PatlakPlot() override;   //!< default destructor
    /*! \name Functions to get parameters */
    //@{
     //! Simply gets model matrix, if it has been already stored.
@@ -129,9 +129,9 @@ class PatlakPlot : public RegisteredParsingObject<PatlakPlot, KineticModel>
     void 
       apply_linear_regression(ParametricVoxelsOnCartesianGrid & par_image, const DynamicDiscretisedDensity & dyn_image) const;
 
-    void set_defaults();
+    void set_defaults() override;
 
-    Succeeded set_up(); 
+    Succeeded set_up() override; 
 
   bool _if_cardiac;   //!< Switches between cardiac and brain data
   unsigned int _starting_frame;   //!< Starting frame to apply the model
@@ -146,8 +146,8 @@ class PatlakPlot : public RegisteredParsingObject<PatlakPlot, KineticModel>
 
  private:
   void create_model_matrix();  //!< Creates model matrix from private members
-  void initialise_keymap();
-  bool post_processing();
+  void initialise_keymap() override;
+  bool post_processing() override;
   mutable ModelMatrix<2> _model_matrix;
   bool _matrix_is_stored;
   typedef RegisteredParsingObject<PatlakPlot,KineticModel> base_type;

--- a/src/include/stir/numerics/BSplines_weights.inl
+++ b/src/include/stir/numerics/BSplines_weights.inl
@@ -70,10 +70,10 @@ namespace BSpline
   {
   public:
     BSplineFunction() {}
-    posT kernel_length_left() const { return static_cast<posT>(.5); }
+    posT kernel_length_left() const override { return static_cast<posT>(.5); }
     BOOST_STATIC_CONSTANT(int, kernel_total_length_value=1);
-    int kernel_total_length() const  { return kernel_total_length_value; }
-    posT function_piece(const posT x, int p) const
+    int kernel_total_length() const override  { return kernel_total_length_value; }
+    posT function_piece(const posT x, int p) const override
     {
       switch (p)
         {
@@ -84,7 +84,7 @@ namespace BSpline
           return 0;
         }
     }
-    posT derivative_piece(const posT, int ) const
+    posT derivative_piece(const posT, int ) const override
     {
       return 0;
     }
@@ -93,7 +93,7 @@ namespace BSpline
     {
       return static_cast<int>(absx+.5);
     }
-    int find_piece(const posT x) const
+    int find_piece(const posT x) const override
     {
       const int abs_p = this->find_abs_piece(fabs(x));
       if (x>0)
@@ -101,7 +101,7 @@ namespace BSpline
       else
         return -abs_p;
     }
-    int find_highest_piece() const
+    int find_highest_piece() const override
     {
       return 0;
     }
@@ -112,10 +112,10 @@ namespace BSpline
   {
   public:
     BSplineFunction() {}
-    posT kernel_length_left() const { return static_cast<posT>(1); }
+    posT kernel_length_left() const override { return static_cast<posT>(1); }
     BOOST_STATIC_CONSTANT(int, kernel_total_length_value=2);
-    int kernel_total_length() const  { return kernel_total_length_value; }
-    posT function_piece(const posT x, int p) const
+    int kernel_total_length() const override  { return kernel_total_length_value; }
+    posT function_piece(const posT x, int p) const override
     {
       switch (p)
         {
@@ -127,7 +127,7 @@ namespace BSpline
           return 0;
         }
     }
-    posT derivative_piece(const posT x, int p) const
+    posT derivative_piece(const posT x, int p) const override
     {
       switch (p)
         {
@@ -139,12 +139,12 @@ namespace BSpline
           return 0;
         }
     }
-    int find_piece(const posT x) const
+    int find_piece(const posT x) const override
     {
       return static_cast<int>(floor(x));
     }
 
-    int find_highest_piece() const
+    int find_highest_piece() const override
     {
       return 0;
     }
@@ -155,10 +155,10 @@ namespace BSpline
   {
   public:
     BSplineFunction() {}
-    posT kernel_length_left() const { return static_cast<posT>(1.5); }
+    posT kernel_length_left() const override { return static_cast<posT>(1.5); }
     BOOST_STATIC_CONSTANT(int, kernel_total_length_value=3);
-    int kernel_total_length() const  { return kernel_total_length_value; }
-    posT function_piece(const posT x, int p) const
+    int kernel_total_length() const override  { return kernel_total_length_value; }
+    posT function_piece(const posT x, int p) const override
     {
       switch (std::abs(p))
         {
@@ -173,7 +173,7 @@ namespace BSpline
           return 0;
         }
     }
-    posT derivative_piece(const posT x, int p) const
+    posT derivative_piece(const posT x, int p) const override
     {
       switch (std::abs(p))
         {
@@ -205,7 +205,7 @@ namespace BSpline
 
     }
   public:
-    int find_piece(const posT x) const
+    int find_piece(const posT x) const override
     {
       const int abs_p = this->find_abs_piece(fabs(x));
       if (x>0)
@@ -213,7 +213,7 @@ namespace BSpline
       else
         return -abs_p;
     }
-    int find_highest_piece() const
+    int find_highest_piece() const override
     {
       return 1;
     }
@@ -240,10 +240,10 @@ namespace BSpline
   {
   public:
     BSplineFunction() {}
-    posT kernel_length_left() const { return static_cast<posT>(2); }
+    posT kernel_length_left() const override { return static_cast<posT>(2); }
     BOOST_STATIC_CONSTANT(int, kernel_total_length_value=4);
-    int kernel_total_length() const  { return kernel_total_length_value; }
-    posT function_piece(const posT x, int p) const
+    int kernel_total_length() const override  { return kernel_total_length_value; }
+    posT function_piece(const posT x, int p) const override
     {
       const posT absx = std::fabs(x);
       switch (p)
@@ -261,7 +261,7 @@ namespace BSpline
           return 0;
         }
     }
-    posT derivative_piece(const posT x, int p) const
+    posT derivative_piece(const posT x, int p) const override
     {
       switch (p)
         {
@@ -277,11 +277,11 @@ namespace BSpline
           return 0;
         }
     }
-    int find_piece(const posT x) const
+    int find_piece(const posT x) const override
     {
       return static_cast<int>(floor(x));
     }
-    int find_highest_piece() const
+    int find_highest_piece() const override
     {
       return 1;
     }
@@ -293,10 +293,10 @@ namespace BSpline
   {
   public: 
     BSplineFunction() {}
-    posT kernel_length_left() const { return static_cast<posT>(2); }
+    posT kernel_length_left() const override { return static_cast<posT>(2); }
     BOOST_STATIC_CONSTANT(int, kernel_total_length_value=4);
-    int kernel_total_length() const  { return kernel_total_length_value; }
-    posT function_piece(const posT x, int p) const
+    int kernel_total_length() const override  { return kernel_total_length_value; }
+    posT function_piece(const posT x, int p) const override
     {
       const posT absx = std::fabs(x);
       switch (p)
@@ -311,7 +311,7 @@ namespace BSpline
           return 0;
         }
     }
-    posT derivative_piece(const posT x, int p) const
+    posT derivative_piece(const posT x, int p) const override
     {
       const posT absx = std::fabs(x);
       const int sign=x>0?1:-1;
@@ -327,11 +327,11 @@ namespace BSpline
           return 0;
         }
     }
-    int find_piece(const posT x) const
+    int find_piece(const posT x) const override
     {
       return static_cast<int>(floor(x));
     }
-    int find_highest_piece() const
+    int find_highest_piece() const override
     {
       return 1;
     }

--- a/src/include/stir/recon_buildblock/AnalyticReconstruction.h
+++ b/src/include/stir/recon_buildblock/AnalyticReconstruction.h
@@ -68,8 +68,8 @@ public:
     Reconstruction::output_filename_prefix. 
     \return Succeeded::yes if everything was alright.
    */
-  virtual Succeeded 
-    reconstruct(); 
+  Succeeded 
+    reconstruct() override; 
 
   //! executes the reconstruction storing result in \c target_image_sptr
   /*!
@@ -82,11 +82,11 @@ public:
    in a derived class, hides the other. So, we need an implementation for 
    this function. This is the reason to use the actual_reconstruct function.
   */     
-  virtual Succeeded 
-    reconstruct(shared_ptr<TargetT> const& target_image_sptr);
+  Succeeded 
+    reconstruct(shared_ptr<TargetT> const& target_image_sptr) override;
 
-  virtual void set_input_data(const shared_ptr<ExamData>&);
-  virtual const ProjData& get_input_data() const;
+  void set_input_data(const shared_ptr<ExamData>&) override;
+  const ProjData& get_input_data() const override;
   //! @name forwarding functions for ParseDiscretisedDensityParameters
   //@{
   int get_output_image_size_xy() const;
@@ -130,9 +130,9 @@ protected:
     actual_reconstruct(shared_ptr<TargetT> const& target_image_sptr) = 0;
  
   //! used to check acceptable parameter ranges, etc...
-  virtual bool post_processing();  
-  virtual void set_defaults();
-  virtual void initialise_keymap();
+  bool post_processing() override;  
+  void set_defaults() override;
+  void initialise_keymap() override;
 
 
 };

--- a/src/include/stir/recon_buildblock/BackProjectorByBin.h
+++ b/src/include/stir/recon_buildblock/BackProjectorByBin.h
@@ -54,7 +54,7 @@ public:
   //! Default constructor calls reset_timers()
   BackProjectorByBin();
 
-  virtual ~BackProjectorByBin();
+  ~BackProjectorByBin() override;
 
   //! Stores all necessary geometric info
  /*! 
@@ -190,8 +190,8 @@ protected:
   shared_ptr<DiscretisedDensity<3,float> > _density_sptr;
   shared_ptr<DataProcessor<DiscretisedDensity<3,float> > > _post_data_processor_sptr;
 
-  virtual void set_defaults();
-  virtual void initialise_keymap();
+  void set_defaults() override;
+  void initialise_keymap() override;
 
  protected:
   //! ProjDataInfo set by set_up()

--- a/src/include/stir/recon_buildblock/BackProjectorByBinUsingInterpolation.h
+++ b/src/include/stir/recon_buildblock/BackProjectorByBinUsingInterpolation.h
@@ -146,10 +146,10 @@ public:
   //! Stores all necessary geometric info
   /*! Note that the density_info_ptr is not stored in this object. It's only used to get some info on sizes etc.
   */
-  virtual void set_up(		 
+  void set_up(		 
     const shared_ptr<const ProjDataInfo>& proj_data_info_ptr,
     const shared_ptr<const DiscretisedDensity<3,float> >& density_info_ptr // TODO should be Info only
-    );
+    ) override;
 
   /*! \brief Gets the symmetries used by this backprojector
 
@@ -158,7 +158,7 @@ public:
   to the current member. Using another DataSymmetriesForViewSegmentNumbers 
   object will likely crash the program.
   */
-  const DataSymmetriesForViewSegmentNumbers * get_symmetries_used() const;
+  const DataSymmetriesForViewSegmentNumbers * get_symmetries_used() const override;
   /*! 
   \brief Use this to switch between the exact Jacobian and 
    an approximate Jacobian (valid for s << R).
@@ -172,7 +172,7 @@ public:
   */
   void use_piecewise_linear_interpolation(const bool use_piecewise_linear_interpolation);
 
-  BackProjectorByBinUsingInterpolation* clone() const;
+  BackProjectorByBinUsingInterpolation* clone() const override;
 
 private:
  
@@ -220,7 +220,7 @@ struct ProjDataForIntBP
  void actual_back_project(DiscretisedDensity<3,float>&,
                           const RelatedViewgrams<float>&,
 		          const int min_axial_pos_num, const int max_axial_pos_num,
-		          const int min_tangential_pos_num, const int max_tangential_pos_num);
+		          const int min_tangential_pos_num, const int max_tangential_pos_num) override;
 
  void actual_back_project(DiscretisedDensity<3,float>&,
                                   const Bin&);
@@ -314,8 +314,8 @@ static void   backproj2D_Cho_view_viewplus90( PETPlane & image,
                                     const double cphi, const double sphi, int s);
 
 */
-  virtual void set_defaults();
-  virtual void initialise_keymap();
+  void set_defaults() override;
+  void initialise_keymap() override;
 
 };
 

--- a/src/include/stir/recon_buildblock/BackProjectorByBinUsingProjMatrixByBin.h
+++ b/src/include/stir/recon_buildblock/BackProjectorByBinUsingProjMatrixByBin.h
@@ -58,15 +58,15 @@ public:
   //! Stores all necessary geometric info
   /*! Note that the density_info_ptr is not stored in this object. It's only used to get some info on sizes etc.
   */
-  virtual void set_up(		 
+  void set_up(		 
     const shared_ptr<const ProjDataInfo>& proj_data_info_ptr,
     const shared_ptr<const DiscretisedDensity<3,float> >& density_info_ptr // TODO should be Info only
     ) override;
 	 
-  const DataSymmetriesForViewSegmentNumbers * get_symmetries_used() const;
+  const DataSymmetriesForViewSegmentNumbers * get_symmetries_used() const override;
 
 
-  virtual void actual_back_project(DiscretisedDensity<3,float>& image,
+  void actual_back_project(DiscretisedDensity<3,float>& image,
                                    const RelatedViewgrams<float>&,
 		                   const int min_axial_pos_num, const int max_axial_pos_num,
 		                   const int min_tangential_pos_num, const int max_tangential_pos_num) override;
@@ -86,9 +86,9 @@ protected:
                                    const Bin& bin);
 
 private:
-  virtual void set_defaults() override;
-  virtual void initialise_keymap() override;
-  virtual bool post_processing() override;
+  void set_defaults() override;
+  void initialise_keymap() override;
+  bool post_processing() override;
 };
 
 

--- a/src/include/stir/recon_buildblock/BackProjectorByBinUsingSquareProjMatrixByBin.h
+++ b/src/include/stir/recon_buildblock/BackProjectorByBinUsingSquareProjMatrixByBin.h
@@ -52,18 +52,18 @@ public:
     const shared_ptr<ProjMatrixByBin>& proj_matrix_ptr);
 	 
 	 
-  const DataSymmetriesForViewSegmentNumbers * get_symmetries_used() const;
+  const DataSymmetriesForViewSegmentNumbers * get_symmetries_used() const override;
 
-   virtual void set_up(		 
+   void set_up(		 
     const shared_ptr<const ProjDataInfo>& proj_data_info_ptr,
     const shared_ptr<const DiscretisedDensity<3,float> >& density_info_ptr // TODO should be Info only
-    );
+    ) override;
 
 
-  virtual void actual_back_project(DiscretisedDensity<3,float>& image,
+  void actual_back_project(DiscretisedDensity<3,float>& image,
                                    const RelatedViewgrams<float>&,
 		                   const int min_axial_pos_num, const int max_axial_pos_num,
-		                   const int min_tangential_pos_num, const int max_tangential_pos_num);
+		                   const int min_tangential_pos_num, const int max_tangential_pos_num) override;
 
 
   shared_ptr<ProjMatrixByBin> &
@@ -77,8 +77,8 @@ public:
                                    const Bin& bin);
 
 private:
-  virtual void set_defaults();
-  virtual void initialise_keymap();
+  void set_defaults() override;
+  void initialise_keymap() override;
 };
 
 

--- a/src/include/stir/recon_buildblock/BinNormalisation.h
+++ b/src/include/stir/recon_buildblock/BinNormalisation.h
@@ -54,9 +54,9 @@ public:
 
   BinNormalisation();
 
-  virtual ~BinNormalisation();
+  ~BinNormalisation() override;
   /*! sets \c _already_setup to \c false */
-  virtual void set_defaults() override;
+  void set_defaults() override;
   virtual float get_calibration_factor() const {return -1;}
 
   //! check if we would be multiplying with 1 (i.e. do nothing)

--- a/src/include/stir/recon_buildblock/BinNormalisationFromAttenuationImage.h
+++ b/src/include/stir/recon_buildblock/BinNormalisationFromAttenuationImage.h
@@ -85,7 +85,7 @@ public:
   /*! This test is essentially checking if the forward projector can handle the data 
       by calling ForwardProjectorByBin::set_up().
   */
-  virtual Succeeded set_up(const shared_ptr<const ExamInfo>& exam_info_sptr, const shared_ptr<const ProjDataInfo>& ) override;
+  Succeeded set_up(const shared_ptr<const ExamInfo>& exam_info_sptr, const shared_ptr<const ProjDataInfo>& ) override;
 
   using base_type::apply;
   //! Normalise some data
@@ -93,7 +93,7 @@ public:
     This means \c multiply with the data in the projdata object 
     passed in the constructor. 
   */
-  virtual void apply(RelatedViewgrams<float>& viewgrams) const override;
+  void apply(RelatedViewgrams<float>& viewgrams) const override;
 
   //! Undo the normalisation of some data
   /*! 
@@ -101,18 +101,18 @@ public:
     passed in the constructor. 
   */
   
-  virtual void undo(RelatedViewgrams<float>& viewgrams) const override;
+  void undo(RelatedViewgrams<float>& viewgrams) const override;
 
-  virtual float get_bin_efficiency(const Bin& bin) const override; 
+  float get_bin_efficiency(const Bin& bin) const override; 
 
 private:
   shared_ptr<const DiscretisedDensity<3,float> > attenuation_image_ptr;
   shared_ptr<ForwardProjectorByBin> forward_projector_ptr;
 
   // parsing stuff
-  virtual void set_defaults() override;
-  virtual void initialise_keymap() override;
-  virtual bool post_processing() override;
+  void set_defaults() override;
+  void initialise_keymap() override;
+  bool post_processing() override;
 
   std::string attenuation_image_filename;
 };

--- a/src/include/stir/recon_buildblock/BinNormalisationFromECAT8.h
+++ b/src/include/stir/recon_buildblock/BinNormalisationFromECAT8.h
@@ -105,7 +105,7 @@ public:
   //! Constructor that reads the projdata from a file
   BinNormalisationFromECAT8(const string& filename);
 
-  virtual Succeeded set_up(const shared_ptr<const ExamInfo>& exam_info_sptr, const shared_ptr<const ProjDataInfo>& ) override;
+  Succeeded set_up(const shared_ptr<const ExamInfo>& exam_info_sptr, const shared_ptr<const ProjDataInfo>& ) override;
   float get_uncalibrated_bin_efficiency(const Bin& bin) const override;
 
   bool use_detector_efficiencies() const;
@@ -156,9 +156,9 @@ public:
   void construct_sino_lookup_table();
   float find_axial_effects(int ring1, int ring2) const;
   // parsing stuff
-  virtual void set_defaults() override;
-  virtual void initialise_keymap() override;
-  virtual bool post_processing() override;
+  void set_defaults() override;
+  void initialise_keymap() override;
+  bool post_processing() override;
 
   string normalisation_ECAT8_filename;
 };

--- a/src/include/stir/recon_buildblock/BinNormalisationFromGEHDF5.h
+++ b/src/include/stir/recon_buildblock/BinNormalisationFromGEHDF5.h
@@ -90,7 +90,7 @@ public:
   BinNormalisationFromGEHDF5(const string& filename);
 
 
-  virtual Succeeded set_up(const shared_ptr<const ExamInfo> &exam_info_sptr, const shared_ptr<const ProjDataInfo>&) override;
+  Succeeded set_up(const shared_ptr<const ExamInfo> &exam_info_sptr, const shared_ptr<const ProjDataInfo>&) override;
   float get_uncalibrated_bin_efficiency(const Bin& bin) const override;
 
   bool use_detector_efficiencies() const;
@@ -127,9 +127,9 @@ private:
   float get_geometric_efficiency_factors  (const DetectionPositionPair<>& detection_position_pair) const;
   float get_efficiency_factors (const DetectionPositionPair<>& detection_position_pair) const;
   // parsing stuff
-  virtual void set_defaults() override;
-  virtual void initialise_keymap() override;
-  virtual bool post_processing() override;
+  void set_defaults() override;
+  void initialise_keymap() override;
+  bool post_processing() override;
 
   string normalisation_GEHDF5_filename;
   shared_ptr<GEHDF5Wrapper> m_input_hdf5_sptr;

--- a/src/include/stir/recon_buildblock/BinNormalisationFromProjData.h
+++ b/src/include/stir/recon_buildblock/BinNormalisationFromProjData.h
@@ -74,12 +74,12 @@ public:
     will never occur in "real life", so we save ourselves some time/complications
     by returning \c false
   */
-  virtual bool is_trivial() const override;
+  bool is_trivial() const override;
 
   //! Checks if we can handle certain projection data.
   /*! Compares the  ProjDataInfo from the ProjData object containing the normalisation factors 
       with the ProjDataInfo supplied. */
-  virtual Succeeded set_up(const shared_ptr<const ExamInfo>& exam_info_sptr, const shared_ptr<const ProjDataInfo>& ) override;
+  Succeeded set_up(const shared_ptr<const ExamInfo>& exam_info_sptr, const shared_ptr<const ProjDataInfo>& ) override;
 
   //! Normalise some data
   /*! 
@@ -87,7 +87,7 @@ public:
     passed in the constructor. 
   */
   
-  virtual void apply(RelatedViewgrams<float>& viewgrams) const override;
+  void apply(RelatedViewgrams<float>& viewgrams) const override;
 
   //! Undo the normalisation of some data
   /*! 
@@ -95,17 +95,17 @@ public:
     passed in the constructor. 
   */
 
-  virtual void undo(RelatedViewgrams<float>& viewgrams) const override;
-  virtual float get_bin_efficiency(const Bin& bin) const override;
+  void undo(RelatedViewgrams<float>& viewgrams) const override;
+  float get_bin_efficiency(const Bin& bin) const override;
   
     //! Get a shared_ptr to the normalisation proj_data.
   virtual shared_ptr<ProjData> get_norm_proj_data_sptr() const;
  
 private:
   shared_ptr<ProjData> norm_proj_data_ptr;
-  virtual void set_defaults() override;
-  virtual void initialise_keymap() override;
-  virtual bool post_processing() override;
+  void set_defaults() override;
+  void initialise_keymap() override;
+  bool post_processing() override;
 
   std::string normalisation_projdata_filename;
 };

--- a/src/include/stir/recon_buildblock/BinNormalisationPETFromComponents.h
+++ b/src/include/stir/recon_buildblock/BinNormalisationPETFromComponents.h
@@ -92,27 +92,27 @@ public:
   //! check if we would be multiplying with 1 (i.e. do nothing)
   /*! Checks if all data is equal to 1 (up to a tolerance of 1e-4). To do this, it checks if all components are 1.
    */
-  virtual bool is_trivial() const override;
+  bool is_trivial() const override;
 
   //! Checks if we can handle certain projection data.
   /*! Compares the stored ProjDataInfo  with the ProjDataInfo supplied. */
-  virtual Succeeded set_up(const shared_ptr<const ExamInfo>& exam_info_sptr, const shared_ptr<const ProjDataInfo>&) override;
+  Succeeded set_up(const shared_ptr<const ExamInfo>& exam_info_sptr, const shared_ptr<const ProjDataInfo>&) override;
 
   //! Normalise some data
   /*!
     This means \c divide with the efficiency model. 0/0 is set to 0.
   */
 
-  virtual void apply(RelatedViewgrams<float>& viewgrams) const override;
+  void apply(RelatedViewgrams<float>& viewgrams) const override;
 
   using base_type::apply;
   //! Undo the normalisation of some data
   /*!
     This means \c multiply with the efficiency model.
   */
-  virtual void undo(RelatedViewgrams<float>& viewgrams) const override;
+  void undo(RelatedViewgrams<float>& viewgrams) const override;
   using base_type::undo;
-  virtual float get_bin_efficiency(const Bin& bin) const override;
+  float get_bin_efficiency(const Bin& bin) const override;
 
 #if 0
   //! Get a shared_ptr to the normalisation proj_data.

--- a/src/include/stir/recon_buildblock/BinNormalisationSPECT.h
+++ b/src/include/stir/recon_buildblock/BinNormalisationSPECT.h
@@ -45,7 +45,7 @@ public:
   BinNormalisationSPECT(const std::string& filename);
 
   void read_norm_data(const std::string& filename);
-  virtual Succeeded set_up(const shared_ptr<const ExamInfo>& exam_info_sptr, const shared_ptr<const ProjDataInfo>& ) override;
+  Succeeded set_up(const shared_ptr<const ExamInfo>& exam_info_sptr, const shared_ptr<const ProjDataInfo>& ) override;
   void set_num_views(int num_views) const { this->num_views=num_views;}
 
   void set_uniformity(Array<3,float>& uniformity){
@@ -65,11 +65,11 @@ public:
                               const double end_time) const;
 
 
-  virtual void apply(RelatedViewgrams<float>& viewgrams) const override;
+  void apply(RelatedViewgrams<float>& viewgrams) const override;
 
-  virtual void undo(RelatedViewgrams<float>& viewgrams) const override;
+  void undo(RelatedViewgrams<float>& viewgrams) const override;
 
-  virtual float get_uncalibrated_bin_efficiency(const Bin& bin) const override;
+  float get_uncalibrated_bin_efficiency(const Bin& bin) const override;
 
   void read_linearity_table(Array<3,float>& linearity) const;
   void read_uniformity_table(Array<3,float>& uniformity) const;
@@ -82,9 +82,9 @@ public:
 
 protected:
   // parsing stuff
-  virtual void set_defaults() override;
-  virtual void initialise_keymap() override;
-  virtual bool post_processing() override;
+  void set_defaults() override;
+  void initialise_keymap() override;
+  bool post_processing() override;
 
   int max_tang;
   shared_ptr<ProjData> norm_proj_data_info_ptr;

--- a/src/include/stir/recon_buildblock/BinNormalisationWithCalibration.h
+++ b/src/include/stir/recon_buildblock/BinNormalisationWithCalibration.h
@@ -51,7 +51,7 @@ public:
   BinNormalisationWithCalibration();
   //! initialises the object and checks if it can handle such projection data
   /*! Computes internal numbers related to calibration etc. */
-  virtual Succeeded set_up(const shared_ptr<const ExamInfo>& exam_info_sptr,const shared_ptr<const ProjDataInfo>&) override;
+  Succeeded set_up(const shared_ptr<const ExamInfo>& exam_info_sptr,const shared_ptr<const ProjDataInfo>&) override;
   //! product of calibration factor etc
   float get_calib_decay_branching_ratio_factor(const Bin&) const; // TODO find a better name
   float get_calibration_factor() const override;
@@ -66,14 +66,14 @@ public:
   //! return efficiency for 1 bin
   /*! returns get_uncalibrated_bin_efficiency(bin)/get_calib_decay_branching_ratio_factor(bin)
    */
-  virtual float get_bin_efficiency(const Bin& bin) const final
+  float get_bin_efficiency(const Bin& bin) const final
    { return this->get_uncalibrated_bin_efficiency(bin)/this->_calib_decay_branching_ratio; }
   
  protected:
   // parsing stuff
-  virtual void set_defaults() override;
-  virtual void initialise_keymap() override;
-  virtual bool post_processing() override;
+  void set_defaults() override;
+  void initialise_keymap() override;
+  bool post_processing() override;
 
 
 private:

--- a/src/include/stir/recon_buildblock/ChainedBinNormalisation.h
+++ b/src/include/stir/recon_buildblock/ChainedBinNormalisation.h
@@ -89,14 +89,14 @@ ChainedBinNormalisation(shared_ptr<BinNormalisation> const& apply_first,
 
   //! Checks if we can handle certain projection data.
   /*! Calls set_up for the BinNormalisation members. */
-  virtual Succeeded set_up(const shared_ptr<const ExamInfo>& exam_info_sptr, const shared_ptr<const ProjDataInfo>& ) override;
+  Succeeded set_up(const shared_ptr<const ExamInfo>& exam_info_sptr, const shared_ptr<const ProjDataInfo>& ) override;
 
   //! Normalise some data
   /*! 
     This calls apply() of the 2 BinNormalisation members
   */
 
-  virtual void apply(RelatedViewgrams<float>& viewgrams) const override;
+  void apply(RelatedViewgrams<float>& viewgrams) const override;
 #if 0
   virtual void apply(ProjData&) const override;
 #endif
@@ -113,7 +113,7 @@ virtual void apply_only_second(ProjData&) const;
   /*! 
     This calls undo() of the 2 BinNormalisation members. 
   */
-  virtual void undo(RelatedViewgrams<float>& viewgrams) const override;
+  void undo(RelatedViewgrams<float>& viewgrams) const override;
 #if 0
   virtual void undo(ProjData&) const override;
  #endif 
@@ -126,7 +126,7 @@ virtual void undo_only_second(RelatedViewgrams<float>& viewgrams) const;
 
 virtual void undo_only_second(ProjData&) const;
 
-  virtual float get_bin_efficiency(const Bin& bin) const override;
+  float get_bin_efficiency(const Bin& bin) const override;
   
  //! Returns the is_trivial() status of the first normalisation object.
  //! \warning Currently, if the object has not been set the function throws an error.
@@ -142,9 +142,9 @@ private:
   shared_ptr<BinNormalisation> apply_first;
   shared_ptr<BinNormalisation> apply_second;
   // parsing stuff
-  virtual void set_defaults() override;
-  virtual void initialise_keymap() override;
-  virtual bool post_processing() override;
+  void set_defaults() override;
+  void initialise_keymap() override;
+  bool post_processing() override;
 };
 
 END_NAMESPACE_STIR

--- a/src/include/stir/recon_buildblock/DataSymmetriesForBins.h
+++ b/src/include/stir/recon_buildblock/DataSymmetriesForBins.h
@@ -75,10 +75,10 @@ private:
 public:
   DataSymmetriesForBins(const shared_ptr<const ProjDataInfo>& proj_data_info_ptr);
 
-  virtual ~DataSymmetriesForBins();
+  ~DataSymmetriesForBins() override;
 
-  virtual 
-    DataSymmetriesForBins * clone() const = 0;
+  
+    DataSymmetriesForBins * clone() const override = 0;
 
 #if 0
   TODO!
@@ -169,7 +169,7 @@ protected:
   const shared_ptr<const ProjDataInfo> proj_data_info_ptr;
 
   //! Check equality
-  virtual bool blindly_equals(const root_type * const) const = 0;
+  bool blindly_equals(const root_type * const) const override = 0;
 };
 
 END_NAMESPACE_STIR

--- a/src/include/stir/recon_buildblock/DataSymmetriesForBins_PET_CartesianGrid.h
+++ b/src/include/stir/recon_buildblock/DataSymmetriesForBins_PET_CartesianGrid.h
@@ -90,13 +90,13 @@ public:
 					  const bool do_symmetry_shift_z = true);
 
 
-  virtual 
+  
 #ifndef STIR_NO_COVARIANT_RETURN_TYPES
     DataSymmetriesForBins_PET_CartesianGrid
 #else
     DataSymmetriesForViewSegmentNumbers
 #endif
-    * clone() const;
+    * clone() const override;
 
   //! Check equality
   virtual bool operator==(const DataSymmetriesForBins_PET_CartesianGrid&) const;
@@ -111,25 +111,25 @@ public:
   inline void
     get_related_bins_factorised(std::vector<AxTangPosNumbers>&, const Bin& b,
                                 const int min_axial_pos_num, const int max_axial_pos_num,
-                                const int min_tangential_pos_num, const int max_tangential_pos_num) const;
+                                const int min_tangential_pos_num, const int max_tangential_pos_num) const override;
 
   inline int
-    num_related_bins(const Bin& b) const;
+    num_related_bins(const Bin& b) const override;
 
   inline unique_ptr<SymmetryOperation>
-    find_symmetry_operation_from_basic_bin(Bin&) const;
+    find_symmetry_operation_from_basic_bin(Bin&) const override;
 
   inline bool
-    find_basic_bin(Bin& b) const;
+    find_basic_bin(Bin& b) const override;
   
   inline int
-    num_related_view_segment_numbers(const ViewSegmentNumbers& vs) const;
+    num_related_view_segment_numbers(const ViewSegmentNumbers& vs) const override;
   
   inline void
-    get_related_view_segment_numbers(std::vector<ViewSegmentNumbers>& rel_vs, const ViewSegmentNumbers& vs) const;
+    get_related_view_segment_numbers(std::vector<ViewSegmentNumbers>& rel_vs, const ViewSegmentNumbers& vs) const override;
   
   inline bool
-    find_basic_view_segment_numbers(ViewSegmentNumbers& v_s) const;
+    find_basic_view_segment_numbers(ViewSegmentNumbers& v_s) const override;
 
   //! find out how many image planes there are for every scanner ring
   inline float get_num_planes_per_scanner_ring() const;
@@ -188,7 +188,7 @@ private:
     cartesian_grid_info_ptr() const;
 #endif
 
-  virtual bool blindly_equals(const root_type * const) const;
+  bool blindly_equals(const root_type * const) const override;
 
 
   inline bool

--- a/src/include/stir/recon_buildblock/FilterRootPrior.h
+++ b/src/include/stir/recon_buildblock/FilterRootPrior.h
@@ -87,31 +87,31 @@ public:
   FilterRootPrior(shared_ptr<DataProcessor<DataT> >const&, 
 		  const float penalization_factor);
 
-  bool is_convex() const;
+  bool is_convex() const override;
 
  //! compute the value of the function
   /*! \warning Generally there is no function associated to this prior,
     so we just return 0 and write a warning the first time it's called.
    */
-  virtual double
-    compute_value(const DataT &current_estimate);
+  double
+    compute_value(const DataT &current_estimate) override;
   
   //! compute gradient by applying the filter
   void compute_gradient(DataT& prior_gradient, 
-			const DataT &current_estimate);
+			const DataT &current_estimate) override;
 
   //! Has to be called before using this object
-  virtual Succeeded set_up(shared_ptr<const DataT> const& target_sptr);
+  Succeeded set_up(shared_ptr<const DataT> const& target_sptr) override;
   
 protected:
 
   //! Check that the prior is ready to be used
-  virtual void check(DataT const& current_image_estimate) const;
+  void check(DataT const& current_image_estimate) const override;
   
 private:  
    shared_ptr<DataProcessor<DataT> > filter_ptr;   
-   virtual void set_defaults();
-   virtual void initialise_keymap();
+   void set_defaults() override;
+   void initialise_keymap() override;
 
 };
 

--- a/src/include/stir/recon_buildblock/ForwardProjectorByBin.h
+++ b/src/include/stir/recon_buildblock/ForwardProjectorByBin.h
@@ -125,7 +125,7 @@ virtual void set_up(
     void forward_project(Bin&,
                          const DiscretisedDensity<3,float>&);
 #endif
-    virtual ~ForwardProjectorByBin();
+    ~ForwardProjectorByBin() override;
 
     /// Set input
     virtual void set_input(const DiscretisedDensity<3,float>&);
@@ -172,8 +172,8 @@ protected:
   shared_ptr<DiscretisedDensity<3,float> > _density_sptr;
   shared_ptr<DataProcessor<DiscretisedDensity<3,float> > > _pre_data_processor_sptr;
 
-  virtual void set_defaults();
-  virtual void initialise_keymap();
+  void set_defaults() override;
+  void initialise_keymap() override;
 
  protected:
   //! ProjDataInfo set by set_up()

--- a/src/include/stir/recon_buildblock/ForwardProjectorByBinUsingProjMatrixByBin.h
+++ b/src/include/stir/recon_buildblock/ForwardProjectorByBinUsingProjMatrixByBin.h
@@ -63,13 +63,13 @@ public:
   //! Stores all necessary geometric info
   /*! Note that the density_info_ptr is not stored in this object. It's only used to get some info on sizes etc.
   */
-  virtual void set_up(		 
+  void set_up(		 
     const shared_ptr<const ProjDataInfo>& proj_data_info_ptr,
     const shared_ptr<const DiscretisedDensity<3,float> >& density_info_ptr // TODO should be Info only
-    );
+    ) override;
 
   
-  const DataSymmetriesForViewSegmentNumbers * get_symmetries_used() const;
+  const DataSymmetriesForViewSegmentNumbers * get_symmetries_used() const override;
 
 private:
   shared_ptr<ProjMatrixByBin>  proj_matrix_ptr;
@@ -78,15 +78,15 @@ private:
   void actual_forward_project(RelatedViewgrams<float>&, 
 			      const DiscretisedDensity<3,float>& image,
 			      const int min_axial_pos_num, const int max_axial_pos_num,
-			      const int min_tangential_pos_num, const int max_tangential_pos_num);
+			      const int min_tangential_pos_num, const int max_tangential_pos_num) override;
 
 #if 0 // disabled as currently not used. needs to be written in the new style anyway
   void actual_forward_project(Bin&, const DiscretisedDensity<3,float>&);
 #endif
 
-  virtual void set_defaults();
-  virtual void initialise_keymap();
-  virtual bool post_processing();
+  void set_defaults() override;
+  void initialise_keymap() override;
+  bool post_processing() override;
   
 };
 

--- a/src/include/stir/recon_buildblock/ForwardProjectorByBinUsingRayTracing.h
+++ b/src/include/stir/recon_buildblock/ForwardProjectorByBinUsingRayTracing.h
@@ -87,12 +87,12 @@ public:
   //! Stores all necessary geometric info
   /*! Note that the density_info_ptr is not stored in this object. It's only used to get some info on sizes etc.
   */
-  virtual void set_up(		 
+  void set_up(		 
     const shared_ptr<const ProjDataInfo>& proj_data_info_ptr,
     const shared_ptr<const DiscretisedDensity<3,float> >& density_info_ptr // TODO should be Info only
-    );
+    ) override;
 
-  virtual const DataSymmetriesForViewSegmentNumbers * get_symmetries_used() const;
+  const DataSymmetriesForViewSegmentNumbers * get_symmetries_used() const override;
 
  protected:
   //! variable that determines if a cylindrical FOV or the whole image will be handled
@@ -103,7 +103,7 @@ private:
   void actual_forward_project(RelatedViewgrams<float>&, 
 		  const DiscretisedDensity<3,float>&,
 		  const int min_axial_pos_num, const int max_axial_pos_num,
-		  const int min_tangential_pos_num, const int max_tangential_pos_num);
+		  const int min_tangential_pos_num, const int max_tangential_pos_num) override;
 #if 0 // disabled as currently not used. needs to be written in the new style anyway
   void actual_forward_project(Bin&,
                               const DiscretisedDensity<3,float>&);
@@ -217,8 +217,8 @@ forward_project_view_2D(Viewgram<float> & pos_view,
 			  const float norm_factor,
 			  const bool restrict_to_cylindrical_FOV);
 
-  virtual void set_defaults();
-  virtual void initialise_keymap();
+  void set_defaults() override;
+  void initialise_keymap() override;
 };
 END_NAMESPACE_STIR
 #endif

--- a/src/include/stir/recon_buildblock/FourierRebinning.h
+++ b/src/include/stir/recon_buildblock/FourierRebinning.h
@@ -118,7 +118,7 @@ class FourierRebinning : public   RegisteredParsingObject<
  public:
   //! Name which will be used when parsing a ProjDataRebinning object
   static const char * const registered_name; 
-  virtual void set_defaults();
+  void set_defaults() override;
 
   protected:
 //! Smallest angular freq. index minimum 2 ( 1 is zero frequency)
@@ -137,12 +137,12 @@ class FourierRebinning : public   RegisteredParsingObject<
     FourierRebinning();
 
 //! This method returns the type of the algorithm for the rebinning
-    std::string method_info() const
+    std::string method_info() const override
         { return("FORE"); }
 
 
 //! This method creates a stack of 2D rebinned sinograms from the whole 3D data set (i.e. the ProjData data) and saves it.
-   Succeeded rebin();
+   Succeeded rebin() override;
 
 //! A set of get and set utility functions to access the rebinning parameters     
   inline void set_kmin(int km){kmin = km;}
@@ -215,8 +215,8 @@ class FourierRebinning : public   RegisteredParsingObject<
 
     
  protected:
-  virtual bool post_processing();  
-  virtual void initialise_keymap();
+  bool post_processing() override;  
+  void initialise_keymap() override;
 
 };
 

--- a/src/include/stir/recon_buildblock/GeneralisedObjectiveFunction.h
+++ b/src/include/stir/recon_buildblock/GeneralisedObjectiveFunction.h
@@ -91,7 +91,7 @@ public:
   {}
 
 
-  virtual ~GeneralisedObjectiveFunction(); 
+  ~GeneralisedObjectiveFunction() override; 
 
 
   //! Creates a suitable target as determined by the parameters
@@ -344,10 +344,10 @@ protected:
 
   //! sets any default values
   /*! Has to be called by set_defaults in the leaf-class */
-  virtual void set_defaults();
+  void set_defaults() override;
   //! sets parsing keys
   /*! Has to be called by initialise_keymap in the leaf-class */
-  virtual void initialise_keymap();
+  void initialise_keymap() override;
 
   //virtual bool post_processing();
 

--- a/src/include/stir/recon_buildblock/GeneralisedPrior.h
+++ b/src/include/stir/recon_buildblock/GeneralisedPrior.h
@@ -110,10 +110,10 @@ protected:
   float penalisation_factor;
   //! sets value for penalisation factor
   /*! Has to be called by set_defaults in the leaf-class */
-  virtual void set_defaults();
+  void set_defaults() override;
   //! sets key for penalisation factor
   /*! Has to be called by initialise_keymap in the leaf-class */
-  virtual void initialise_keymap();
+  void initialise_keymap() override;
 
   //! Check that the prior is ready to be used
   virtual void check(DataT const& current_estimate) const;

--- a/src/include/stir/recon_buildblock/IterativeReconstruction.h
+++ b/src/include/stir/recon_buildblock/IterativeReconstruction.h
@@ -123,8 +123,8 @@ public:
 
     \return Succeeded::yes if everything was alright.
    */     
-  virtual Succeeded 
-    reconstruct();
+  Succeeded 
+    reconstruct() override;
 
   //! executes the reconstruction with \a target_data_sptr as initial value
   /*! After calling set_up(), repeatedly calls update_estimate(); end_of_iteration_processing();
@@ -132,8 +132,8 @@ public:
 
       Final reconstruction is saved in \a target_data_sptr
   */
-  virtual Succeeded 
-    reconstruct(shared_ptr<TargetT > const& target_data_sptr);
+  Succeeded 
+    reconstruct(shared_ptr<TargetT > const& target_data_sptr) override;
 
   //! A utility function that creates a filename_prefix by appending the current subiteration number
   /*! Only works when no extension is present.
@@ -235,11 +235,11 @@ public:
   //!
   //! \brief set_input_data
   //! \author Nikos Efthimiou
-  void set_input_data(const shared_ptr<ExamData>& arg);
-  virtual const ExamData& get_input_data() const;
+  void set_input_data(const shared_ptr<ExamData>& arg) override;
+  const ExamData& get_input_data() const override;
   //@}
 
-  virtual Succeeded set_up(shared_ptr <TargetT > const& target_data_ptr);
+  Succeeded set_up(shared_ptr <TargetT > const& target_data_ptr) override;
 
   //! the principal operations for updating the data iterates at each iteration
   virtual void update_estimate(TargetT &current_estimate)=0;
@@ -321,10 +321,10 @@ protected:
   //! prompts the user to enter parameter values manually
   virtual void ask_parameters();
 
-  virtual void set_defaults();
-  virtual void initialise_keymap();
+  void set_defaults() override;
+  void initialise_keymap() override;
   //! used to check acceptable parameter ranges, etc...
-  virtual bool post_processing();
+  bool post_processing() override;
 
  private:
   //! member storing the order in which the subsets will be traversed in this iteration

--- a/src/include/stir/recon_buildblock/LogcoshPrior.h
+++ b/src/include/stir/recon_buildblock/LogcoshPrior.h
@@ -108,33 +108,33 @@ public:
     //! Constructs it explicitly with scalar
     LogcoshPrior(const bool only_2D, float penalization_factor, const float scalar);
 
-    virtual bool
-    parabolic_surrogate_curvature_depends_on_argument() const
+    bool
+    parabolic_surrogate_curvature_depends_on_argument() const override
     { return false; }
 
-    bool is_convex() const;
+    bool is_convex() const override;
 
     //! compute the value of the function
     double
-    compute_value(const DiscretisedDensity<3,elemT> &current_image_estimate);
+    compute_value(const DiscretisedDensity<3,elemT> &current_image_estimate) override;
 
     //! compute gradient
     void compute_gradient(DiscretisedDensity<3,elemT>& prior_gradient,
-                          const DiscretisedDensity<3,elemT> &current_image_estimate);
+                          const DiscretisedDensity<3,elemT> &current_image_estimate) override;
 
     //! compute the parabolic surrogate for the prior
     void parabolic_surrogate_curvature(DiscretisedDensity<3,elemT>& parabolic_surrogate_curvature,
-                                       const DiscretisedDensity<3,elemT> &current_image_estimate);
+                                       const DiscretisedDensity<3,elemT> &current_image_estimate) override;
 
-    virtual void
+    void
     compute_Hessian(DiscretisedDensity<3,elemT>& prior_Hessian_for_single_densel,
                     const BasicCoordinate<3,int>& coords,
-                    const DiscretisedDensity<3,elemT> &current_image_estimate) const;
+                    const DiscretisedDensity<3,elemT> &current_image_estimate) const override;
 
     //! Compute the multiplication of the hessian of the prior (at \c current_estimate) and the \c input.
-    virtual void accumulate_Hessian_times_input(DiscretisedDensity<3,elemT>& output,
+    void accumulate_Hessian_times_input(DiscretisedDensity<3,elemT>& output,
                                                      const DiscretisedDensity<3,elemT>& current_estimate,
-                                                     const DiscretisedDensity<3,elemT>& input) const;
+                                                     const DiscretisedDensity<3,elemT>& input) const override;
 
     //! get penalty weights for the neigbourhood
     Array<3,float> get_weights() const;
@@ -182,9 +182,9 @@ protected:
     //! Filename for the \f$\kappa\f$ image that will be read by post_processing()
     std::string kappa_filename;
 
-    virtual void set_defaults();
-    virtual void initialise_keymap();
-    virtual bool post_processing();
+    void set_defaults() override;
+    void initialise_keymap() override;
+    bool post_processing() override;
 
 private:
     //! Spatially variant penalty penalty image ptr

--- a/src/include/stir/recon_buildblock/PLSPrior.h
+++ b/src/include/stir/recon_buildblock/PLSPrior.h
@@ -120,17 +120,17 @@ class PLSPrior:  public
 
   //! Has to be called before using this object
   /*! \todo set the anatomical image to zero if not defined */
-  virtual Succeeded set_up(shared_ptr<const DiscretisedDensity<3,elemT> > const& target_sptr);
+  Succeeded set_up(shared_ptr<const DiscretisedDensity<3,elemT> > const& target_sptr) override;
 
-  bool is_convex() const;
+  bool is_convex() const override;
 
   //! compute the value of the function
   double
-    compute_value(const DiscretisedDensity<3,elemT> &current_image_estimate);
+    compute_value(const DiscretisedDensity<3,elemT> &current_image_estimate) override;
 
   //! compute gradient
   void compute_gradient(DiscretisedDensity<3,elemT>& prior_gradient,
-                        const DiscretisedDensity<3,elemT> &current_image_estimate);
+                        const DiscretisedDensity<3,elemT> &current_image_estimate) override;
 
   //! get current kappa image
   /*! \warning As this function returns a shared_ptr, this is dangerous. You should not
@@ -184,14 +184,14 @@ protected:
 
   double eta, alpha;
 
-  virtual void set_defaults();
-  virtual void initialise_keymap();
+  void set_defaults() override;
+  void initialise_keymap() override;
 
   //! the parsing will only override any exixting kappa-image or anatomical-image if the relevant keyword is present
-  virtual bool post_processing();
+  bool post_processing() override;
 
   //! Check that the prior is ready to be used
-  virtual void check(DiscretisedDensity<3,elemT> const& current_image_estimate) const;
+  void check(DiscretisedDensity<3,elemT> const& current_image_estimate) const override;
 
  private:
 

--- a/src/include/stir/recon_buildblock/Parallelproj_projector/BackProjectorByBinParallelproj.h
+++ b/src/include/stir/recon_buildblock/Parallelproj_projector/BackProjectorByBinParallelproj.h
@@ -46,37 +46,37 @@ public:
   //! Default constructor calls reset_timers()
   BackProjectorByBinParallelproj();
 
-  virtual ~BackProjectorByBinParallelproj();
+  ~BackProjectorByBinParallelproj() override;
 
   /// Keymap
-  virtual void initialise_keymap();
+  void initialise_keymap() override;
 
   //! Stores all necessary geometric info
  /*!
   If necessary, set_up() can be called more than once.
   */
- virtual void set_up(		 
+ void set_up(		 
     const shared_ptr<const ProjDataInfo>& proj_data_info_ptr,
     const shared_ptr<const DiscretisedDensity<3,float> >& density_info_sptr // TODO should be Info only
-    );
+    ) override;
 
   //! Symmetries not used, so returns TrivialDataSymmetriesForBins.
- virtual const DataSymmetriesForViewSegmentNumbers * get_symmetries_used() const;
+ const DataSymmetriesForViewSegmentNumbers * get_symmetries_used() const override;
 
 #if 0
  /// Back project
   void back_project(const ProjData&, int subset_num = 0, int num_subsets = 1);
 #endif
  /// Get output
- virtual void get_output(DiscretisedDensity<3,float> &) const;
+ void get_output(DiscretisedDensity<3,float> &) const override;
 
 
   /*! \brief tell the back projector to start accumulating into a new target.
     This function has to be called before any back-projection is initiated.*/
-  virtual void start_accumulating_in_new_target();
+  void start_accumulating_in_new_target() override;
 
   /// set defaults
-  void set_defaults();
+  void set_defaults() override;
 
   /// Set verbosity
   void set_verbosity(const bool verbosity) { _cuda_verbosity = verbosity; }
@@ -89,9 +89,9 @@ public:
 
 protected:
 
- virtual void actual_back_project(const RelatedViewgrams<float>&,
+ void actual_back_project(const RelatedViewgrams<float>&,
                           const int min_axial_pos_num, const int max_axial_pos_num,
-                          const int min_tangential_pos_num, const int max_tangential_pos_num);
+                          const int min_tangential_pos_num, const int max_tangential_pos_num) override;
 
  private:
   shared_ptr<DataSymmetriesForViewSegmentNumbers> _symmetries_sptr;

--- a/src/include/stir/recon_buildblock/Parallelproj_projector/ForwardProjectorByBinParallelproj.h
+++ b/src/include/stir/recon_buildblock/Parallelproj_projector/ForwardProjectorByBinParallelproj.h
@@ -48,10 +48,10 @@ public:
     ForwardProjectorByBinParallelproj();
 
     /// Constructor
-    virtual ~ForwardProjectorByBinParallelproj();
+    ~ForwardProjectorByBinParallelproj() override;
 
     /// Keymap
-    virtual void initialise_keymap();
+    void initialise_keymap() override;
 
   //! Stores all necessary geometric info
  /*! 
@@ -63,19 +63,19 @@ public:
   \warning there is currently no check on this.
   \warning Derived classes have to call set_up from the base class.
   */
-virtual void set_up(
+void set_up(
     const shared_ptr<const ProjDataInfo>& proj_data_info_ptr,
     const shared_ptr<const DiscretisedDensity<3,float> >& density_info_sptr // TODO should be Info only
-    );
+    ) override;
 
   //! Symmetries not used, so returns TrivialDataSymmetriesForBins.
-  virtual  const DataSymmetriesForViewSegmentNumbers * get_symmetries_used() const;
+   const DataSymmetriesForViewSegmentNumbers * get_symmetries_used() const override;
 
     /// Set input
-    virtual void set_input(const DiscretisedDensity<3,float>&);
+    void set_input(const DiscretisedDensity<3,float>&) override;
 
     /// set defaults
-    void set_defaults();
+    void set_defaults() override;
 
     /// Set verbosity
     void set_verbosity(const bool verbosity) { _cuda_verbosity = verbosity; }
@@ -90,7 +90,7 @@ virtual void set_up(
 
 protected:
 
-  virtual void actual_forward_project(RelatedViewgrams<float>& viewgrams,
+  void actual_forward_project(RelatedViewgrams<float>& viewgrams,
           const int min_axial_pos_num, const int max_axial_pos_num,
           const int min_tangential_pos_num, const int max_tangential_pos_num) override;
 

--- a/src/include/stir/recon_buildblock/PoissonLogLikelihoodWithLinearKineticModelAndDynamicProjectionData.h
+++ b/src/include/stir/recon_buildblock/PoissonLogLikelihoodWithLinearKineticModelAndDynamicProjectionData.h
@@ -68,34 +68,34 @@ public  RegisteredParsingObject<PoissonLogLikelihoodWithLinearKineticModelAndDyn
   /*! Dimensions etc are set from the \a dyn_proj_data_sptr and other information set by parsing,
     such as \c zoom, \c output_image_size_z etc.
   */
-  virtual TargetT *
-    construct_target_ptr() const; 
+  TargetT *
+    construct_target_ptr() const override; 
 
-  virtual std::unique_ptr<ExamInfo>
-  get_exam_info_uptr_for_target()  const;
+  std::unique_ptr<ExamInfo>
+  get_exam_info_uptr_for_target()  const override;
  protected:
-  virtual double
+  double
     actual_compute_objective_function_without_penalty(const TargetT& current_estimate,
-                                                      const int subset_num);
+                                                      const int subset_num) override;
 
-  virtual Succeeded set_up_before_sensitivity(shared_ptr <const TargetT> const& target_sptr);
+  Succeeded set_up_before_sensitivity(shared_ptr <const TargetT> const& target_sptr) override;
 
   //! Add subset sensitivity to existing data
   /*! \todo Current implementation does NOT add to the subset sensitivity, but overwrites
    */
-  virtual void
-    add_subset_sensitivity(TargetT& sensitivity, const int subset_num) const;
+  void
+    add_subset_sensitivity(TargetT& sensitivity, const int subset_num) const override;
 
-  virtual Succeeded 
+  Succeeded 
       actual_add_multiplication_with_approximate_sub_Hessian_without_penalty(TargetT& output,
                                                                              const TargetT& input,
-                                                                             const int subset_num) const;
+                                                                             const int subset_num) const override;
 
-  virtual Succeeded
+  Succeeded
     actual_accumulate_sub_Hessian_times_input_without_penalty(TargetT &output,
                                                               const TargetT &current_image_estimate,
                                                               const TargetT &input,
-                                                              const int subset_num) const;
+                                                              const int subset_num) const override;
 
  public:
   /*! \name Functions to get parameters
@@ -124,13 +124,13 @@ public  RegisteredParsingObject<PoissonLogLikelihoodWithLinearKineticModelAndDyn
   //@{
   void set_recompute_sensitivity(const bool);
   void set_sensitivity_sptr(const shared_ptr<TargetT>&);
-  virtual int set_num_subsets(const int num_subsets);
+  int set_num_subsets(const int num_subsets) override;
 
-  virtual void set_normalisation_sptr(const shared_ptr<BinNormalisation>&);
-  virtual void set_additive_proj_data_sptr(const shared_ptr<ExamData>&);
+  void set_normalisation_sptr(const shared_ptr<BinNormalisation>&) override;
+  void set_additive_proj_data_sptr(const shared_ptr<ExamData>&) override;
 
-  virtual void set_input_data(const shared_ptr<ExamData> &);
-  virtual const DynamicProjData& get_input_data() const;
+  void set_input_data(const shared_ptr<ExamData> &) override;
+  const DynamicProjData& get_input_data() const override;
   //@}
  protected:
   //! Filename with input projection data
@@ -164,22 +164,22 @@ public  RegisteredParsingObject<PoissonLogLikelihoodWithLinearKineticModelAndDyn
   //! dynamic image template
   DynamicDiscretisedDensity _dyn_image_template;
 
-  bool actual_subsets_are_approximately_balanced(std::string& warning_message) const;
+  bool actual_subsets_are_approximately_balanced(std::string& warning_message) const override;
 
 
-  virtual void
+  void
   actual_compute_subset_gradient_without_penalty(TargetT& gradient,
                                                  const TargetT &current_estimate,
                                                  const int subset_num,
-                                                 const bool add_sensitivity);
+                                                 const bool add_sensitivity) override;
 
   //! Sets defaults for parsing 
   /*! Resets \c sensitivity_filename and \c sensitivity_sptr and
      \c recompute_sensitivity to \c false.
   */
-  virtual void set_defaults();
-  virtual void initialise_keymap();
-  virtual bool post_processing();
+  void set_defaults() override;
+  void initialise_keymap() override;
+  bool post_processing() override;
 
 };
 

--- a/src/include/stir/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMean.h
+++ b/src/include/stir/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMean.h
@@ -132,10 +132,10 @@ public  GeneralisedObjectiveFunction<TargetT>
       (see the class general documentation).
       The sum will however be restricted to a subset.
     */
-  virtual void 
+  void 
     compute_sub_gradient_without_penalty(TargetT& gradient, 
                                          const TargetT &current_estimate, 
-                                         const int subset_num); 
+                                         const int subset_num) override; 
 
     //! This should compute the subset gradient of the (unregularised) objective function plus the subset sensitivity
     /*!
@@ -167,7 +167,7 @@ public  GeneralisedObjectiveFunction<TargetT>
 
       Calls set_up_before_sensitivity().
   */
-  virtual Succeeded set_up(shared_ptr <TargetT> const& target_sptr);
+  Succeeded set_up(shared_ptr <TargetT> const& target_sptr) override;
 
   //! Get a const reference to the total sensitivity
   const TargetT& get_sensitivity() const;
@@ -228,7 +228,7 @@ public  GeneralisedObjectiveFunction<TargetT>
    it will the target voxel will be assigned the desired value.
   */
   void 
-    fill_nonidentifiable_target_parameters(TargetT& target, const float value ) const;
+    fill_nonidentifiable_target_parameters(TargetT& target, const float value ) const override;
 
  private:
 
@@ -290,9 +290,9 @@ protected:
   /*! Resets \c sensitivity_filename, \c subset_sensitivity_filenames to empty,
      \c recompute_sensitivity to \c false, and \c use_subset_sensitivities to false.
   */
-  virtual void set_defaults();
-  virtual void initialise_keymap();
-  virtual bool post_processing();
+  void set_defaults() override;
+  void initialise_keymap() override;
+  bool post_processing() override;
 
 };
 

--- a/src/include/stir/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMeanAndGatedProjDataWithMotion.h
+++ b/src/include/stir/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMeanAndGatedProjDataWithMotion.h
@@ -76,34 +76,34 @@ public  RegisteredParsingObject<PoissonLogLikelihoodWithLinearModelForMeanAndGat
   /*! Dimensions etc are set from the \a gated_proj_data_sptr and other information set by parsing,
     such as \c zoom, \c output_image_size_z etc.
   */
-  virtual TargetT *
-    construct_target_ptr() const; 
+  TargetT *
+    construct_target_ptr() const override; 
 
-  virtual void
+  void
     actual_compute_subset_gradient_without_penalty(TargetT& gradient,
                                                  const TargetT &current_estimate,
                                                  const int subset_num,
-                                                 const bool add_sensitivity);
+                                                 const bool add_sensitivity) override;
 
-  virtual double
+  double
     actual_compute_objective_function_without_penalty(const TargetT& current_estimate,
-						      const int subset_num);
+						      const int subset_num) override;
 
-  virtual Succeeded set_up_before_sensitivity(shared_ptr <const TargetT> const& target_sptr);
+  Succeeded set_up_before_sensitivity(shared_ptr <const TargetT> const& target_sptr) override;
 
   //! Add subset sensitivity to existing data
-  virtual void
-    add_subset_sensitivity(TargetT& sensitivity, const int subset_num) const;
+  void
+    add_subset_sensitivity(TargetT& sensitivity, const int subset_num) const override;
 
-  virtual Succeeded 
+  Succeeded 
     actual_add_multiplication_with_approximate_sub_Hessian_without_penalty(TargetT& output,
                                                                            const TargetT& input,
-                                                                           const int subset_num) const;
-  virtual Succeeded
+                                                                           const int subset_num) const override;
+  Succeeded
     actual_accumulate_sub_Hessian_times_input_without_penalty(TargetT &output,
             const TargetT &current_image_estimate,
             const TargetT &input,
-            const int subset_num) const;
+            const int subset_num) const override;
 
   void set_time_gate_definitions(const TimeGateDefinitions & time_gate_definitions); 
 
@@ -133,13 +133,13 @@ public  RegisteredParsingObject<PoissonLogLikelihoodWithLinearModelForMeanAndGat
   //@{
   void set_recompute_sensitivity(const bool);
   void set_sensitivity_sptr(const shared_ptr<TargetT>&);
-  virtual int set_num_subsets(const int num_subsets);
+  int set_num_subsets(const int num_subsets) override;
 
-  virtual void set_normalisation_sptr(const shared_ptr<BinNormalisation>&);
-  virtual void set_additive_proj_data_sptr(const shared_ptr<ExamData>&);
+  void set_normalisation_sptr(const shared_ptr<BinNormalisation>&) override;
+  void set_additive_proj_data_sptr(const shared_ptr<ExamData>&) override;
 
-  virtual void set_input_data(const shared_ptr<ExamData> &);
-  virtual const GatedProjData& get_input_data() const;
+  void set_input_data(const shared_ptr<ExamData> &) override;
+  const GatedProjData& get_input_data() const override;
   //@}
  protected:
   //! Filename with input projection data
@@ -184,12 +184,12 @@ public  RegisteredParsingObject<PoissonLogLikelihoodWithLinearModelForMeanAndGat
 
   //! gated image template
   GatedDiscretisedDensity _gated_image_template;
-  bool actual_subsets_are_approximately_balanced(std::string& warning_message) const;
+  bool actual_subsets_are_approximately_balanced(std::string& warning_message) const override;
 
   //! Sets defaults before parsing 
-  virtual void set_defaults();
-  virtual void initialise_keymap();
-  virtual bool post_processing();
+  void set_defaults() override;
+  void initialise_keymap() override;
+  bool post_processing() override;
 
 };
 

--- a/src/include/stir/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMeanAndListModeData.h
+++ b/src/include/stir/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMeanAndListModeData.h
@@ -76,8 +76,8 @@ public:
  
   //virtual TargetT * construct_target_ptr();  
  
-  virtual Succeeded
-   set_up_before_sensitivity(shared_ptr <const TargetT > const& target_sptr);
+  Succeeded
+   set_up_before_sensitivity(shared_ptr <const TargetT > const& target_sptr) override;
  
   //! time frame definitions
   /*! \todo This is currently used to be able to compute the gradient for 
@@ -88,11 +88,11 @@ public:
   */
     TimeFrameDefinitions frame_defs;
 
-    virtual void set_normalisation_sptr(const shared_ptr<BinNormalisation>&);
-    virtual void set_additive_proj_data_sptr(const shared_ptr<ExamData>&);
+    void set_normalisation_sptr(const shared_ptr<BinNormalisation>&) override;
+    void set_additive_proj_data_sptr(const shared_ptr<ExamData>&) override;
 
-    virtual void set_input_data(const shared_ptr<ExamData> &);
-    virtual const ListModeData& get_input_data() const;
+    void set_input_data(const shared_ptr<ExamData> &) override;
+    const ListModeData& get_input_data() const override;
     //! set maximum segment_number (in listmode data) to process
     /*! minimum will be -max_segment_num_to_process
 
@@ -181,12 +181,12 @@ protected:
  
   //! sets any default values
   /*! Has to be called by set_defaults in the leaf-class */
-  virtual void set_defaults();
+  void set_defaults() override;
   //! sets keys
   /*! Has to be called by initialise_keymap in the leaf-class */
-  virtual void initialise_keymap(); 
+  void initialise_keymap() override; 
 
-  virtual bool post_processing(); 
+  bool post_processing() override; 
 
    //! will be called when a new time frame starts
    /*! The frame numbers start from 1. */

--- a/src/include/stir/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMeanAndListModeDataWithProjMatrixByBin.h
+++ b/src/include/stir/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMeanAndListModeDataWithProjMatrixByBin.h
@@ -81,21 +81,21 @@ public:
    \warning If <code>add_sensitivity = false</code> and <code>use_subset_sensitivities = false</code> will return an error
    because the gradient will not be correct. Try <code>use_subset_sensitivities = true</code>.
    */
-    virtual
+    
     void actual_compute_subset_gradient_without_penalty(TargetT& gradient,
                                                         const TargetT &current_estimate,
                                                         const int subset_num,
-                                                        const bool add_sensitivity);
+                                                        const bool add_sensitivity) override;
 
-  virtual TargetT * construct_target_ptr() const;
+  TargetT * construct_target_ptr() const override;
 
-  int set_num_subsets(const int new_num_subsets);
+  int set_num_subsets(const int new_num_subsets) override;
 
   const shared_ptr<BinNormalisation> &
   get_normalisation_sptr() const
   { return this->normalisation_sptr; }
 
-  virtual unique_ptr<ExamInfo> get_exam_info_uptr_for_target() const;
+  unique_ptr<ExamInfo> get_exam_info_uptr_for_target() const override;
 
   void set_proj_matrix(const shared_ptr<ProjMatrixByBin>&);
 
@@ -108,19 +108,19 @@ public:
 
 protected:
   /*! \todo this function is not implemented yet and currently calls error() */
-  virtual double
+  double
     actual_compute_objective_function_without_penalty(const TargetT& current_estimate,
-                                                      const int subset_num)
+                                                      const int subset_num) override
   { // TODO
     error("compute_objective_function_without_penalty Not implemented yet");
     return 0;
   }
 
-  virtual Succeeded
-    set_up_before_sensitivity(shared_ptr <const TargetT > const& target_sptr);
+  Succeeded
+    set_up_before_sensitivity(shared_ptr <const TargetT > const& target_sptr) override;
 
-  virtual void
-    add_subset_sensitivity(TargetT& sensitivity, const int subset_num) const;
+  void
+    add_subset_sensitivity(TargetT& sensitivity, const int subset_num) const override;
 
 #if STIR_VERSION < 060000  
   //! Maximum ring difference to take into account
@@ -144,12 +144,12 @@ protected:
   shared_ptr<ProjDataInfo> sens_proj_data_info_sptr;
 
   //! sets any default values
-  virtual void set_defaults();
+  void set_defaults() override;
   //! sets keys for parsing
-  virtual void initialise_keymap();
-  virtual bool post_processing();
+  void initialise_keymap() override;
+  bool post_processing() override;
 
-  virtual bool actual_subsets_are_approximately_balanced(std::string& warning_message) const;
+  bool actual_subsets_are_approximately_balanced(std::string& warning_message) const override;
 
   //! If you know, or have previously checked that the number of subsets is balanced for your
   //! Scanner geometry, you can skip future checks.

--- a/src/include/stir/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMeanAndProjData.h
+++ b/src/include/stir/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMeanAndProjData.h
@@ -162,14 +162,14 @@ public:
   //! Destructor
   /*! Calls end_distributable_computation()
    */
-  ~PoissonLogLikelihoodWithLinearModelForMeanAndProjData();
+  ~PoissonLogLikelihoodWithLinearModelForMeanAndProjData() override;
 
   //! Returns a pointer to a newly allocated target object (with 0 data).
   /*! Dimensions etc are set from the \a proj_data_sptr and other information set by parsing,
     such as \c zoom, \c output_image_size_z etc.
   */
-  virtual TargetT *
-    construct_target_ptr() const; 
+  TargetT *
+    construct_target_ptr() const override; 
 
   /*! \name Functions to get parameters
    \warning Be careful with changing shared pointers. If you modify the objects in 
@@ -198,44 +198,44 @@ public:
 
   */
   //@{
-  int set_num_subsets(const int num_subsets);
+  int set_num_subsets(const int num_subsets) override;
   void set_proj_data_sptr(const shared_ptr<ProjData>&);
   void set_max_segment_num_to_process(const int);
   void set_max_timing_pos_num_to_process(const int);
   void set_zero_seg0_end_planes(const bool);
   //N.E. Changed to ExamData
-  virtual void set_additive_proj_data_sptr(const shared_ptr<ExamData>&);
+  void set_additive_proj_data_sptr(const shared_ptr<ExamData>&) override;
   void set_projector_pair_sptr(const shared_ptr<ProjectorByBinPair>&) ;
   void set_frame_num(const int);
   void set_frame_definitions(const TimeFrameDefinitions&);
-  virtual void set_normalisation_sptr(const shared_ptr<BinNormalisation>&);
+  void set_normalisation_sptr(const shared_ptr<BinNormalisation>&) override;
 
-  virtual void set_input_data(const shared_ptr<ExamData> &);
-  virtual const ProjData& get_input_data() const;
+  void set_input_data(const shared_ptr<ExamData> &) override;
+  const ProjData& get_input_data() const override;
 //@}
   
-  virtual void
+  void
   actual_compute_subset_gradient_without_penalty(TargetT& gradient,
                                                  const TargetT &current_estimate,
                                                  const int subset_num,
-                                                 const bool add_sensitivity);
+                                                 const bool add_sensitivity) override;
 
-  virtual std::unique_ptr<ExamInfo>
-  get_exam_info_uptr_for_target()  const;
+  std::unique_ptr<ExamInfo>
+  get_exam_info_uptr_for_target()  const override;
 #if 0
   // currently not used
   float sum_projection_data() const;
 #endif
-  virtual void
-    add_subset_sensitivity(TargetT& sensitivity, const int subset_num) const;
+  void
+    add_subset_sensitivity(TargetT& sensitivity, const int subset_num) const override;
 
  protected:
-  virtual Succeeded 
-    set_up_before_sensitivity(shared_ptr <const TargetT > const& target_sptr);
+  Succeeded 
+    set_up_before_sensitivity(shared_ptr <const TargetT > const& target_sptr) override;
 
-  virtual double
+  double
     actual_compute_objective_function_without_penalty(const TargetT& current_estimate,
-                                                      const int subset_num);
+                                                      const int subset_num) override;
 
   /*!
     The Hessian (without penalty) is approximately given by:
@@ -270,10 +270,10 @@ public:
 
     It has also been suggested to use \f$1 \over y_i+1 \f$ (at least if the data are still Poisson).
   */
-  virtual Succeeded 
+  Succeeded 
       actual_add_multiplication_with_approximate_sub_Hessian_without_penalty(TargetT& output,
                                                                              const TargetT& input,
-                                                                             const int subset_num) const;
+                                                                             const int subset_num) const override;
 
   /*!
     The Hessian (without penalty) is approximately given by:
@@ -292,11 +292,11 @@ public:
     add_multiplication_with_approximate_sub_Hessian_without_penalty() for
     more details regarding Hessian methods.
   */
-  virtual Succeeded
+  Succeeded
         actual_accumulate_sub_Hessian_times_input_without_penalty(TargetT& output,
                 const TargetT& current_image_estimate,
                 const TargetT& input,
-                const int subset_num) const;
+                const int subset_num) const override;
 
 protected:
   //! Filename with input projection data
@@ -353,13 +353,13 @@ protected:
 
   //! sets any default values
   /*! Has to be called by set_defaults in the leaf-class */
-  virtual void set_defaults();
+  void set_defaults() override;
   //! sets keys for parsing
   /*! Has to be called by initialise_keymap in the leaf-class */
-  virtual void initialise_keymap();
+  void initialise_keymap() override;
   //! checks values after parsing
   /*! Has to be called by post_processing in the leaf-class */  
-  virtual bool post_processing();
+  bool post_processing() override;
 
   //! Checks of the current subset scheme is approximately balanced
   /*! For this class, this means that the sub-sensitivities are 
@@ -367,7 +367,7 @@ protected:
       of views etc. It ignores unbalancing caused by normalisation_sptr
       (e.g. for instance when using asymmetric attenuation).
   */
-  bool actual_subsets_are_approximately_balanced(std::string& warning_message) const;
+  bool actual_subsets_are_approximately_balanced(std::string& warning_message) const override;
  private:
   shared_ptr<DataSymmetriesForViewSegmentNumbers> symmetries_sptr;
 

--- a/src/include/stir/recon_buildblock/PostsmoothingBackProjectorByBin.h
+++ b/src/include/stir/recon_buildblock/PostsmoothingBackProjectorByBin.h
@@ -58,15 +58,15 @@ public:
   //! Default constructor (calls set_defaults())
   PostsmoothingBackProjectorByBin();
 
-  ~ PostsmoothingBackProjectorByBin();
+  ~ PostsmoothingBackProjectorByBin() override;
 
   //! Stores all necessary geometric info
   /*! Note that the density_info_ptr is not stored in this object. It's only used to get some info on sizes etc.
   */
-  virtual void set_up(           
+  void set_up(           
                       const shared_ptr<const ProjDataInfo>& proj_data_info_ptr,
                       const shared_ptr<const DiscretisedDensity<3,float> >& density_info_ptr // TODO should be Info only
-    );
+    ) override;
 
 
   PostsmoothingBackProjectorByBin(
@@ -77,11 +77,11 @@ public:
   // It should get data related by at least those symmetries.
   // Otherwise, a run-time error will occur (unless the derived
   // class has other behaviour).
-  const DataSymmetriesForViewSegmentNumbers * get_symmetries_used() const;
+  const DataSymmetriesForViewSegmentNumbers * get_symmetries_used() const override;
 
   BackProjectorByBin* get_original_back_projector_ptr() const;
 
-  PostsmoothingBackProjectorByBin* clone() const;
+  PostsmoothingBackProjectorByBin* clone() const override;
 
 private:
 
@@ -95,7 +95,7 @@ private:
 #endif
   void actual_back_project(const RelatedViewgrams<float>&,
                            const int min_axial_pos_num, const int max_axial_pos_num,
-                           const int min_tangential_pos_num, const int max_tangential_pos_num);
+                           const int min_tangential_pos_num, const int max_tangential_pos_num) override;
 
   void actual_back_project(DiscretisedDensity<3,float>& density,
                                    const Bin& bin);
@@ -103,9 +103,9 @@ private:
   shared_ptr<DiscretisedDensity<3,float> > filtered_density_sptr;
 
 
-  virtual void set_defaults();
-  virtual void initialise_keymap();
-  virtual bool post_processing();
+  void set_defaults() override;
+  void initialise_keymap() override;
+  bool post_processing() override;
 };
 
 END_NAMESPACE_STIR

--- a/src/include/stir/recon_buildblock/PresmoothingForwardProjectorByBin.h
+++ b/src/include/stir/recon_buildblock/PresmoothingForwardProjectorByBin.h
@@ -56,15 +56,15 @@ public:
   //! Default constructor (calls set_defaults())
   PresmoothingForwardProjectorByBin();
 
-  ~ PresmoothingForwardProjectorByBin();
+  ~ PresmoothingForwardProjectorByBin() override;
 
   //! Stores all necessary geometric info
   /*! Note that the density_info_ptr is not stored in this object. It's only used to get some info on sizes etc.
   */
-  virtual void set_up(           
+  void set_up(           
                       const shared_ptr<const ProjDataInfo>& proj_data_info_ptr,
                       const shared_ptr<const DiscretisedDensity<3,float> >& density_info_ptr // TODO should be Info only
-    );
+    ) override;
 
 
   PresmoothingForwardProjectorByBin(
@@ -75,7 +75,7 @@ public:
   // It should get data related by at least those symmetries.
   // Otherwise, a run-time error will occur (unless the derived
   // class has other behaviour).
-  const DataSymmetriesForViewSegmentNumbers * get_symmetries_used() const;
+  const DataSymmetriesForViewSegmentNumbers * get_symmetries_used() const override;
 
 private:
 
@@ -89,16 +89,16 @@ private:
 #endif
   void actual_forward_project(RelatedViewgrams<float>&,
                               const int min_axial_pos_num, const int max_axial_pos_num,
-                              const int min_tangential_pos_num, const int max_tangential_pos_num);
+                              const int min_tangential_pos_num, const int max_tangential_pos_num) override;
 
 #if 0 // disabled as currently not used. needs to be written in the new style anyway
   void actual_forward_project(Bin&,
                               const DiscretisedDensity<3,float>&);
 #endif
 
-  virtual void set_defaults();
-  virtual void initialise_keymap();
-  virtual bool post_processing();
+  void set_defaults() override;
+  void initialise_keymap() override;
+  bool post_processing() override;
 };
 
 END_NAMESPACE_STIR

--- a/src/include/stir/recon_buildblock/ProjDataRebinning.h
+++ b/src/include/stir/recon_buildblock/ProjDataRebinning.h
@@ -77,7 +77,7 @@ class ProjDataRebinning :
 {
 public:
   //! virtual destructor
-  virtual ~ProjDataRebinning();
+  ~ProjDataRebinning() override;
   
   //! gives method information
   virtual std::string method_info() const = 0;
@@ -145,9 +145,9 @@ protected:
 #endif
 
   //! used to check acceptable parameter ranges, etc...
-  virtual bool post_processing();  
-  virtual void set_defaults();
-  virtual void initialise_keymap();
+  bool post_processing() override;  
+  void set_defaults() override;
+  void initialise_keymap() override;
 
  protected: // members
 

--- a/src/include/stir/recon_buildblock/ProjMatrixByBin.h
+++ b/src/include/stir/recon_buildblock/ProjMatrixByBin.h
@@ -81,7 +81,7 @@ class ProjMatrixByBin :
 {
 public:
   
-  virtual ~ProjMatrixByBin() {}
+  ~ProjMatrixByBin() override {}
 
   //! To be called before any calculation is performed
   /*! Note that get_proj_matrix_elems_for_one_bin() will expect objects of
@@ -170,13 +170,13 @@ protected:
   
   //! sets value for caching configuration (enables caching, but for 'basic' bins only)
   /*! Has to be called by set_defaults in the leaf-class */
-  virtual void set_defaults();
+  void set_defaults() override;
   //! sets keys for caching configuration
   /*! Has to be called by initialise_keymap in the leaf-class */
-  virtual void initialise_keymap();
+  void initialise_keymap() override;
   //! Checks if parameters have sensible values
   /*! Has to be called by post_processing in the leaf-class */
-  virtual bool post_processing();
+  bool post_processing() override;
   
   /////////////////////////////// caching stuff //////////////////////
 

--- a/src/include/stir/recon_buildblock/ProjMatrixByBinFromFile.h
+++ b/src/include/stir/recon_buildblock/ProjMatrixByBinFromFile.h
@@ -95,12 +95,12 @@ static Succeeded
   ProjMatrixByBinFromFile();
 
   //! Checks all necessary geometric info
-  virtual void set_up(		 
+  void set_up(		 
 		      const shared_ptr<const ProjDataInfo>& proj_data_info_ptr,
 		      const shared_ptr<const DiscretisedDensity<3,float> >& density_info_ptr // TODO should be Info only
-    );
+    ) override;
 
-  virtual ProjMatrixByBinFromFile* clone() const;
+  ProjMatrixByBinFromFile* clone() const override;
 
 private:
 
@@ -127,13 +127,13 @@ private:
   shared_ptr<const ProjDataInfo> proj_data_info_ptr;
 
 
-  virtual void 
+  void 
     calculate_proj_matrix_elems_for_one_bin(
-                                            ProjMatrixElemsForOneBin&) const;
+                                            ProjMatrixElemsForOneBin&) const override;
 
-  virtual void set_defaults();
-  virtual void initialise_keymap();
-  virtual bool post_processing();
+  void set_defaults() override;
+  void initialise_keymap() override;
+  bool post_processing() override;
 
   Succeeded read_data();
     

--- a/src/include/stir/recon_buildblock/ProjMatrixByBinPinholeSPECTUB.h
+++ b/src/include/stir/recon_buildblock/ProjMatrixByBinPinholeSPECTUB.h
@@ -131,13 +131,13 @@ class ProjMatrixByBinPinholeSPECTUB :
     ProjMatrixByBinPinholeSPECTUB(const ProjMatrixByBinPinholeSPECTUB&) = delete;
 
     //! Destructor (deallocates UB SPECT memory)
-    ~ProjMatrixByBinPinholeSPECTUB();
+    ~ProjMatrixByBinPinholeSPECTUB() override;
 
     //! Checks all necessary geometric info
-    virtual void set_up(		 
+    void set_up(		 
         const shared_ptr<const ProjDataInfo>& proj_data_info_ptr,
         const shared_ptr<const DiscretisedDensity<3,float> >& density_info_ptr // TODO should be Info only
-        );
+        ) override;
 
     //******************** get/set functions *************
 
@@ -207,7 +207,7 @@ class ProjMatrixByBinPinholeSPECTUB :
     bool get_keep_all_views_in_cache() const;
     void set_keep_all_views_in_cache(bool value = false);
 
-    ProjMatrixByBinPinholeSPECTUB * clone() const;
+    ProjMatrixByBinPinholeSPECTUB * clone() const override;
 
   private:
 
@@ -242,12 +242,12 @@ class ProjMatrixByBinPinholeSPECTUB :
     mutable SPECTUB_mph::wm_da_type wm;          // double array weight matrix structure.
     mutable SPECTUB_mph::pcf_type pcf;           // pre-calculated functions
 
-    virtual void 
-        calculate_proj_matrix_elems_for_one_bin(ProjMatrixElemsForOneBin&) const;
+    void 
+        calculate_proj_matrix_elems_for_one_bin(ProjMatrixElemsForOneBin&) const override;
 
-    virtual void set_defaults();
-    virtual void initialise_keymap();
-    virtual bool post_processing();
+    void set_defaults() override;
+    void initialise_keymap() override;
+    bool post_processing() override;
 
     shared_ptr<const DiscretisedDensity<3,float> > attenuation_image_sptr;
     shared_ptr<const DiscretisedDensity<3,float> > mask_image_sptr;

--- a/src/include/stir/recon_buildblock/ProjMatrixByBinSPECTUB.h
+++ b/src/include/stir/recon_buildblock/ProjMatrixByBinSPECTUB.h
@@ -94,13 +94,13 @@ class ProjMatrixByBinSPECTUB :
   ProjMatrixByBinSPECTUB(const ProjMatrixByBinSPECTUB&) = delete;
 
   //! Destructor (deallocates UB SPECT memory)
-  ~ProjMatrixByBinSPECTUB();
+  ~ProjMatrixByBinSPECTUB() override;
 
   //! Checks all necessary geometric info
-  virtual void set_up(		 
+  void set_up(		 
 		      const shared_ptr<const ProjDataInfo>& proj_data_info_ptr,
                       const shared_ptr<const DiscretisedDensity<3,float> >& density_info_ptr // TODO should be Info only
-);
+) override;
 
   bool get_keep_all_views_in_cache() const;
   //! Enable keeping the matrix in memory
@@ -152,7 +152,7 @@ class ProjMatrixByBinSPECTUB :
     
     //Alex
     //Fix to compile, missing function definition in header
-    ProjMatrixByBinSPECTUB * clone() const;
+    ProjMatrixByBinSPECTUB * clone() const override;
  private:
 
   // parameters that will be parsed
@@ -182,13 +182,13 @@ class ProjMatrixByBinSPECTUB :
   mutable SPECTUB::wmh_type wmh; // this could be an arry of wmh_type for each index
   float * Rrad;
 
-  virtual void 
+  void 
     calculate_proj_matrix_elems_for_one_bin(
-                                            ProjMatrixElemsForOneBin&) const;
+                                            ProjMatrixElemsForOneBin&) const override;
 
-  virtual void set_defaults();
-  virtual void initialise_keymap();
-  virtual bool post_processing();
+  void set_defaults() override;
+  void initialise_keymap() override;
+  bool post_processing() override;
 
   shared_ptr<const DiscretisedDensity<3,float> > attenuation_image_sptr;
 

--- a/src/include/stir/recon_buildblock/ProjMatrixByBinUsingInterpolation.h
+++ b/src/include/stir/recon_buildblock/ProjMatrixByBinUsingInterpolation.h
@@ -65,12 +65,12 @@ public :
   //! Stores all necessary geometric info
   /*! Note that the density_info_ptr is not stored in this object. It's only used to get some info on sizes etc.
   */
-  virtual void set_up(		 
+  void set_up(		 
 		      const shared_ptr<const ProjDataInfo>& proj_data_info_ptr,
 		      const shared_ptr<const DiscretisedDensity<3,float> >& density_info_ptr // TODO should be Info only
-    );
+    ) override;
 
-  virtual ProjMatrixByBinUsingInterpolation* clone() const;
+  ProjMatrixByBinUsingInterpolation* clone() const override;
 
 private:
   bool do_symmetry_90degrees_min_phi;
@@ -149,13 +149,13 @@ public:
   bool use_piecewise_linear_interpolation_now;
   bool use_exact_Jacobian_now;
 
-  virtual void 
+  void 
     calculate_proj_matrix_elems_for_one_bin(
-                                            ProjMatrixElemsForOneBin&) const;
+                                            ProjMatrixElemsForOneBin&) const override;
 
-  virtual void set_defaults();
-  virtual void initialise_keymap();
-  virtual bool post_processing();
+  void set_defaults() override;
+  void initialise_keymap() override;
+  bool post_processing() override;
 
    float
      get_element(const Bin& bin, 

--- a/src/include/stir/recon_buildblock/ProjMatrixByBinUsingRayTracing.h
+++ b/src/include/stir/recon_buildblock/ProjMatrixByBinUsingRayTracing.h
@@ -127,12 +127,12 @@ public :
   //! Stores all necessary geometric info
   /*! Note that the density_info_ptr is not stored in this object. It's only used to get some info on sizes etc.
   */
-  virtual void set_up(		 
+  void set_up(		 
     const shared_ptr<const ProjDataInfo>& proj_data_info_ptr,
     const shared_ptr<const DiscretisedDensity<3,float> >& density_info_ptr // TODO should be Info only
-    );
+    ) override;
 
-  virtual ProjMatrixByBinUsingRayTracing* clone() const;
+  ProjMatrixByBinUsingRayTracing* clone() const override;
 
   //! \name If a cylindrical FOV or the whole image will be handled
   //!@{
@@ -193,13 +193,13 @@ private:
   CartesianCoordinate3D<int> min_index;
   CartesianCoordinate3D<int> max_index;
 
-  virtual void 
+  void 
     calculate_proj_matrix_elems_for_one_bin(
-                                            ProjMatrixElemsForOneBin&) const;
+                                            ProjMatrixElemsForOneBin&) const override;
 
-   virtual void set_defaults();
-   virtual void initialise_keymap();
-   virtual bool post_processing();
+   void set_defaults() override;
+   void initialise_keymap() override;
+   bool post_processing() override;
   
 };
 

--- a/src/include/stir/recon_buildblock/ProjectorByBinPair.h
+++ b/src/include/stir/recon_buildblock/ProjectorByBinPair.h
@@ -49,7 +49,7 @@ public:
   //! Default constructor 
   ProjectorByBinPair();
 
-  virtual ~ProjectorByBinPair() {}
+  ~ProjectorByBinPair() override {}
 
   //! Stores all necessary geometric info
   /*! 

--- a/src/include/stir/recon_buildblock/ProjectorByBinPairUsingProjMatrixByBin.h
+++ b/src/include/stir/recon_buildblock/ProjectorByBinPairUsingProjMatrixByBin.h
@@ -54,10 +54,10 @@ public:
 
   //! Stores all necessary geometric info
   /*! First constructs forward and back projectors and then calls base_type::setup */
-  virtual Succeeded set_up(		 
+  Succeeded set_up(		 
     const shared_ptr<const ProjDataInfo>& proj_data_info_sptr,
     const shared_ptr<const DiscretisedDensity<3,float> >& density_info_sptr // TODO should be Info only
-    );
+    ) override;
 
   ProjMatrixByBin const * 
     get_proj_matrix_ptr() const;
@@ -69,9 +69,9 @@ public:
 private:
 
   shared_ptr<ProjMatrixByBin> proj_matrix_sptr;
-  void set_defaults();
-  void initialise_keymap();
-  bool post_processing();
+  void set_defaults() override;
+  void initialise_keymap() override;
+  bool post_processing() override;
 };
 
 END_NAMESPACE_STIR

--- a/src/include/stir/recon_buildblock/ProjectorByBinPairUsingSeparateProjectors.h
+++ b/src/include/stir/recon_buildblock/ProjectorByBinPairUsingSeparateProjectors.h
@@ -55,9 +55,9 @@ public:
 
 private:
 
-  void set_defaults();
-  void initialise_keymap();
-  bool post_processing();
+  void set_defaults() override;
+  void initialise_keymap() override;
+  bool post_processing() override;
 };
 
 END_NAMESPACE_STIR

--- a/src/include/stir/recon_buildblock/QuadraticPrior.h
+++ b/src/include/stir/recon_buildblock/QuadraticPrior.h
@@ -102,41 +102,41 @@ class QuadraticPrior:  public
   //! Constructs it explicitly
   QuadraticPrior(const bool only_2D, float penalization_factor);
   
-  virtual bool
-    parabolic_surrogate_curvature_depends_on_argument() const
+  bool
+    parabolic_surrogate_curvature_depends_on_argument() const override
     { return false; }
 
-  bool is_convex() const;
+  bool is_convex() const override;
 
   //! compute the value of the function
   double
-    compute_value(const DiscretisedDensity<3,elemT> &current_image_estimate);
+    compute_value(const DiscretisedDensity<3,elemT> &current_image_estimate) override;
 
   //! compute gradient 
   void compute_gradient(DiscretisedDensity<3,elemT>& prior_gradient, 
-                        const DiscretisedDensity<3,elemT> &current_image_estimate);
+                        const DiscretisedDensity<3,elemT> &current_image_estimate) override;
 
   //! compute the parabolic surrogate for the prior
   /*! in the case of quadratic priors this will just be the sum of weighting coefficients*/
   void parabolic_surrogate_curvature(DiscretisedDensity<3,elemT>& parabolic_surrogate_curvature, 
-                        const DiscretisedDensity<3,elemT> &current_image_estimate);
+                        const DiscretisedDensity<3,elemT> &current_image_estimate) override;
 
-  virtual void
+  void
   compute_Hessian(DiscretisedDensity<3,elemT>& prior_Hessian_for_single_densel,
                   const BasicCoordinate<3,int>& coords,
-                  const DiscretisedDensity<3,elemT> &current_image_estimate) const;
+                  const DiscretisedDensity<3,elemT> &current_image_estimate) const override;
 
   //! Call accumulate_Hessian_times_input
-  virtual void
+  void
     add_multiplication_with_approximate_Hessian(DiscretisedDensity<3,elemT>& output,
-                                                const DiscretisedDensity<3,elemT>& input) const;
+                                                const DiscretisedDensity<3,elemT>& input) const override;
 
   //! Compute the multiplication of the hessian of the prior multiplied by the input.
   //! For the quadratic function, the hessian of the prior is 1.
   //! Therefore this will return the weights multiplied by the input.
-  virtual void accumulate_Hessian_times_input(DiscretisedDensity<3,elemT>& output,
+  void accumulate_Hessian_times_input(DiscretisedDensity<3,elemT>& output,
                                                    const DiscretisedDensity<3,elemT>& current_estimate,
-                                                   const DiscretisedDensity<3,elemT>& input) const;
+                                                   const DiscretisedDensity<3,elemT>& input) const override;
 
   //! get penalty weights for the neighbourhood
   Array<3,float> get_weights() const;
@@ -155,7 +155,7 @@ class QuadraticPrior:  public
   void set_kappa_sptr(const shared_ptr<const DiscretisedDensity<3,elemT> >&);
 
   //! Has to be called before using this object
-  virtual Succeeded set_up(shared_ptr<const DiscretisedDensity<3,elemT> > const& target_sptr);
+  Succeeded set_up(shared_ptr<const DiscretisedDensity<3,elemT> > const& target_sptr) override;
   
 protected:
   //! can be set during parsing to restrict the weights to the 2D case
@@ -177,11 +177,11 @@ protected:
   std::string kappa_filename;
 
   //! Check that the prior is ready to be used
-  virtual void check(DiscretisedDensity<3,elemT> const& current_image_estimate) const;
+  void check(DiscretisedDensity<3,elemT> const& current_image_estimate) const override;
 
-  virtual void set_defaults();
-  virtual void initialise_keymap();
-  virtual bool post_processing();
+  void set_defaults() override;
+  void initialise_keymap() override;
+  bool post_processing() override;
  private:
   shared_ptr<const DiscretisedDensity<3,elemT> > kappa_ptr;
 

--- a/src/include/stir/recon_buildblock/Reconstruction.h
+++ b/src/include/stir/recon_buildblock/Reconstruction.h
@@ -76,7 +76,7 @@ public:
   Reconstruction();
 
   //! virtual destructor
-  virtual ~Reconstruction() {};
+  ~Reconstruction() override {};
   
   //! gives method information
   virtual std::string method_info() const = 0;
@@ -190,8 +190,8 @@ protected:
   */
   void initialise(const std::string& parameter_filename);
   
-  virtual void set_defaults();
-  virtual void initialise_keymap();
+  void set_defaults() override;
+  void initialise_keymap() override;
   //! used to check acceptable parameters after parsing
   /*!
     The function should be used to set members that have 
@@ -205,7 +205,7 @@ protected:
     set parameters by calling various \c set_ functions (such as
     \c set_post_processor_sptr() ).
   */
-  virtual bool post_processing();
+  bool post_processing() override;
 
   //!
   //! \brief target_data_sptr

--- a/src/include/stir/recon_buildblock/RelativeDifferencePrior.h
+++ b/src/include/stir/recon_buildblock/RelativeDifferencePrior.h
@@ -112,24 +112,24 @@ class RelativeDifferencePrior:  public
 
   //! compute the value of the function
   double
-    compute_value(const DiscretisedDensity<3,elemT> &current_image_estimate);
+    compute_value(const DiscretisedDensity<3,elemT> &current_image_estimate) override;
 
   //! compute gradient 
   void compute_gradient(DiscretisedDensity<3,elemT>& prior_gradient, 
-                        const DiscretisedDensity<3,elemT> &current_image_estimate);
+                        const DiscretisedDensity<3,elemT> &current_image_estimate) override;
 
-  virtual void compute_Hessian(DiscretisedDensity<3,elemT>& prior_Hessian_for_single_densel,
+  void compute_Hessian(DiscretisedDensity<3,elemT>& prior_Hessian_for_single_densel,
                                     const BasicCoordinate<3,int>& coords,
-                                    const DiscretisedDensity<3,elemT> &current_image_estimate) const;
+                                    const DiscretisedDensity<3,elemT> &current_image_estimate) const override;
 
-  virtual void
+  void
     add_multiplication_with_approximate_Hessian(DiscretisedDensity<3,elemT>& output,
-                                                const DiscretisedDensity<3,elemT>& input) const;
+                                                const DiscretisedDensity<3,elemT>& input) const override;
 
     //! Compute the multiplication of the hessian of the prior multiplied by the input.
-  virtual void accumulate_Hessian_times_input(DiscretisedDensity<3,elemT>& output,
+  void accumulate_Hessian_times_input(DiscretisedDensity<3,elemT>& output,
                                                    const DiscretisedDensity<3,elemT>& current_estimate,
-                                                   const DiscretisedDensity<3,elemT>& input) const;
+                                                   const DiscretisedDensity<3,elemT>& input) const override;
 
   //! get the gamma value used in RDP
   float get_gamma() const;
@@ -161,7 +161,7 @@ class RelativeDifferencePrior:  public
   //! Has to be called before using this object
   virtual Succeeded set_up(shared_ptr<DiscretisedDensity<3,elemT> > const& target_sptr);
   
-  bool is_convex() const;
+  bool is_convex() const override;
   
 protected:
   //! Create variable gamma for Relative Difference Penalty
@@ -189,11 +189,11 @@ protected:
   std::string kappa_filename;
 
   //! Check that the prior is ready to be used
-  virtual void check(DiscretisedDensity<3,elemT> const& current_image_estimate) const;
+  void check(DiscretisedDensity<3,elemT> const& current_image_estimate) const override;
 
-  virtual void set_defaults();
-  virtual void initialise_keymap();
-  virtual bool post_processing();
+  void set_defaults() override;
+  void initialise_keymap() override;
+  bool post_processing() override;
  private:
   shared_ptr<DiscretisedDensity<3,elemT> > kappa_ptr;
 

--- a/src/include/stir/recon_buildblock/SqrtHessianRowSum.h
+++ b/src/include/stir/recon_buildblock/SqrtHessianRowSum.h
@@ -67,7 +67,7 @@ public:
     //! sets default values
     /*! Sets \c use_approximate_hessian to \c true and \c compute_with_penalty to \c false
     */
-    void set_defaults();
+    void set_defaults() override;
 
     //! The main function to compute and save the sqrt of the Hessian row sum volume
     /*! Different Hessian row sum methods can be used, see compute_Hessian_row_sum() and
@@ -148,8 +148,8 @@ private:
     int _verbosity;
 
     //! used to check acceptable parameter ranges, etc...
-    bool post_processing();
-    void initialise_keymap();
+    bool post_processing() override;
+    void initialise_keymap() override;
 };
 
 END_NAMESPACE_STIR

--- a/src/include/stir/recon_buildblock/SymmetryOperation.h
+++ b/src/include/stir/recon_buildblock/SymmetryOperation.h
@@ -96,20 +96,20 @@ public:
 class TrivialSymmetryOperation : public SymmetryOperation
 {
 public:
-  inline bool is_trivial() const { return true;}
+  inline bool is_trivial() const override { return true;}
   inline void 
-    transform_bin_coordinates(Bin& b) const {}
+    transform_bin_coordinates(Bin& b) const override {}
   inline void 
-    transform_view_segment_indices(ViewSegmentNumbers& n) const {}
+    transform_view_segment_indices(ViewSegmentNumbers& n) const override {}
   inline void
-    transform_image_coordinates(BasicCoordinate<3,int>& c) const {}
+    transform_image_coordinates(BasicCoordinate<3,int>& c) const override {}
   inline void 
     transform_proj_matrix_elems_for_one_bin(
-       ProjMatrixElemsForOneBin& lor) const {}
+       ProjMatrixElemsForOneBin& lor) const override {}
 
-  virtual void 
+  void 
     transform_proj_matrix_elems_for_one_densel(
-      ProjMatrixElemsForOneDensel&) const {}
+      ProjMatrixElemsForOneDensel&) const override {}
 };
 
 

--- a/src/include/stir/recon_buildblock/SymmetryOperations_PET_CartesianGrid.h
+++ b/src/include/stir/recon_buildblock/SymmetryOperations_PET_CartesianGrid.h
@@ -56,19 +56,19 @@ public:
   {}
 
   inline void 
-    transform_bin_coordinates(Bin&) const;
+    transform_bin_coordinates(Bin&) const override;
   inline void 
-    transform_view_segment_indices(ViewSegmentNumbers&) const;
+    transform_view_segment_indices(ViewSegmentNumbers&) const override;
   inline void
-    transform_image_coordinates(BasicCoordinate<3,int>& c) const;
+    transform_image_coordinates(BasicCoordinate<3,int>& c) const override;
 
   void 
     transform_proj_matrix_elems_for_one_bin(
-      ProjMatrixElemsForOneBin& lor) const;
+      ProjMatrixElemsForOneBin& lor) const override;
 
-  virtual void 
+  void 
     transform_proj_matrix_elems_for_one_densel(
-      ProjMatrixElemsForOneDensel& ) const;
+      ProjMatrixElemsForOneDensel& ) const override;
 
 private:
   int axial_pos_shift;
@@ -85,20 +85,20 @@ public:
   {}
 
   inline void 
-    transform_bin_coordinates(Bin&) const;
+    transform_bin_coordinates(Bin&) const override;
   inline void 
-    transform_view_segment_indices(ViewSegmentNumbers&) const;
+    transform_view_segment_indices(ViewSegmentNumbers&) const override;
   inline void
-    transform_image_coordinates(BasicCoordinate<3,int>& c) const;
+    transform_image_coordinates(BasicCoordinate<3,int>& c) const override;
 
   void 
     transform_proj_matrix_elems_for_one_bin(
-      ProjMatrixElemsForOneBin& lor) const;
+      ProjMatrixElemsForOneBin& lor) const override;
 
 
-  virtual void 
+  void 
     transform_proj_matrix_elems_for_one_densel(
-      ProjMatrixElemsForOneDensel&) const;
+      ProjMatrixElemsForOneDensel&) const override;
 
 private:
   int view180;
@@ -120,20 +120,20 @@ public:
   {}
 
   inline void 
-    transform_bin_coordinates(Bin&) const;
+    transform_bin_coordinates(Bin&) const override;
   inline void 
-    transform_view_segment_indices(ViewSegmentNumbers&) const;
+    transform_view_segment_indices(ViewSegmentNumbers&) const override;
   inline void
-    transform_image_coordinates(BasicCoordinate<3,int>& c) const;
+    transform_image_coordinates(BasicCoordinate<3,int>& c) const override;
 
   void 
     transform_proj_matrix_elems_for_one_bin(
-      ProjMatrixElemsForOneBin& lor) const;
+      ProjMatrixElemsForOneBin& lor) const override;
 
 
-  virtual void 
+  void 
     transform_proj_matrix_elems_for_one_densel(
-      ProjMatrixElemsForOneDensel&) const;
+      ProjMatrixElemsForOneDensel&) const override;
 
 private:
   int view180;
@@ -153,20 +153,20 @@ public:
   {}
 
   inline void 
-    transform_bin_coordinates(Bin&) const;
+    transform_bin_coordinates(Bin&) const override;
   inline void 
-    transform_view_segment_indices(ViewSegmentNumbers&) const;
+    transform_view_segment_indices(ViewSegmentNumbers&) const override;
   inline void
-    transform_image_coordinates(BasicCoordinate<3,int>& c) const;
+    transform_image_coordinates(BasicCoordinate<3,int>& c) const override;
 
   void 
     transform_proj_matrix_elems_for_one_bin(
-      ProjMatrixElemsForOneBin& lor) const;
+      ProjMatrixElemsForOneBin& lor) const override;
 
 
-  virtual void 
+  void 
     transform_proj_matrix_elems_for_one_densel(
-      ProjMatrixElemsForOneDensel&) const;
+      ProjMatrixElemsForOneDensel&) const override;
 
 private:
   int view180;
@@ -185,20 +185,20 @@ public:
   {}
 
   inline void 
-    transform_bin_coordinates(Bin&) const;
+    transform_bin_coordinates(Bin&) const override;
   inline void 
-    transform_view_segment_indices(ViewSegmentNumbers&) const;
+    transform_view_segment_indices(ViewSegmentNumbers&) const override;
   inline void
-    transform_image_coordinates(BasicCoordinate<3,int>& c) const;
+    transform_image_coordinates(BasicCoordinate<3,int>& c) const override;
 
   void 
     transform_proj_matrix_elems_for_one_bin(
-      ProjMatrixElemsForOneBin& lor) const;
+      ProjMatrixElemsForOneBin& lor) const override;
 
 
-  virtual void 
+  void 
     transform_proj_matrix_elems_for_one_densel(
-      ProjMatrixElemsForOneDensel&) const;
+      ProjMatrixElemsForOneDensel&) const override;
 
 private:
   int view180;
@@ -217,20 +217,20 @@ public:
   {}
 
   inline void 
-    transform_bin_coordinates(Bin&) const;
+    transform_bin_coordinates(Bin&) const override;
   inline void 
-    transform_view_segment_indices(ViewSegmentNumbers&) const;
+    transform_view_segment_indices(ViewSegmentNumbers&) const override;
   inline void
-    transform_image_coordinates(BasicCoordinate<3,int>& c) const;
+    transform_image_coordinates(BasicCoordinate<3,int>& c) const override;
 
   void 
     transform_proj_matrix_elems_for_one_bin(
-      ProjMatrixElemsForOneBin& lor) const;
+      ProjMatrixElemsForOneBin& lor) const override;
 
 
-  virtual void 
+  void 
     transform_proj_matrix_elems_for_one_densel(
-      ProjMatrixElemsForOneDensel&) const;
+      ProjMatrixElemsForOneDensel&) const override;
 
 private:
   int view180;
@@ -250,20 +250,20 @@ public:
   {}
 
   inline void 
-    transform_bin_coordinates(Bin&) const;
+    transform_bin_coordinates(Bin&) const override;
   inline void 
-    transform_view_segment_indices(ViewSegmentNumbers&) const;
+    transform_view_segment_indices(ViewSegmentNumbers&) const override;
   inline void
-    transform_image_coordinates(BasicCoordinate<3,int>& c) const;
+    transform_image_coordinates(BasicCoordinate<3,int>& c) const override;
 
   void 
     transform_proj_matrix_elems_for_one_bin(
-      ProjMatrixElemsForOneBin& lor) const;
+      ProjMatrixElemsForOneBin& lor) const override;
 
 
-  virtual void 
+  void 
     transform_proj_matrix_elems_for_one_densel(
-      ProjMatrixElemsForOneDensel&) const;
+      ProjMatrixElemsForOneDensel&) const override;
 
 private:
   int view180;
@@ -281,20 +281,20 @@ public:
   {}
 
   inline void 
-    transform_bin_coordinates(Bin&) const;
+    transform_bin_coordinates(Bin&) const override;
   inline void 
-    transform_view_segment_indices(ViewSegmentNumbers&) const;
+    transform_view_segment_indices(ViewSegmentNumbers&) const override;
   inline void
-    transform_image_coordinates(BasicCoordinate<3,int>& c) const;
+    transform_image_coordinates(BasicCoordinate<3,int>& c) const override;
 
   void 
     transform_proj_matrix_elems_for_one_bin(
-      ProjMatrixElemsForOneBin& lor) const;
+      ProjMatrixElemsForOneBin& lor) const override;
 
 
-  virtual void 
+  void 
     transform_proj_matrix_elems_for_one_densel(
-      ProjMatrixElemsForOneDensel&) const;
+      ProjMatrixElemsForOneDensel&) const override;
 
 private:
   int view180;
@@ -312,20 +312,20 @@ public:
   {}
 
   inline void 
-    transform_bin_coordinates(Bin&) const;
+    transform_bin_coordinates(Bin&) const override;
   inline void 
-    transform_view_segment_indices(ViewSegmentNumbers&) const;
+    transform_view_segment_indices(ViewSegmentNumbers&) const override;
   inline void
-    transform_image_coordinates(BasicCoordinate<3,int>& c) const;
+    transform_image_coordinates(BasicCoordinate<3,int>& c) const override;
 
   void 
     transform_proj_matrix_elems_for_one_bin(
-      ProjMatrixElemsForOneBin& lor) const;
+      ProjMatrixElemsForOneBin& lor) const override;
 
 
-  virtual void 
+  void 
     transform_proj_matrix_elems_for_one_densel(
-      ProjMatrixElemsForOneDensel&) const;
+      ProjMatrixElemsForOneDensel&) const override;
 
 private:
   int view180;
@@ -344,20 +344,20 @@ public:
   {}
 
   inline void 
-    transform_bin_coordinates(Bin&) const;
+    transform_bin_coordinates(Bin&) const override;
   inline void 
-    transform_view_segment_indices(ViewSegmentNumbers&) const;
+    transform_view_segment_indices(ViewSegmentNumbers&) const override;
   inline void
-    transform_image_coordinates(BasicCoordinate<3,int>& c) const;
+    transform_image_coordinates(BasicCoordinate<3,int>& c) const override;
 
   void 
     transform_proj_matrix_elems_for_one_bin(
-      ProjMatrixElemsForOneBin& lor) const;
+      ProjMatrixElemsForOneBin& lor) const override;
 
 
-  virtual void 
+  void 
     transform_proj_matrix_elems_for_one_densel(
-      ProjMatrixElemsForOneDensel&) const;
+      ProjMatrixElemsForOneDensel&) const override;
 
 private:
   int view180;
@@ -376,20 +376,20 @@ public:
   {}
 
   inline void 
-    transform_bin_coordinates(Bin&) const;
+    transform_bin_coordinates(Bin&) const override;
   inline void 
-    transform_view_segment_indices(ViewSegmentNumbers&) const;
+    transform_view_segment_indices(ViewSegmentNumbers&) const override;
   inline void
-    transform_image_coordinates(BasicCoordinate<3,int>& c) const;
+    transform_image_coordinates(BasicCoordinate<3,int>& c) const override;
 
   void 
     transform_proj_matrix_elems_for_one_bin(
-      ProjMatrixElemsForOneBin& lor) const;
+      ProjMatrixElemsForOneBin& lor) const override;
 
 
-  virtual void 
+  void 
     transform_proj_matrix_elems_for_one_densel(
-      ProjMatrixElemsForOneDensel&) const;
+      ProjMatrixElemsForOneDensel&) const override;
 
 private:
   int view180;
@@ -408,20 +408,20 @@ public:
   {}
 
   inline void 
-    transform_bin_coordinates(Bin&) const;
+    transform_bin_coordinates(Bin&) const override;
   inline void 
-    transform_view_segment_indices(ViewSegmentNumbers&) const;
+    transform_view_segment_indices(ViewSegmentNumbers&) const override;
   inline void
-    transform_image_coordinates(BasicCoordinate<3,int>& c) const;
+    transform_image_coordinates(BasicCoordinate<3,int>& c) const override;
 
   void 
     transform_proj_matrix_elems_for_one_bin(
-      ProjMatrixElemsForOneBin& lor) const;
+      ProjMatrixElemsForOneBin& lor) const override;
 
 
-  virtual void 
+  void 
     transform_proj_matrix_elems_for_one_densel(
-      ProjMatrixElemsForOneDensel&) const;
+      ProjMatrixElemsForOneDensel&) const override;
 
 private:
   int view180;
@@ -439,20 +439,20 @@ public:
   {}
 
   inline void 
-    transform_bin_coordinates(Bin&) const;
+    transform_bin_coordinates(Bin&) const override;
   inline void 
-    transform_view_segment_indices(ViewSegmentNumbers&) const;
+    transform_view_segment_indices(ViewSegmentNumbers&) const override;
   inline void
-    transform_image_coordinates(BasicCoordinate<3,int>& c) const;
+    transform_image_coordinates(BasicCoordinate<3,int>& c) const override;
 
   void 
     transform_proj_matrix_elems_for_one_bin(
-      ProjMatrixElemsForOneBin& lor) const;
+      ProjMatrixElemsForOneBin& lor) const override;
 
 
-  virtual void 
+  void 
     transform_proj_matrix_elems_for_one_densel(
-      ProjMatrixElemsForOneDensel&) const;
+      ProjMatrixElemsForOneDensel&) const override;
 
 private:
   int view180;
@@ -470,20 +470,20 @@ public:
   {}
 
   inline void 
-    transform_bin_coordinates(Bin&) const;
+    transform_bin_coordinates(Bin&) const override;
   inline void 
-    transform_view_segment_indices(ViewSegmentNumbers&) const;
+    transform_view_segment_indices(ViewSegmentNumbers&) const override;
   inline void
-    transform_image_coordinates(BasicCoordinate<3,int>& c) const;
+    transform_image_coordinates(BasicCoordinate<3,int>& c) const override;
 
   void 
     transform_proj_matrix_elems_for_one_bin(
-      ProjMatrixElemsForOneBin& lor) const;
+      ProjMatrixElemsForOneBin& lor) const override;
 
 
-  virtual void 
+  void 
     transform_proj_matrix_elems_for_one_densel(
-      ProjMatrixElemsForOneDensel&) const;
+      ProjMatrixElemsForOneDensel&) const override;
 
 private:
   int view180;
@@ -502,20 +502,20 @@ public:
   {}
 
   inline void 
-    transform_bin_coordinates(Bin&) const;
+    transform_bin_coordinates(Bin&) const override;
   inline void 
-    transform_view_segment_indices(ViewSegmentNumbers&) const;
+    transform_view_segment_indices(ViewSegmentNumbers&) const override;
   inline void
-    transform_image_coordinates(BasicCoordinate<3,int>& c) const;
+    transform_image_coordinates(BasicCoordinate<3,int>& c) const override;
 
   void 
     transform_proj_matrix_elems_for_one_bin(
-      ProjMatrixElemsForOneBin& lor) const;
+      ProjMatrixElemsForOneBin& lor) const override;
 
 
-  virtual void 
+  void 
     transform_proj_matrix_elems_for_one_densel(
-      ProjMatrixElemsForOneDensel&) const;
+      ProjMatrixElemsForOneDensel&) const override;
 
 private:
   int view180;
@@ -533,20 +533,20 @@ public:
   {}
 
   inline void 
-    transform_bin_coordinates(Bin&) const;
+    transform_bin_coordinates(Bin&) const override;
   inline void 
-    transform_view_segment_indices(ViewSegmentNumbers&) const;
+    transform_view_segment_indices(ViewSegmentNumbers&) const override;
   inline void
-    transform_image_coordinates(BasicCoordinate<3,int>& c) const;
+    transform_image_coordinates(BasicCoordinate<3,int>& c) const override;
 
   void 
     transform_proj_matrix_elems_for_one_bin(
-      ProjMatrixElemsForOneBin& lor) const;
+      ProjMatrixElemsForOneBin& lor) const override;
 
 
-  virtual void 
+  void 
     transform_proj_matrix_elems_for_one_densel(
-      ProjMatrixElemsForOneDensel&) const;
+      ProjMatrixElemsForOneDensel&) const override;
 
 private:
   int view180;

--- a/src/include/stir/recon_buildblock/TrivialBinNormalisation.h
+++ b/src/include/stir/recon_buildblock/TrivialBinNormalisation.h
@@ -38,16 +38,16 @@ public:
   //! Name which will be used when parsing a BinNormalisation object
   static const char * const registered_name; 
 
-  virtual inline void apply(RelatedViewgrams<float>&) const override {}
-  virtual inline void undo(RelatedViewgrams<float>&) const override {}
+  inline void apply(RelatedViewgrams<float>&) const override {}
+  inline void undo(RelatedViewgrams<float>&) const override {}
   
-  virtual inline float get_bin_efficiency(const Bin& bin) const override { return 1.F;}
+  inline float get_bin_efficiency(const Bin& bin) const override { return 1.F;}
 
-  virtual inline bool is_trivial() const override { return true;}  
+  inline bool is_trivial() const override { return true;}  
 
 private:
-  virtual inline void set_defaults() override {}
-  virtual inline void initialise_keymap() override {}
+  inline void set_defaults() override {}
+  inline void initialise_keymap() override {}
   
 };
 

--- a/src/include/stir/recon_buildblock/TrivialDataSymmetriesForBins.h
+++ b/src/include/stir/recon_buildblock/TrivialDataSymmetriesForBins.h
@@ -37,45 +37,45 @@ class TrivialDataSymmetriesForBins : public DataSymmetriesForBins
 public:
   TrivialDataSymmetriesForBins(const shared_ptr<const ProjDataInfo>& proj_data_info_ptr);
 
-  virtual 
-    TrivialDataSymmetriesForBins * clone() const;
+  
+    TrivialDataSymmetriesForBins * clone() const override;
 
-  virtual void
+  void
     get_related_bins(std::vector<Bin>&, const Bin& b,
                       const int min_axial_pos_num, const int max_axial_pos_num,
                       const int min_tangential_pos_num, const int max_tangential_pos_num,
-                     const int min_timing_pos_num, const int max_timing_pos_num0) const;
+                     const int min_timing_pos_num, const int max_timing_pos_num0) const override;
 
-  virtual void
+  void
     get_related_bins_factorised(std::vector<AxTangPosNumbers>&, const Bin& b,
                                 const int min_axial_pos_num, const int max_axial_pos_num,
-                                const int min_tangential_pos_num, const int max_tangential_pos_num) const;
+                                const int min_tangential_pos_num, const int max_tangential_pos_num) const override;
 
-  virtual int
-    num_related_bins(const Bin& b) const;
+  int
+    num_related_bins(const Bin& b) const override;
 
-  virtual unique_ptr<SymmetryOperation>
-    find_symmetry_operation_from_basic_bin(Bin&) const;
+  unique_ptr<SymmetryOperation>
+    find_symmetry_operation_from_basic_bin(Bin&) const override;
 
-  virtual bool
-    find_basic_bin(Bin& b) const;
+  bool
+    find_basic_bin(Bin& b) const override;
 
-  virtual bool
-    is_basic(const Bin& v_s) const;
+  bool
+    is_basic(const Bin& v_s) const override;
 
-  virtual unique_ptr<SymmetryOperation>
-    find_symmetry_operation_from_basic_view_segment_numbers(ViewSegmentNumbers&) const;
+  unique_ptr<SymmetryOperation>
+    find_symmetry_operation_from_basic_view_segment_numbers(ViewSegmentNumbers&) const override;
 
-  virtual void
-    get_related_view_segment_numbers(std::vector<ViewSegmentNumbers>&, const ViewSegmentNumbers&) const;
+  void
+    get_related_view_segment_numbers(std::vector<ViewSegmentNumbers>&, const ViewSegmentNumbers&) const override;
 
-  virtual int
-    num_related_view_segment_numbers(const ViewSegmentNumbers&) const;
-  virtual bool
-    find_basic_view_segment_numbers(ViewSegmentNumbers&) const;
+  int
+    num_related_view_segment_numbers(const ViewSegmentNumbers&) const override;
+  bool
+    find_basic_view_segment_numbers(ViewSegmentNumbers&) const override;
 
 private:
-  virtual bool blindly_equals(const root_type * const) const;
+  bool blindly_equals(const root_type * const) const override;
 };
 
 END_NAMESPACE_STIR

--- a/src/include/stir/recon_buildblock/test/ReconstructionTests.h
+++ b/src/include/stir/recon_buildblock/test/ReconstructionTests.h
@@ -39,7 +39,7 @@ public:
     ReconstructionTests(const std::string &proj_data_filename = "",
                         const std::string & density_filename = "");
 
-  virtual ~ReconstructionTests() {}
+  ~ReconstructionTests() override {}
 
   //! default proj_data_info
   virtual inline std::unique_ptr<ProjDataInfo>

--- a/src/include/stir/scatter/CreateTailMaskFromACFs.h
+++ b/src/include/stir/scatter/CreateTailMaskFromACFs.h
@@ -88,9 +88,9 @@ public:
     int safety_margin;
 
 protected:
-    void initialise_keymap();
-    bool post_processing();
-    void set_defaults();
+    void initialise_keymap() override;
+    bool post_processing() override;
+    void set_defaults() override;
 
 private:
     //!

--- a/src/include/stir/scatter/ScatterEstimation.h
+++ b/src/include/stir/scatter/ScatterEstimation.h
@@ -206,9 +206,9 @@ public:
 
  protected:
     //! All recomputes_** will default true
-    virtual void set_defaults();
-    virtual void initialise_keymap();
-    virtual bool post_processing();
+    void set_defaults() override;
+    void initialise_keymap() override;
+    bool post_processing() override;
 
     //! Recompute or load the mask image.
     bool recompute_mask_image;

--- a/src/include/stir/scatter/ScatterSimulation.h
+++ b/src/include/stir/scatter/ScatterSimulation.h
@@ -89,7 +89,7 @@ public:
     //! Default constructor
     ScatterSimulation();
 
-    virtual ~ScatterSimulation();
+    ~ScatterSimulation() override;
 
     virtual Succeeded process_data();
     //! gives method information
@@ -274,12 +274,12 @@ protected:
 
 
 
-    virtual void set_defaults();
-    virtual void initialise_keymap();
+    void set_defaults() override;
+    void initialise_keymap() override;
     //! \warning post_processing will set everything that has a file name in
     //! the par file. The corresponding set functions should be used either
     //! for files that are not stored in the drive.
-    virtual bool post_processing();
+    bool post_processing() override;
 
     enum image_type{act_image_type, att_image_type};
     struct ScatterPoint

--- a/src/include/stir/scatter/SingleScatterSimulation.h
+++ b/src/include/stir/scatter/SingleScatterSimulation.h
@@ -53,24 +53,24 @@ public:
     explicit
     SingleScatterSimulation(const std::string& parameter_filename);
 
-    virtual ~SingleScatterSimulation();
+    ~SingleScatterSimulation() override;
 
-    virtual Succeeded process_data();
+    Succeeded process_data() override;
     //! gives method information
-    virtual std::string method_info() const;
+    std::string method_info() const override;
     //! prompts the user to enter parameter values manually
-    virtual void ask_parameters();
+    void ask_parameters() override;
     //! Perform checks and intialisations
-    virtual Succeeded set_up();
+    Succeeded set_up() override;
 protected:
 
     void initialise(const std::string& parameter_filename);
 
-    virtual void set_defaults();
-    virtual void initialise_keymap();
+    void set_defaults() override;
+    void initialise_keymap() override;
 
     //! used to check acceptable parameter ranges, etc...
-    virtual bool post_processing();
+    bool post_processing() override;
 
 
     //!
@@ -80,8 +80,8 @@ protected:
                                                   const unsigned det_num_A,
                                                   const unsigned det_num_B);
 
-    virtual double
-      scatter_estimate(const Bin& bin);
+    double
+      scatter_estimate(const Bin& bin) override;
 
     virtual void
     actual_scatter_estimate(double& scatter_ratio_singles,

--- a/src/include/stir/spatial_transformation/GatedSpatialTransformation.h
+++ b/src/include/stir/spatial_transformation/GatedSpatialTransformation.h
@@ -39,7 +39,7 @@ class GatedSpatialTransformation: public RegisteredParsingObject<GatedSpatialTra
   static const char * const registered_name; 
 
   GatedSpatialTransformation(); //!< default constructor
-  ~GatedSpatialTransformation(); //!< default destructor
+  ~GatedSpatialTransformation() override; //!< default destructor
   //!  Construct an empty GatedSpatialTransformation based on a shared_ptr<DiscretisedDensity<3,float> >
   GatedSpatialTransformation(const TimeGateDefinitions& time_gate_definitions,
                 const shared_ptr<DiscretisedDensity<3,float> >& density_sptr);
@@ -73,13 +73,13 @@ class GatedSpatialTransformation: public RegisteredParsingObject<GatedSpatialTra
   void 
     accumulate_warp_image(DiscretisedDensity<3, float> & new_reference_image,
                           const GatedDiscretisedDensity & gated_image) const ;
-  void set_defaults();
-  Succeeded set_up(); 
+  void set_defaults() override;
+  Succeeded set_up() override; 
   //@}
  private:
   typedef RegisteredParsingObject<GatedSpatialTransformation,SpatialTransformation> base_type;
-  void initialise_keymap();
-  bool post_processing();	
+  void initialise_keymap() override;
+  bool post_processing() override;	
   std::string _transformation_filename_prefix;
   GatedDiscretisedDensity _spatial_transformation_z;
   GatedDiscretisedDensity _spatial_transformation_y;

--- a/src/include/stir/spatial_transformation/SpatialTransformation.h
+++ b/src/include/stir/spatial_transformation/SpatialTransformation.h
@@ -36,7 +36,7 @@ class SpatialTransformation: public RegisteredObject<SpatialTransformation>
   SpatialTransformation();
 
   //! default destructor
-  virtual ~SpatialTransformation();
+  ~SpatialTransformation() override;
 
   virtual Succeeded set_up() = 0;
 };

--- a/src/include/stir_experimental/AbsTimeInterval.h
+++ b/src/include/stir_experimental/AbsTimeInterval.h
@@ -32,7 +32,7 @@ class AbsTimeInterval: public RegisteredObject<AbsTimeInterval>
 {
 
 public:
-  virtual ~AbsTimeInterval() {}
+  ~AbsTimeInterval() override {}
   AbsTimeInterval()
     :
     _start_time_in_secs_since_1970(0),

--- a/src/include/stir_experimental/AbsTimeIntervalFromDynamicData.h
+++ b/src/include/stir_experimental/AbsTimeIntervalFromDynamicData.h
@@ -53,7 +53,7 @@ public:
   //! Name which will be used when parsing a AbsTimeInterval object 
   static const char * const registered_name; 
 
-  virtual ~AbsTimeIntervalFromDynamicData() {}
+  ~AbsTimeIntervalFromDynamicData() override {}
   //! default constructor gives ill-defined values
   AbsTimeIntervalFromDynamicData();
   //! read info from file
@@ -69,9 +69,9 @@ public:
   unsigned int _start_time_frame_num;
   unsigned int _end_time_frame_num;
 
-  virtual void set_defaults();
-  virtual void initialise_keymap();
-  virtual bool post_processing();
+  void set_defaults() override;
+  void initialise_keymap() override;
+  bool post_processing() override;
 
 
   Succeeded set_times();

--- a/src/include/stir_experimental/AbsTimeIntervalFromECAT7ACF.h
+++ b/src/include/stir_experimental/AbsTimeIntervalFromECAT7ACF.h
@@ -42,7 +42,7 @@ public:
   //! Name which will be used when parsing a AbsTimeInterval object 
   static const char * const registered_name; 
 
-  virtual ~AbsTimeIntervalFromECAT7ACF() {}
+  ~AbsTimeIntervalFromECAT7ACF() override {}
   //! default constructor sets duration to -1 (i.e. ill-defined)
   AbsTimeIntervalFromECAT7ACF();
   //! read info from ECAT7 file
@@ -54,9 +54,9 @@ public:
   std::string _attenuation_filename; 
   double _transmission_duration;
 
-  virtual void set_defaults();
-  virtual void initialise_keymap();
-  virtual bool post_processing();
+  void set_defaults() override;
+  void initialise_keymap() override;
+  bool post_processing() override;
 
   Succeeded set_times();
 

--- a/src/include/stir_experimental/AbsTimeIntervalWithParsing.h
+++ b/src/include/stir_experimental/AbsTimeIntervalWithParsing.h
@@ -42,15 +42,15 @@ public:
   //! Name which will be used when parsing a AbsTimeInterval object 
   static const char * const registered_name; 
 
-  virtual ~AbsTimeIntervalWithParsing() {}
+  ~AbsTimeIntervalWithParsing() override {}
   //! default constructor sets times to invalid values
   AbsTimeIntervalWithParsing();
   
  private:
 
-  virtual void set_defaults();
-  virtual void initialise_keymap();
-  virtual bool post_processing();
+  void set_defaults() override;
+  void initialise_keymap() override;
+  bool post_processing() override;
 
 };
 

--- a/src/include/stir_experimental/listmode/LmToProjDataWithMC.h
+++ b/src/include/stir_experimental/listmode/LmToProjDataWithMC.h
@@ -39,8 +39,8 @@ public:
   LmToProjDataWithMC(const char * const par_filename);
 
   virtual void get_bin_from_event(Bin& bin, const CListEvent&) const;
-  virtual void process_new_time_event(const ListTime& time_event);
-  virtual Succeeded set_up();
+  void process_new_time_event(const ListTime& time_event) override;
+  Succeeded set_up() override;
   
 protected: 
   //! motion information
@@ -50,12 +50,12 @@ protected:
   //! constant reference position (if used)
   shared_ptr<AbsTimeInterval> _reference_abs_time_sptr;  
 
-  virtual void start_new_time_frame(const unsigned int new_frame_num);
+  void start_new_time_frame(const unsigned int new_frame_num) override;
 
    
-  virtual void set_defaults();
-  virtual void initialise_keymap();
-  virtual bool post_processing();
+  void set_defaults() override;
+  void initialise_keymap() override;
+  bool post_processing() override;
 
 private:
 

--- a/src/include/stir_experimental/modelling/BloodFrameData.h
+++ b/src/include/stir_experimental/modelling/BloodFrameData.h
@@ -22,7 +22,6 @@
 #define __stir_modelling_BloodFrameData_H__
 
 #include "stir_experimental/modelling/BloodFrame.h"
-#include "stir_experimental/decay_correct.h"
 #include <vector>
 
 START_NAMESPACE_STIR

--- a/src/include/stir_experimental/modelling/BloodFrameData.inl
+++ b/src/include/stir_experimental/modelling/BloodFrameData.inl
@@ -18,7 +18,7 @@
 */
 #include "stir/warning.h"
 #include "stir/error.h"
-
+#include "stir/decay_correction_factor.h"
 START_NAMESPACE_STIR
 
 //! default constructor

--- a/src/include/stir_experimental/modelling/OneParamModel.h
+++ b/src/include/stir_experimental/modelling/OneParamModel.h
@@ -20,7 +20,7 @@
 #ifndef __stir_modelling_OneParamModel_H__
 #define __stir_modelling_OneParamModel_H__
 
-#include "stir_experimental/modelling/ModelMatrix.h"
+#include "stir/modelling/ModelMatrix.h"
 
 START_NAMESPACE_STIR
 

--- a/src/include/stir_experimental/motion/MatchTrackerAndScanner.h
+++ b/src/include/stir_experimental/motion/MatchTrackerAndScanner.h
@@ -23,6 +23,7 @@
 #include "stir/shared_ptr.h"
 #include "stir/ParsingObject.h"
 #include "stir_experimental/motion/RigidObject3DMotion.h"
+#include <string>
 
 START_NAMESPACE_STIR
 /*! \ingroup motion
@@ -104,7 +105,7 @@ public:
   double get_frame_end_time(unsigned frame_num) const
   { return frame_defs.get_end_time(frame_num) + scan_start_time; }
 
-  const string& get_image_filename_prefix() const
+  const std::string& get_image_filename_prefix() const
   { return _image_filename_prefix; }
   
   const RigidObject3DMotion& get_motion() const
@@ -123,16 +124,16 @@ protected:
   double _current_frame_start_time;
   
   //! parsing functions
-  virtual void set_defaults();
-  virtual void initialise_keymap();
-  virtual bool post_processing();
+  void set_defaults() override;
+  void initialise_keymap() override;
+  bool post_processing() override;
 
   //! parsing variables
-  string frame_definition_filename;
+  std::string frame_definition_filename;
 
   double scan_start_time;
 
-  string _image_filename_prefix;
+  std::string _image_filename_prefix;
 
   float relative_threshold;
 private:

--- a/src/include/stir_experimental/motion/ObjectTransformation.h
+++ b/src/include/stir_experimental/motion/ObjectTransformation.h
@@ -34,7 +34,7 @@ public:
   //! typedef used by read_from_file
   typedef ObjectTransformation hierarchy_base_type;
 
-  virtual ~ObjectTransformation() {}
+  ~ObjectTransformation() override {}
   //! Transform point 
   /* \todo should be CartesianCoordinate<num_dimensions,elemT>, but we don't have that class yet*/
   virtual BasicCoordinate<num_dimensions,elemT> 

--- a/src/include/stir_experimental/motion/RigidObject3DMotion.h
+++ b/src/include/stir_experimental/motion/RigidObject3DMotion.h
@@ -47,7 +47,7 @@ class RigidObject3DMotion: public RegisteredObject<RigidObject3DMotion>
 {
 
 public:
-  virtual ~RigidObject3DMotion() {}
+  ~RigidObject3DMotion() override {}
 
   //! get motion in tracker coordinates  
   virtual
@@ -119,9 +119,9 @@ public:
     set_transformation_from_scanner_coords(const RigidObject3DTransformation&) = 0;
 
 protected:
-  virtual void set_defaults();
-  virtual void initialise_keymap();
-  virtual bool post_processing();
+  void set_defaults() override;
+  void initialise_keymap() override;
+  bool post_processing() override;
 
 };
 

--- a/src/include/stir_experimental/motion/RigidObject3DMotionFromPolaris.h
+++ b/src/include/stir_experimental/motion/RigidObject3DMotionFromPolaris.h
@@ -68,35 +68,35 @@ public:
   // only need this to enable LmToProjDataWithMC(const char * const par_filename) function
   RigidObject3DMotionFromPolaris();
 
-  virtual RigidObject3DTransformation 
-    compute_average_motion_in_tracker_coords_rel_time(const double start_time, const double end_time) const;
+  RigidObject3DTransformation 
+    compute_average_motion_in_tracker_coords_rel_time(const double start_time, const double end_time) const override;
 
-  virtual 
+  
     RigidObject3DTransformation
-    get_motion_in_tracker_coords_rel_time(const double time) const;
+    get_motion_in_tracker_coords_rel_time(const double time) const override;
 
-  virtual std::vector<double>
-    get_rel_time_of_samples(const double start_time, const double end_time) const;
+  std::vector<double>
+    get_rel_time_of_samples(const double start_time, const double end_time) const override;
 
   //! set mask to be able to ignore one or more channels in the listmode gating data
   void set_mask_for_tags(const unsigned int mask_for_tags);
 
   //! Synchronise motion tracking file and listmode file
-  virtual Succeeded synchronise();
-  virtual double secs_since_1970_to_rel_time(std::time_t) const;
+  Succeeded synchronise() override;
+  double secs_since_1970_to_rel_time(std::time_t) const override;
 
-  virtual const RigidObject3DTransformation& 
-    get_transformation_to_scanner_coords() const;
-  virtual const RigidObject3DTransformation& 
-    get_transformation_from_scanner_coords() const;
-  virtual void  
-    set_transformation_from_scanner_coords(const RigidObject3DTransformation&);
+  const RigidObject3DTransformation& 
+    get_transformation_to_scanner_coords() const override;
+  const RigidObject3DTransformation& 
+    get_transformation_from_scanner_coords() const override;
+  void  
+    set_transformation_from_scanner_coords(const RigidObject3DTransformation&) override;
   Succeeded set_mt_file(const std::string& mt_filename);
   Succeeded set_list_mode_data_file(const std::string& lm_filename);
 
-  virtual void set_defaults();
-  virtual void initialise_keymap();
-  virtual bool post_processing();
+  void set_defaults() override;
+  void initialise_keymap() override;
+  bool post_processing() override;
 
   //! Gets boundaries to determine when the time offset is out of bounds
   //*! Currently, the time offset is compared to the start of the listmode scan.*/
@@ -116,7 +116,7 @@ public:
 private: 
 
   void do_synchronisation(CListModeData& listmode_data);
-  virtual bool is_synchronised() const;
+  bool is_synchronised() const override;
 
   double rel_time_to_polaris_time(const double time) const;
   double polaris_time_to_rel_time(const double time) const;

--- a/src/include/stir_experimental/motion/RigidObject3DTransformation.h
+++ b/src/include/stir_experimental/motion/RigidObject3DTransformation.h
@@ -132,12 +132,12 @@ public:
 
   //! Transform point 
   // can't return CartesianCoordinate3D<float> anymore because virtual function
-  virtual
+  
     BasicCoordinate<3,float>
-    transform_point(const BasicCoordinate<3,float>& point) const;
+    transform_point(const BasicCoordinate<3,float>& point) const override;
 
   //! Computes the jacobian for the transformation (which is always 1)
-  float jacobian(const BasicCoordinate<3,float>& point) const
+  float jacobian(const BasicCoordinate<3,float>& point) const override
     { return 1; }
 
   //! Transform bin from some projection data

--- a/src/include/stir_experimental/motion/TimeFrameMotion.h
+++ b/src/include/stir_experimental/motion/TimeFrameMotion.h
@@ -103,9 +103,9 @@ protected:
 
   
   //! parsing functions
-  virtual void set_defaults();
-  virtual void initialise_keymap();
-  virtual bool post_processing();
+  void set_defaults() override;
+  void initialise_keymap() override;
+  bool post_processing() override;
 
 
 private:

--- a/src/include/stir_experimental/phantoms/CylindersWithLineSource.h
+++ b/src/include/stir_experimental/phantoms/CylindersWithLineSource.h
@@ -3,8 +3,8 @@
     See STIR/LICENSE.txt for details
 */
 
-#include "stir_experimental/Shape/EllipsoidalCylinder.h"
-#include "stir_experimental/Shape/CombinedShape3D.h"
+#include "stir/Shape/EllipsoidalCylinder.h"
+#include "stir/Shape/CombinedShape3D.h"
 
   
 

--- a/src/include/stir_experimental/phantoms/Utah.h
+++ b/src/include/stir_experimental/phantoms/Utah.h
@@ -21,8 +21,8 @@
 
 */
 
-#include "stir/EllipsoidalCylinder.h"
-#include "stir/CombinedShape3D.h"
+#include "stir/Shape/EllipsoidalCylinder.h"
+#include "stir/Shape/CombinedShape3D.h"
 
 START_NAMESPACE_STIR
   

--- a/src/include/stir_experimental/recon_buildblock/BinNormalisationFromML2D.h
+++ b/src/include/stir_experimental/recon_buildblock/BinNormalisationFromML2D.h
@@ -77,19 +77,19 @@ public:
     This means \c multiply with the data in the projdata object 
     passed in the constructor. 
   */
-  virtual void apply(RelatedViewgrams<float>& viewgrams) const;
+  void apply(RelatedViewgrams<float>& viewgrams) const override;
 
   //! Undo the normalisation of some data
   /*! 
     This means \c divide with the data in the projdata object 
     passed in the constructor. 
   */
-  virtual void undo(RelatedViewgrams<float>& viewgrams) const;
+  void undo(RelatedViewgrams<float>& viewgrams) const override;
 
 private:
-  virtual void set_defaults();
-  virtual void initialise_keymap();
-  virtual bool post_processing();
+  void set_defaults() override;
+  void initialise_keymap() override;
+  bool post_processing() override;
 
   std::string normalisation_filename_prefix;
   bool do_block;

--- a/src/include/stir_experimental/recon_buildblock/BinNormalisationSinogramRescaling.h
+++ b/src/include/stir_experimental/recon_buildblock/BinNormalisationSinogramRescaling.h
@@ -61,13 +61,13 @@ public:
   /*! 
     This means \c multiply with the data in the scale factors file.
   */
-  virtual void apply(RelatedViewgrams<float>& viewgrams) const override;
+  void apply(RelatedViewgrams<float>& viewgrams) const override;
 
   //! Undo the normalisation of some data
   /*! 
     This means \c divide with the data in th scale factors file.
   */
-  virtual void undo(RelatedViewgrams<float>& viewgrams) const override;
+  void undo(RelatedViewgrams<float>& viewgrams) const override;
 
 private:
   // the proj data info used for obtaining axial position num, segment num
@@ -76,9 +76,9 @@ private:
   Array<3,float> rescaling_factors;
 
   // parsing stuff
-  virtual void set_defaults();
-  virtual void initialise_keymap();
-  virtual bool post_processing();
+  void set_defaults() override;
+  void initialise_keymap() override;
+  bool post_processing() override;
 
   std::string sinogram_rescaling_factors_filename;
 };

--- a/src/include/stir_experimental/recon_buildblock/BinNormalisationUsingProfile.h
+++ b/src/include/stir_experimental/recon_buildblock/BinNormalisationUsingProfile.h
@@ -35,19 +35,19 @@ public:
 
   BinNormalisationUsingProfile(const std::string& filename);
 
-  virtual void apply(RelatedViewgrams<float>& viewgrams) const override;
+  void apply(RelatedViewgrams<float>& viewgrams) const override;
 
-  virtual void undo(RelatedViewgrams<float>& viewgrams) const override;
+  void undo(RelatedViewgrams<float>& viewgrams) const override;
 
-  virtual float get_bin_efficiency(const Bin& bin) const override { return 1;}
+  float get_bin_efficiency(const Bin& bin) const override { return 1;}
  
 private:
   mutable Array<1,float> profile;
   std::string profile_filename;
 
-  virtual void set_defaults();
-  virtual void initialise_keymap();
-  virtual bool post_processing();
+  void set_defaults() override;
+  void initialise_keymap() override;
+  bool post_processing() override;
 };
 
 END_NAMESPACE_STIR

--- a/src/include/stir_experimental/recon_buildblock/DataSymmetriesForDensels_PET_CartesianGrid.h
+++ b/src/include/stir_experimental/recon_buildblock/DataSymmetriesForDensels_PET_CartesianGrid.h
@@ -29,6 +29,7 @@
 //#include "stir/VoxelsOnCartesianGrid.h"
 #include "stir/Densel.h"
 #include "stir/shared_ptr.h"
+#include <vector>
 
 START_NAMESPACE_STIR
 
@@ -54,13 +55,13 @@ public:
 					     const shared_ptr<const DiscretisedDensity<3,float> >& image_info_ptr);
 
 
-  virtual 
+  
 #ifndef STIR_NO_COVARIANT_RETURN_TYPES
     DataSymmetriesForDensels_PET_CartesianGrid *
 #else
     DataSymmetriesForDensels *
 #endif
-     clone() const;
+     clone() const override;
 
   bool
     operator ==(const DataSymmetriesForDensels_PET_CartesianGrid&) const;
@@ -73,16 +74,16 @@ public:
 #endif
 
   inline void
-    get_related_densels(vector<Densel>&, const Densel& b) const;
+    get_related_densels(std::vector<Densel>&, const Densel& b) const override;
 
   inline int
-    num_related_densels(const Densel& b) const;
+    num_related_densels(const Densel& b) const override;
 
   inline unique_ptr<SymmetryOperation>
-    find_symmetry_operation_from_basic_densel(Densel&) const;
+    find_symmetry_operation_from_basic_densel(Densel&) const override;
 
   inline bool
-    find_basic_densel(Densel& b) const;
+    find_basic_densel(Densel& b) const override;
   
 
   //! find out how many image planes there are for every scanner ring
@@ -121,7 +122,7 @@ private:
     cartesian_grid_info_ptr() const;
 #endif
 
-  virtual bool blindly_equals(const root_type * const) const;
+  bool blindly_equals(const root_type * const) const override;
   
   inline SymmetryOperation* 
     find_sym_op_general_densel( const int z, const int y, const int x) const;  

--- a/src/include/stir_experimental/recon_buildblock/DataSymmetriesForDensels_PET_CartesianGrid.inl
+++ b/src/include/stir_experimental/recon_buildblock/DataSymmetriesForDensels_PET_CartesianGrid.inl
@@ -153,7 +153,7 @@ num_related_densels(const Densel& b) const
 
 void
 DataSymmetriesForDensels_PET_CartesianGrid::
-get_related_densels(vector<Densel>& v, const Densel& d) const
+get_related_densels(std::vector<Densel>& v, const Densel& d) const
 {
 #ifndef NDEBUG
   {

--- a/src/include/stir_experimental/recon_buildblock/ParametricQuadraticPrior.h
+++ b/src/include/stir_experimental/recon_buildblock/ParametricQuadraticPrior.h
@@ -149,7 +149,7 @@ class ParametricQuadraticPrior:  public
   void set_kappa_sptr(const shared_ptr<TargetT >&);
 
   //! Has to be called before using this object
-  virtual Succeeded set_up(shared_ptr<const DiscretisedDensity<3,elemT> > const& target_sptr);
+  virtual Succeeded set_up(shared_ptr<const TargetT> const& target_sptr);
   
 protected:
   //! can be set during parsing to restrict the weights to the 2D case
@@ -159,7 +159,7 @@ protected:
      gradient is computed. The filename will be constructed by concatenating 
      gradient_filename_prefix and the counter.
   */
-  string gradient_filename_prefix;
+  std::string gradient_filename_prefix;
 
   //! penalty weights
   /*! 
@@ -171,7 +171,7 @@ protected:
   std::string kappa_filename; 	  //CHECK IF THERE IS A CONFILCT WHEN GIVING A KAPPA FILE...// THINK IF IT IS BETTER TO ESTIMATE KAPPA FILE IN THE CODE...
 
   //! Check that the prior is ready to be used
-  virtual void check(DiscretisedDensity<3,elemT> const& current_image_estimate) const;
+  virtual void check(TargetT const& current_image_estimate) const;
 
   virtual void set_defaults();
   virtual void initialise_keymap();

--- a/src/include/stir_experimental/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMeanAndDynamicProjData.h
+++ b/src/include/stir_experimental/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMeanAndDynamicProjData.h
@@ -94,7 +94,7 @@ public  RegisteredParsingObject<PoissonLogLikelihoodWithLinearModelForMeanAndDyn
 #endif // ChT::ToDo
  protected:
   //! Filename with input dynamic projection data
-  string _input_filename;
+  std::string _input_filename;
 
   //! points to the object for the total input dynamic projection data
   shared_ptr<DynamicProjData> _dyn_proj_data_sptr;
@@ -133,7 +133,7 @@ public  RegisteredParsingObject<PoissonLogLikelihoodWithLinearModelForMeanAndDyn
   
   /********************************/
   //! name of file in which additive projection data are stored
-  string _additive_dyn_proj_data_filename;
+  std::string _additive_dyn_proj_data_filename;
  //! points to the additive projection data
   /*! the projection data in this file is bin-wise added to forward projection results*/
   shared_ptr<DynamicProjData> _additive_dyn_proj_data_sptr;
@@ -144,7 +144,7 @@ public  RegisteredParsingObject<PoissonLogLikelihoodWithLinearModelForMeanAndDyn
   //! signals whether to zero the data in the end planes of the projection data
   bool _zero_seg0_end_planes;
 
-  bool actual_subsets_are_approximately_balanced(string& warning_message) const;
+  bool actual_subsets_are_approximately_balanced(std::string& warning_message) const;
 
   //! Sets defaults for parsing 
   /*! Resets \c sensitivity_filename and \c sensitivity_sptr and

--- a/src/include/stir_experimental/recon_buildblock/PostsmoothingForwardProjectorByBin.h
+++ b/src/include/stir_experimental/recon_buildblock/PostsmoothingForwardProjectorByBin.h
@@ -46,10 +46,10 @@ public:
   //! Stores all necessary geometric info
   /*! Note that the density_info_ptr is not stored in this object. It's only used to get some info on sizes etc.
   */
-  virtual void set_up(		 
+  void set_up(		 
 		      const shared_ptr<const ProjDataInfo>& proj_data_info_ptr,
                       const shared_ptr<const DiscretisedDensity<3,float> >& density_info_ptr // TODO should be Info only
-    );
+    ) override;
 
 
   PostsmoothingForwardProjectorByBin(
@@ -62,7 +62,7 @@ public:
   // It should get data related by at least those symmetries.
   // Otherwise, a run-time error will occur (unless the derived
   // class has other behaviour).
-  const DataSymmetriesForViewSegmentNumbers * get_symmetries_used() const;
+  const DataSymmetriesForViewSegmentNumbers * get_symmetries_used() const override;
 
 
 private:
@@ -85,15 +85,15 @@ private:
   /// Actual forward project where input has already been set.
   void actual_forward_project(RelatedViewgrams<float>&,
           const int min_axial_pos_num, const int max_axial_pos_num,
-          const int min_tangential_pos_num, const int max_tangential_pos_num);
+          const int min_tangential_pos_num, const int max_tangential_pos_num) override;
   void smooth(Viewgram<float>&,
               const int min_axial_pos_num, const int max_axial_pos_num,
               const int min_tangential_pos_num, const int max_tangential_pos_num) const;
 
 
-  virtual void set_defaults();
-  virtual void initialise_keymap();
-  virtual bool post_processing();
+  void set_defaults() override;
+  void initialise_keymap() override;
+  bool post_processing() override;
 };
 
 END_NAMESPACE_STIR

--- a/src/include/stir_experimental/recon_buildblock/ProjMatrixByBinSinglePhoton.h
+++ b/src/include/stir_experimental/recon_buildblock/ProjMatrixByBinSinglePhoton.h
@@ -55,10 +55,10 @@ public :
   //! Stores all necessary geometric info
   /*! Note that the density_info_ptr is not stored in this object. It's only used to get some info on sizes etc.
   */
-  virtual void set_up(		 
+  void set_up(		 
 		      const shared_ptr<const ProjDataInfo>& proj_data_info_ptr,
 		      const shared_ptr<const DiscretisedDensity<3,float> >& density_info_ptr // TODO should be Info only
-    );
+    ) override;
 
 private:
 
@@ -69,12 +69,12 @@ private:
   shared_ptr<const ProjDataInfo> proj_data_info_ptr;
 
 
-  virtual void 
+  void 
     calculate_proj_matrix_elems_for_one_bin(
-                                            ProjMatrixElemsForOneBin&) const;
+                                            ProjMatrixElemsForOneBin&) const override;
 
-   virtual void set_defaults();
-   virtual void initialise_keymap();
+   void set_defaults() override;
+   void initialise_keymap() override;
   
 };
 

--- a/src/include/stir_experimental/recon_buildblock/ProjMatrixByBinUsingSolidAngle.h
+++ b/src/include/stir_experimental/recon_buildblock/ProjMatrixByBinUsingSolidAngle.h
@@ -52,10 +52,10 @@ public :
   //! Stores all necessary geometric info
   /*! Note that the density_info_ptr is not stored in this object. It's only used to get some info on sizes etc.
   */
-  virtual void set_up(		 
+  void set_up(		 
 		      const shared_ptr<const ProjDataInfo>& proj_data_info_ptr,
 		      const shared_ptr<const DiscretisedDensity<3,float> >& density_info_ptr // TODO should be Info only
-    );
+    ) override;
 
 private:
 
@@ -69,12 +69,12 @@ private:
   shared_ptr<const ProjDataInfo> proj_data_info_ptr;
 
 
-  virtual void 
+  void 
     calculate_proj_matrix_elems_for_one_bin(
-                                            ProjMatrixElemsForOneBin&) const;
+                                            ProjMatrixElemsForOneBin&) const override;
 
-   virtual void set_defaults();
-   virtual void initialise_keymap();
+   void set_defaults() override;
+   void initialise_keymap() override;
   
 };
 

--- a/src/include/stir_experimental/recon_buildblock/ProjMatrixByBinWithPositronRange.h
+++ b/src/include/stir_experimental/recon_buildblock/ProjMatrixByBinWithPositronRange.h
@@ -52,10 +52,10 @@ public :
   //! Stores all necessary geometric info
   /*! Note that the density_info_ptr is not stored in this object. It's only used to get some info on sizes etc.
   */
-  virtual void set_up(		 
+  void set_up(		 
 		      const shared_ptr<const ProjDataInfo>& proj_data_info_ptr,
 		      const shared_ptr<const DiscretisedDensity<3,float> >& density_info_ptr // TODO should be Info only
-    );
+    ) override;
 
 private:
 
@@ -77,13 +77,13 @@ private:
   shared_ptr<const ProjDataInfo> proj_data_info_ptr;
 
 
-  virtual void 
+  void 
     calculate_proj_matrix_elems_for_one_bin(
-                                            ProjMatrixElemsForOneBin&) const;
+                                            ProjMatrixElemsForOneBin&) const override;
 
-   virtual void set_defaults();
-   virtual void initialise_keymap();
-   virtual bool post_processing();
+   void set_defaults() override;
+   void initialise_keymap() override;
+   bool post_processing() override;
   
 };
 

--- a/src/include/stir_experimental/recon_buildblock/ProjMatrixByDensel.h
+++ b/src/include/stir_experimental/recon_buildblock/ProjMatrixByDensel.h
@@ -50,7 +50,7 @@ class ProjMatrixByDensel :  public RegisteredObject<ProjMatrixByDensel>
 {
 public:
   
-  virtual ~ProjMatrixByDensel() {}
+  ~ProjMatrixByDensel() override {}
 
   //! To be called before any calculation is performed
   /*! Note that get_proj_matrix_elems_for_one_Densel() will expect objects of

--- a/src/include/stir_experimental/recon_buildblock/ProjMatrixByDenselOnCartesianGridUsingElement.h
+++ b/src/include/stir_experimental/recon_buildblock/ProjMatrixByDenselOnCartesianGridUsingElement.h
@@ -65,10 +65,10 @@ public :
 
       Currently, the proj_data_info_ptr argument is not used.
   */
-  virtual void set_up(		 
+  void set_up(		 
     const shared_ptr<const ProjDataInfo>& proj_data_info_ptr,
     const shared_ptr<const DiscretisedDensity<3,float> >& density_info_ptr // TODO should be Info only
-    );
+    ) override;
 
   //! this member computes a single element of the projection matrix
   /*! \param bin The bin-coordinates specifying the row of the projection matrix
@@ -103,7 +103,7 @@ protected:
       few assumptions.
       TODO more doc.
   */
-  void calculate_proj_matrix_elems_for_one_densel(ProjMatrixElemsForOneDensel &) const;
+  void calculate_proj_matrix_elems_for_one_densel(ProjMatrixElemsForOneDensel &) const override;
   
   
 };

--- a/src/include/stir_experimental/recon_buildblock/ProjMatrixByDenselUsingRayTracing.h
+++ b/src/include/stir_experimental/recon_buildblock/ProjMatrixByDenselUsingRayTracing.h
@@ -69,15 +69,15 @@ public :
   //! Stores all necessary geometric info
   /*! Note that the density_info_ptr is not stored in this object. It's only used to get some info on sizes etc.
   */
-  virtual void set_up(		 
+  void set_up(		 
     const shared_ptr<const ProjDataInfo>& proj_data_info_ptr,
     const shared_ptr<const DiscretisedDensity<3,float> >& density_info_ptr // TODO should be Info only
-    );
+    ) override;
 
-  virtual const  DataSymmetriesForDensels* get_symmetries_ptr() const;
+  const  DataSymmetriesForDensels* get_symmetries_ptr() const override;
 
-  virtual float 
-    get_element(const Bin&, const CartesianCoordinate3D<float>&) const;
+  float 
+    get_element(const Bin&, const CartesianCoordinate3D<float>&) const override;
 
 private:
   shared_ptr<DataSymmetriesForDensels_PET_CartesianGrid> symmetries_ptr;
@@ -103,9 +103,9 @@ private:
 
 
 
-   virtual void set_defaults();
-   virtual void initialise_keymap();
-   virtual bool post_processing();
+   void set_defaults() override;
+   void initialise_keymap() override;
+   bool post_processing() override;
   
 };
 

--- a/src/listmode_utilities/lm_fansums.cxx
+++ b/src/listmode_utilities/lm_fansums.cxx
@@ -68,9 +68,9 @@ public:
   void compute();
 private:
 
-  virtual void set_defaults();
-  virtual void initialise_keymap();
-  virtual bool post_processing();
+  void set_defaults() override;
+  void initialise_keymap() override;
+  bool post_processing() override;
   std::string input_filename;
   std::string output_filename_prefix;
   std::string frame_definition_filename;

--- a/src/recon_test/test_DataSymmetriesForBins_PET_CartesianGrid.cxx
+++ b/src/recon_test/test_DataSymmetriesForBins_PET_CartesianGrid.cxx
@@ -63,7 +63,7 @@ class DataSymmetriesForBins_PET_CartesianGridTests : public RunTests
 public:
   DataSymmetriesForBins_PET_CartesianGridTests(char const * template_proj_data_filename = 0);
 
-  void run_tests();
+  void run_tests() override;
 private:
   char const * template_proj_data_filename;
 

--- a/src/recon_test/test_FBP2D.cxx
+++ b/src/recon_test/test_FBP2D.cxx
@@ -33,13 +33,13 @@ public:
             const std::string & density_filename = "")
     : base_type(proj_data_filename, density_filename)
   {}
-  virtual ~TestFBP2D() {}
+  ~TestFBP2D() override {}
 
-  virtual std::unique_ptr<ProjDataInfo>
-    construct_default_proj_data_info_uptr() const;
+  std::unique_ptr<ProjDataInfo>
+    construct_default_proj_data_info_uptr() const override;
   
-  virtual void construct_reconstructor();
-  void run_tests();
+  void construct_reconstructor() override;
+  void run_tests() override;
 };
 
 std::unique_ptr<ProjDataInfo>

--- a/src/recon_test/test_FBP3DRP.cxx
+++ b/src/recon_test/test_FBP3DRP.cxx
@@ -33,13 +33,13 @@ public:
             const std::string & density_filename = "")
     : base_type(proj_data_filename, density_filename)
   {}
-  virtual ~TestFBP3DRP() {}
+  ~TestFBP3DRP() override {}
 
-  virtual std::unique_ptr<ProjDataInfo>
-    construct_default_proj_data_info_uptr() const;
+  std::unique_ptr<ProjDataInfo>
+    construct_default_proj_data_info_uptr() const override;
   
-  virtual void construct_reconstructor();
-  void run_tests();
+  void construct_reconstructor() override;
+  void run_tests() override;
 };
 
 std::unique_ptr<ProjDataInfo>

--- a/src/recon_test/test_OSMAPOSL.cxx
+++ b/src/recon_test/test_OSMAPOSL.cxx
@@ -34,15 +34,15 @@ public:
                const std::string & density_filename = "")
     : base_type(projector_pair_filename, proj_data_filename, density_filename)
   {}
-  virtual ~TestOSMAPOSL() {}
+  ~TestOSMAPOSL() override {}
 
   
-  virtual void construct_reconstructor();
+  void construct_reconstructor() override;
   OSMAPOSLReconstruction<target_type>&
   recon()
   { return dynamic_cast<OSMAPOSLReconstruction<target_type>& >(*this->_recon_sptr); }
 
-  void run_tests();
+  void run_tests() override;
 };
 
 

--- a/src/recon_test/test_PoissonLogLikelihoodWithLinearModelForMeanAndProjData.cxx
+++ b/src/recon_test/test_PoissonLogLikelihoodWithLinearModelForMeanAndProjData.cxx
@@ -94,7 +94,7 @@ public:
   typedef DiscretisedDensity<3,float> target_type;
   void construct_input_data(shared_ptr<target_type>& density_sptr);
 
-  void run_tests();
+  void run_tests() override;
 protected:
   char const * proj_data_filename;
   char const * density_filename;

--- a/src/recon_test/test_blocks_on_cylindrical_projectors.cxx
+++ b/src/recon_test/test_blocks_on_cylindrical_projectors.cxx
@@ -65,7 +65,7 @@ START_NAMESPACE_STIR
 class BlocksTests : public RunTests
 {
 public:
-  void run_tests();
+  void run_tests() override;
 
 private:
   template <class TProjDataInfo>

--- a/src/recon_test/test_data_processor_projectors.cxx
+++ b/src/recon_test/test_data_processor_projectors.cxx
@@ -32,9 +32,9 @@ public:
     //! Constructor that can take some input data to run the test with
     TestDataProcessorProjectors(const std::string &sinogram_filename, const float fwhm);
 
-    virtual ~TestDataProcessorProjectors() {}
+    ~TestDataProcessorProjectors() override {}
 
-    void run_tests();
+    void run_tests() override;
 protected:
     std::string _sinogram_filename;
     float _fwhm;

--- a/src/test/IO/test_IO_DiscretisedDensity.cxx
+++ b/src/test/IO/test_IO_DiscretisedDensity.cxx
@@ -67,9 +67,9 @@ public:
 
 protected:
 
-    void create_image();
-    void read_image();
-    void check_result();
+    void create_image() override;
+    void read_image() override;
+    void check_result() override;
 };
 
 void IOTests_DiscretisedDensity::create_image()

--- a/src/test/IO/test_IO_DynamicDiscretisedDensity.cxx
+++ b/src/test/IO/test_IO_DynamicDiscretisedDensity.cxx
@@ -68,8 +68,8 @@ public:
 
 protected:
 
-    void create_image();
-    void check_result();
+    void create_image() override;
+    void check_result() override;
 };
 
 void IOTests_DynamicDiscretisedDensity::create_image()

--- a/src/test/IO/test_IO_ITKMulticomponent.cxx
+++ b/src/test/IO/test_IO_ITKMulticomponent.cxx
@@ -38,7 +38,7 @@ public:
     explicit IOTests_ITKMulticomponent(const std::string &multi) :
         _multi(multi) {}
 
-    void run_tests();
+    void run_tests() override;
 
 protected:
 

--- a/src/test/IO/test_IO_ParametricDiscretisedDensity.cxx
+++ b/src/test/IO/test_IO_ParametricDiscretisedDensity.cxx
@@ -68,8 +68,8 @@ public:
     explicit IOTests_ParametricDiscretisedDensity(istream& in) : IOTests(in) {}
 
 protected:
-    void create_image();
-    void check_result();
+    void create_image() override;
+    void check_result() override;
 };
 void IOTests_ParametricDiscretisedDensity::create_image()
 {

--- a/src/test/modelling/test_ParametricDiscretisedDensity.cxx
+++ b/src/test/modelling/test_ParametricDiscretisedDensity.cxx
@@ -56,7 +56,7 @@ class ParametricDiscretisedDensityTests : public RunTests
 public:
   ParametricDiscretisedDensityTests() 
   {}
-  void run_tests();
+  void run_tests() override;
   //private:
 };
 

--- a/src/test/modelling/test_modelling.cxx
+++ b/src/test/modelling/test_modelling.cxx
@@ -38,7 +38,7 @@ class modellingTests : public RunTests
 public:
   explicit modellingTests(const std::string& directory);
 
-  void run_tests();
+  void run_tests() override;
 private:
   //istream& in;
   std::string directory;

--- a/src/test/numerics/test_BSplines.cxx
+++ b/src/test/numerics/test_BSplines.cxx
@@ -44,7 +44,7 @@ namespace BSpline {
   public:
     BSplines_Tests() 
     {}
-    void run_tests();
+    void run_tests() override;
   private:  
     template <class elemT>
     bool check_at_sample_points(const std::vector<elemT>& v,

--- a/src/test/numerics/test_BSplinesRegularGrid.cxx
+++ b/src/test/numerics/test_BSplinesRegularGrid.cxx
@@ -41,7 +41,7 @@ namespace BSpline {
   public:
     BSplinesRegularGrid_Tests() 
     {}
-    void run_tests();
+    void run_tests() override;
   private:  
     template <class elemT>
     bool check_at_sample_points(const Array<2,elemT>& v,

--- a/src/test/numerics/test_BSplinesRegularGrid1D.cxx
+++ b/src/test/numerics/test_BSplinesRegularGrid1D.cxx
@@ -36,7 +36,7 @@ namespace BSpline {
   public:
     BSplinesRegularGrid1D_Tests() 
     {}
-    void run_tests();
+    void run_tests() override;
   private:  
     template <class elemT>
     bool check_at_sample_points(const Array<1,elemT>& v,

--- a/src/test/numerics/test_Fourier.cxx
+++ b/src/test/numerics/test_Fourier.cxx
@@ -66,7 +66,7 @@ class FourierTests : public RunTests
 public:
   FourierTests() 
   {}
-  void run_tests();
+  void run_tests() override;
 private:
   template <int num_dimensions>
   void test_single_dimension(const IndexRange<num_dimensions>& index_range);

--- a/src/test/numerics/test_IR_filters.cxx
+++ b/src/test/numerics/test_IR_filters.cxx
@@ -38,7 +38,7 @@ class IR_filterTests : public RunTests
 public:
   IR_filterTests() 
   {}
-  void run_tests();
+  void run_tests() override;
 private:
   //istream& in;
 };

--- a/src/test/numerics/test_erf.cxx
+++ b/src/test/numerics/test_erf.cxx
@@ -32,7 +32,7 @@ class erfTests : public RunTests
 public:
   erfTests() 
   {}
-  void run_tests();
+  void run_tests() override;
 
   /*!\brief Tests STIR's erf(x) function against known values */
   void test_stir_erf();

--- a/src/test/numerics/test_integrate_discrete_function.cxx
+++ b/src/test/numerics/test_integrate_discrete_function.cxx
@@ -35,7 +35,7 @@ class integrate_discrete_functionTests : public RunTests
 public:
   integrate_discrete_functionTests() 
   {}
-  void run_tests();
+  void run_tests() override;
 };
 
 

--- a/src/test/numerics/test_matrices.cxx
+++ b/src/test/numerics/test_matrices.cxx
@@ -42,7 +42,7 @@ START_NAMESPACE_STIR
 class MatrixTests : public RunTests
 {
 public:
-  void run_tests();
+  void run_tests() override;
 private:
   void run_tests_1D();
   void run_tests_2D();

--- a/src/test/numerics/test_overlap_interpolate.cxx
+++ b/src/test/numerics/test_overlap_interpolate.cxx
@@ -36,7 +36,7 @@ START_NAMESPACE_STIR
 class overlap_interpolateTests : public RunTests
 {
 public:
-  void run_tests();
+  void run_tests() override;
 private:
 #ifndef STIR_OVERLAP_NORMALISATION
   template <class ValueT, class BoundaryT>

--- a/src/test/test_ArcCorrection.cxx
+++ b/src/test/test_ArcCorrection.cxx
@@ -52,7 +52,7 @@ START_NAMESPACE_STIR
 class ArcCorrectionTests: public RunTests
 {
 public:
-  void run_tests();
+  void run_tests() override;
   void run_tests_tof();
 protected:
   void run_tests_for_specific_proj_data_info(const ArcCorrection&);

--- a/src/test/test_Array.cxx
+++ b/src/test/test_Array.cxx
@@ -271,7 +271,7 @@ private:
   }
 
 public:
-  void run_tests();
+  void run_tests() override;
 };
 
 

--- a/src/test/test_ArrayFilter.cxx
+++ b/src/test/test_ArrayFilter.cxx
@@ -50,7 +50,7 @@ START_NAMESPACE_STIR
 class ArrayFilterTests : public RunTests
 {
 public:
-  void run_tests();
+  void run_tests() override;
 private:
 
 

--- a/src/test/test_ByteOrder.cxx
+++ b/src/test/test_ByteOrder.cxx
@@ -39,7 +39,7 @@ START_NAMESPACE_STIR
 class ByteOrderTests : public RunTests
 {
 public:
-  void run_tests();
+  void run_tests() override;
 };
 
 void

--- a/src/test/test_DateTime.cxx
+++ b/src/test/test_DateTime.cxx
@@ -35,7 +35,7 @@ class DateTimeTest : public RunTests
 {
   void check_round_trip(const double secs, const double tz_offset, const std::string& str);
 public:
-  void run_tests();
+  void run_tests() override;
 };
 
 

--- a/src/test/test_DetectionPosition.cxx
+++ b/src/test/test_DetectionPosition.cxx
@@ -32,7 +32,7 @@ START_NAMESPACE_STIR
 class DetectionPosition_Tests : public RunTests
 {
 public:
-  void run_tests();
+  void run_tests() override;
 };
 
 

--- a/src/test/test_DetectorCoordinateMap.cxx
+++ b/src/test/test_DetectorCoordinateMap.cxx
@@ -55,7 +55,7 @@ START_NAMESPACE_STIR
 class DetectionPosMapTests: public RunTests
 {
 public:
-  void run_tests();
+  void run_tests() override;
   float calculate_angle_within_half_bucket(const shared_ptr<Scanner> scanner_ptr,
                                            const shared_ptr<ProjDataInfoBlocksOnCylindricalNoArcCorr> proj_data_info_ptr);
 private:

--- a/src/test/test_DynamicDiscretisedDensity.cxx
+++ b/src/test/test_DynamicDiscretisedDensity.cxx
@@ -47,7 +47,7 @@ START_NAMESPACE_STIR
   public:
     DynamicDiscretisedDensityTests() 
     {}
-    void run_tests();
+    void run_tests() override;
     //private:
   };
 

--- a/src/test/test_GeneralisedPoissonNoiseGenerator.cxx
+++ b/src/test/test_GeneralisedPoissonNoiseGenerator.cxx
@@ -41,7 +41,7 @@ private:
   run_one_test(const int size, const float mu, const float scaling_factor, const bool preserve_mean);
     
 public:
-  void run_tests();
+  void run_tests() override;
 };
 
 void

--- a/src/test/test_ImagingModality.cxx
+++ b/src/test/test_ImagingModality.cxx
@@ -37,7 +37,7 @@ START_NAMESPACE_STIR
 class ImagingModalityTests : public RunTests
 {
 public:
-  void run_tests();
+  void run_tests() override;
 };
 
 void

--- a/src/test/test_IndexRange.cxx
+++ b/src/test/test_IndexRange.cxx
@@ -39,7 +39,7 @@ START_NAMESPACE_STIR
 class IndexRange_Tests : public RunTests
 {
 public:
-  void run_tests();
+  void run_tests() override;
 };
 
 

--- a/src/test/test_KeyParser.cxx
+++ b/src/test/test_KeyParser.cxx
@@ -63,7 +63,7 @@ class KeyParserTests : public RunTests
 {
 public:
   template <typename elemT> void run_tests_one_type();
-  void run_tests();
+  void run_tests() override;
 };
 
 void

--- a/src/test/test_ML_norm.cxx
+++ b/src/test/test_ML_norm.cxx
@@ -43,7 +43,7 @@ START_NAMESPACE_STIR
 class ML_normTests: public RunTests
 {
 public:
-  void run_tests();
+  void run_tests() override;
 protected:  
   template <class TProjDataInfo>
   void test_proj_data_info(shared_ptr<TProjDataInfo> proj_data_info_sptr);

--- a/src/test/test_NestedIterator.cxx
+++ b/src/test/test_NestedIterator.cxx
@@ -41,7 +41,7 @@ class NestedIteratorTests : public RunTests
 private:
 
 public:
-  void run_tests();
+  void run_tests() override;
 };
 
 

--- a/src/test/test_OutputFileFormat.cxx
+++ b/src/test/test_OutputFileFormat.cxx
@@ -80,7 +80,7 @@ class OutputFileFormatTests : public RunTests
 public:
   OutputFileFormatTests(istream& in) ;
 
-  void run_tests();
+  void run_tests() override;
 private:
   istream& in;
   shared_ptr<OutputFileFormat<DiscretisedDensity<3,float> > > output_file_format_ptr;

--- a/src/test/test_ROIs.cxx
+++ b/src/test/test_ROIs.cxx
@@ -62,7 +62,7 @@ START_NAMESPACE_STIR
 class ROITests : public RunTests
 {
 public:
-  void run_tests();
+  void run_tests() override;
 private:
   //! Run a series of tests for a shape
   /*!

--- a/src/test/test_Scanner.cxx
+++ b/src/test/test_Scanner.cxx
@@ -47,7 +47,7 @@ START_NAMESPACE_STIR
 class ScannerTests: public RunTests
 {
 public:  
-  void run_tests();
+  void run_tests() override;
 private:
   void test_scanner(const Scanner&);
 };

--- a/src/test/test_ScatterSimulation.cxx
+++ b/src/test/test_ScatterSimulation.cxx
@@ -59,7 +59,7 @@ class ScatterSimulationTests: public RunTests
 {
 public:  
     bool write_output;
-    void run_tests();
+    void run_tests() override;
 private:
 
     //! Load a ProjDataInfo downsample and perform some consistency checks.

--- a/src/test/test_SeparableGaussianArrayFilter.cxx
+++ b/src/test/test_SeparableGaussianArrayFilter.cxx
@@ -46,7 +46,7 @@ START_NAMESPACE_STIR
 class SeparableGaussianArrayFilterTests : public RunTests
 {
 public:
-  void run_tests();
+  void run_tests() override;
 private:
   //! test one case (overwrites contents of \c test)
   void test_one(Array<num_dimensions, float>&,

--- a/src/test/test_SeparableMetzArrayFilter.cxx
+++ b/src/test/test_SeparableMetzArrayFilter.cxx
@@ -42,7 +42,7 @@ START_NAMESPACE_STIR
 class SeparableMetzArrayFilterTests : public RunTests
 {
 public:
-  void run_tests();
+  void run_tests() override;
 private:
 
 

--- a/src/test/test_VectorWithOffset.cxx
+++ b/src/test/test_VectorWithOffset.cxx
@@ -52,7 +52,7 @@ START_NAMESPACE_STIR
 class VectorWithOffsetTests : public RunTests
 {
 public:
-  void run_tests();
+  void run_tests() override;
 };
 
 void

--- a/src/test/test_VoxelsOnCartesianGrid.cxx
+++ b/src/test/test_VoxelsOnCartesianGrid.cxx
@@ -50,7 +50,7 @@ START_NAMESPACE_STIR
 class VoxelsOnCartesianGridTests : public RunTests
 {
 public:
-  void run_tests();
+  void run_tests() override;
 };
 
 

--- a/src/test/test_convert_array.cxx
+++ b/src/test/test_convert_array.cxx
@@ -36,7 +36,7 @@ START_NAMESPACE_STIR
 class convert_array_Tests : public RunTests
 {
 public:
-  void run_tests();
+  void run_tests() override;
 };
 
 

--- a/src/test/test_coordinates.cxx
+++ b/src/test/test_coordinates.cxx
@@ -44,7 +44,7 @@ START_NAMESPACE_STIR
 class coordinateTests : public RunTests
 {
 public:
-  void run_tests();
+  void run_tests() override;
 };
 
 

--- a/src/test/test_export_array.cxx
+++ b/src/test/test_export_array.cxx
@@ -42,7 +42,7 @@ START_NAMESPACE_STIR
 class ExportArrayTests : public RunTests
 {
 public:
-    void run_tests();
+    void run_tests() override;
 
 protected:
     void test_static_data();

--- a/src/test/test_filename_functions.cxx
+++ b/src/test/test_filename_functions.cxx
@@ -36,7 +36,7 @@ START_NAMESPACE_STIR
 class FilenameTests : public RunTests
 {
 public:
-  void run_tests();
+  void run_tests() override;
 };
 
 void FilenameTests::run_tests()

--- a/src/test/test_find_fwhm_in_image.cxx
+++ b/src/test/test_find_fwhm_in_image.cxx
@@ -50,7 +50,7 @@ class find_fwhm_in_imageTests : public RunTests
 public:
   find_fwhm_in_imageTests() 
   {}
-  void run_tests();
+  void run_tests() override;
 private:
   //istream& in;
 };

--- a/src/test/test_interpolate_projdata.cxx
+++ b/src/test/test_interpolate_projdata.cxx
@@ -48,7 +48,7 @@ START_NAMESPACE_STIR
 class InterpolationTests : public RunTests
 {
 public:
-  void run_tests();
+  void run_tests() override;
 
 private:
   void scatter_interpolation_test_blocks();

--- a/src/test/test_linear_regression.cxx
+++ b/src/test/test_linear_regression.cxx
@@ -75,7 +75,7 @@ public:
     : in(in)
   {}
 
-  void run_tests();
+  void run_tests() override;
 private:
   istream& in;
 };

--- a/src/test/test_multiple_proj_data.cxx
+++ b/src/test/test_multiple_proj_data.cxx
@@ -52,7 +52,7 @@ START_NAMESPACE_STIR
 class MultipleProjDataTests: public RunTests
 {
 public:
-  void run_tests();
+  void run_tests() override;
   void set_multi_file(const std::string &multi_file) { _multi_file = multi_file; }
 private:
   std::string _multi_file;

--- a/src/test/test_proj_data.cxx
+++ b/src/test/test_proj_data.cxx
@@ -46,7 +46,7 @@ START_NAMESPACE_STIR
 class ProjDataTests: public RunTests
 {
 public:
-  void run_tests();
+  void run_tests() override;
 private:
   void run_tests_on_proj_data(ProjData&);
   void run_tests_in_memory_only(ProjDataInMemory&);

--- a/src/test/test_proj_data_info.cxx
+++ b/src/test/test_proj_data_info.cxx
@@ -943,7 +943,7 @@ ProjDataInfoTests::run_lor_get_s_test()
 class ProjDataInfoCylindricalArcCorrTests : public ProjDataInfoCylindricalTests
 {
 public:
-  void run_tests();
+  void run_tests() override;
 };
 
 void
@@ -1115,7 +1115,7 @@ ProjDataInfoCylindricalArcCorrTests::run_tests()
 class ProjDataInfoCylindricalNoArcCorrTests : public ProjDataInfoCylindricalTests
 {
 public:
-  void run_tests();
+  void run_tests() override;
 
 private:
   void test_proj_data_info(ProjDataInfoCylindricalNoArcCorr& proj_data_info);

--- a/src/test/test_proj_data_info_subsets.cxx
+++ b/src/test/test_proj_data_info_subsets.cxx
@@ -63,9 +63,9 @@ public:
   //! Constructor that can take some input data to run the test with
   TestProjDataInfoSubsets(const std::string& sinogram_filename);
 
-  virtual ~TestProjDataInfoSubsets() {}
+  ~TestProjDataInfoSubsets() override {}
 
-  void run_tests();
+  void run_tests() override;
   void run_tests(
                  const std::shared_ptr<ProjData>& proj_data_sptr, const std::shared_ptr<const VoxelsOnCartesianGrid<float>>& test_image_sptr);
 

--- a/src/test/test_proj_data_maths.cxx
+++ b/src/test/test_proj_data_maths.cxx
@@ -39,7 +39,7 @@ START_NAMESPACE_STIR
 class ProjDataInMemoryTests: public RunTests
 {
 public:
-  void run_tests();
+  void run_tests() override;
 private:
   void run_tests(shared_ptr<const ExamInfo> exam_info_sptr, shared_ptr<const ProjDataInfo> proj_data_info_sptr);
 };

--- a/src/test/test_radionuclide.cxx
+++ b/src/test/test_radionuclide.cxx
@@ -34,7 +34,7 @@ START_NAMESPACE_STIR
 class RadionuclideTest : public RunTests
 {
 public:
-  void run_tests();
+  void run_tests() override;
 };
 
 

--- a/src/test/test_stir_math.cxx
+++ b/src/test/test_stir_math.cxx
@@ -58,7 +58,7 @@ public:
     : stir_math_executable(stir_math_executable)
   {}
   
-  void run_tests();
+  void run_tests() override;
 private:
   string stir_math_executable;
   //! returns true if it ran it successfully

--- a/src/test/test_time_of_flight.cxx
+++ b/src/test/test_time_of_flight.cxx
@@ -74,7 +74,7 @@ public:
 class TOF_Tests : public RunTests
 {
 public:
-    void run_tests();
+    void run_tests() override;
 
 private:
 

--- a/src/test/test_warp_image.cxx
+++ b/src/test/test_warp_image.cxx
@@ -39,7 +39,7 @@ START_NAMESPACE_STIR
 class warp_imageTests : public RunTests
 {
 public:
-  void run_tests();
+  void run_tests() override;
 };
 
 void

--- a/src/test/test_zoom_image.cxx
+++ b/src/test/test_zoom_image.cxx
@@ -40,7 +40,7 @@ START_NAMESPACE_STIR
 class zoom_imageTests : public RunTests
 {
 public:
-  void run_tests();
+  void run_tests() override;
 };
 
 

--- a/src/utilities/correct_projdata.cxx
+++ b/src/utilities/correct_projdata.cxx
@@ -202,9 +202,9 @@ public:
   bool do_arc_correction;
 private:
 
-  virtual void set_defaults();
-  virtual void initialise_keymap();
-  virtual bool post_processing();
+  void set_defaults() override;
+  void initialise_keymap() override;
+  bool post_processing() override;
   string input_filename;
   string output_filename;
   string scatter_projdata_filename;

--- a/src/utilities/find_recovery_coefficients_in_image_quality_phantom_nema_nu4.cxx
+++ b/src/utilities/find_recovery_coefficients_in_image_quality_phantom_nema_nu4.cxx
@@ -70,8 +70,8 @@ private:
   std::string input_filename;
   std::string output_filename;
 
-  void initialise_keymap();
-  void set_defaults();
+  void initialise_keymap() override;
+  void set_defaults() override;
 };
 
 void FindRecoveryCoefficient::

--- a/src/utilities/list_ROI_values.cxx
+++ b/src/utilities/list_ROI_values.cxx
@@ -68,7 +68,7 @@ public:
   ROIValuesParameters();
   virtual void set_defaults();
   virtual void initialise_keymap();
-  virtual bool post_processing();
+  bool post_processing() override;
   std::vector<shared_ptr<Shape3D> > shape_ptrs;
   std::vector<std::string> shape_names;
   CartesianCoordinate3D<int> num_samples;

--- a/src/utilities/rebin_projdata.cxx
+++ b/src/utilities/rebin_projdata.cxx
@@ -53,9 +53,9 @@ public:
   shared_ptr<ProjDataRebinning> proj_data_rebinning_sptr;
 private:
 
-  virtual void set_defaults();
-  virtual void initialise_keymap();
-  virtual bool post_processing();
+  void set_defaults() override;
+  void initialise_keymap() override;
+  bool post_processing() override;
   
 };
 


### PR DESCRIPTION
following prescription of #857 after getting rid of old compiler work-arounds