### PR TITLE
Enabling to read TOF-bin order from Interfile Header

### DIFF
--- a/documentation/release_6.1.htm
+++ b/documentation/release_6.1.htm
@@ -52,6 +52,7 @@ improvements to the documentation.
 <ul>
 <li>
   Add TOF capability of the parallelproj projector (see <a href=https://github.com/UCL/STIR/pull/1356>PR #1356</a>)
+  Read TOF bin order from interfile header (see <a href=https://github.com/UCL/STIR/pull/1389> PR #1389</a>)
 </li>
 </ul>
 

--- a/src/IO/InterfileHeader.cxx
+++ b/src/IO/InterfileHeader.cxx
@@ -1030,9 +1030,9 @@ InterfilePDFSHeader::post_processing()
     {
       if (this->timing_poss_sequence.size() != static_cast<std::vector<int>::size_type>(this->num_timing_poss))
         {
-          warning("Inconsistent number of TOF bins (" + std::to_string(this->num_timing_poss) +
-          ") and size of the 'TOF bin order' list (" + std::to_string(this->timing_poss_sequence.size()) + ").");
-          //return true;
+          warning("Inconsistent number of TOF bins (" + std::to_string(this->num_timing_poss)
+                  + ") and size of the 'TOF bin order' list (" + std::to_string(this->timing_poss_sequence.size()) + ").");
+          // return true;
         }
     }
 

--- a/src/IO/InterfileHeader.cxx
+++ b/src/IO/InterfileHeader.cxx
@@ -617,6 +617,8 @@ InterfilePDFSHeader::InterfilePDFSHeader()
 #if STIR_VERSION < 070000
   add_alias_key("Maximum number of (unmashed) TOF time bins", "Number of TOF time bins");
 #endif
+  timing_poss_sequence.clear();
+  add_key("TOF bin order", &timing_poss_sequence);
   size_of_timing_pos = -1.f;
   add_key("Size of unmashed TOF time bins (ps)", &size_of_timing_pos);
 #if STIR_VERSION < 070000
@@ -701,7 +703,7 @@ InterfilePDFSHeader::find_storage_order()
       // TOF
       if (matrix_labels[4] == "timing positions")
         {
-          num_timing_poss = matrix_size[4][0];
+          this->num_timing_poss = matrix_size[4][0];
         }
       else
         {
@@ -1022,6 +1024,17 @@ InterfilePDFSHeader::post_processing()
     << std::accumulate(num_rings_per_segment.begin(), num_rings_per_segment.end(), 0)
     << endl;
 #endif
+
+  // TOF order
+  if (this->timing_poss_sequence.size())
+    {
+      if (this->timing_poss_sequence.size() != static_cast<std::vector<int>::size_type>(this->num_timing_poss))
+        {
+          warning("Inconsistent number of TOF bins (" + std::to_string(this->num_timing_poss) +
+          ") and size of the 'TOF bin order' list (" + std::to_string(this->timing_poss_sequence.size()) + ").");
+          //return true;
+        }
+    }
 
   // handle scanner
 


### PR DESCRIPTION
<!-- Fill in most of this text, and delete what is not appropriate.
Please read and adhere to the [contribution guidelines](https://github.com/UCL/STIR/blob/master/CONTRIBUTING.md).
Did you sign the STIR Contribution License Agreement?
-->

## Changes in this pull request
With this change, the "TOF bin order" is assigned from the keyword in Interfile Headers.

## Testing performed


## Related issues
<!-- Use keywords such as "fixes", "closes", see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->


## Checklist before requesting a review
<!--Put an x between the [] when completed. Delete a line if not applicable. -->
  - [x] I have performed a self-review of my code
  - [] I have added docstrings/doxygen in line with the guidance in the developer guide
  - [] I have implemented unit tests that cover any new or modified functionality (if applicable)
  - [x] The code builds and runs on my machine
  - [] `documentation/release_XXX.md` has been updated with any functionality change (if applicable)
