### PR TITLE
BlocksOnCylindrical refactor and add axial bucket gaps

### DIFF
--- a/src/include/stir/GeometryBlocksOnCylindrical.h
+++ b/src/include/stir/GeometryBlocksOnCylindrical.h
@@ -52,6 +52,45 @@ class GeometryBlocksOnCylindrical : public DetectorCoordinateMap
 public:
   GeometryBlocksOnCylindrical(const Scanner& scanner);
 
+  //! Calculates the transaxial coordinate of a crystal given a scanner and the crystal's indices
+  static int
+  get_transaxial_coord(const Scanner& scanner, int transaxial_bucket_num, int transaxial_block_num, int transaxial_crystal_num);
+
+  //! Calculates the axial coordinate of a crystal given a scanner and the crystal's indices
+  static int get_axial_coord(const Scanner& scanner, int axial_bucket_num, int axial_block_num, int axial_crystal_num);
+
+  //! Calculates the transaxial translation of a crystal given a scanner and the crystal's indices
+  static float
+  get_crystal_in_bucket_transaxial_translation(const Scanner& scanner, int transaxial_block_num, int transaxial_crystal_num);
+
+  //! Calculates the axial translation of a crystal given a scanner and the crystal's indices
+  static float get_axial_translation(const Scanner& scanner, int axial_bucket_num, int axial_block_num, int axial_crystal_num);
+
+  //! Calculate the initial axial z offset to center the scanner on 0,0,0
+  static float get_initial_axial_z_offset(const Scanner& scanner);
+
+  //! Calculate the initial transaxial x offset to center the scanner on 0,0,0
+  static float get_initial_axial_x_offset_for_each_bucket(const Scanner& scanner);
+
+  static float get_csi_minus_csi_gaps(const Scanner& scanner)
+  {
+    //! Calculate the CSI, angle covered by half a bucket
+    // 2 * PI / num_transaxial_buckets / 2 (simplified)
+    float csi = _PI / scanner.get_num_transaxial_buckets(); // TODO, this assumes 1 transaxial bucket per angle
+
+    // The difference between the transaxial block spacing and the sum of all transaxial crystal spacing's in the block
+    float trans_blocks_gap = scanner.get_transaxial_block_spacing()
+                             - scanner.get_num_transaxial_crystals_per_block() * scanner.get_transaxial_crystal_spacing();
+    // Calculate the angle covered by the gaps between the blocks
+    float csi_gaps
+        = 2 * csi * (scanner.get_transaxial_crystal_spacing() / 2 + trans_blocks_gap) / scanner.get_transaxial_block_spacing();
+    return csi - csi_gaps;
+  };
+
+  //!
+  CartesianCoordinate3D<float> calculate_crystal_rotation(const CartesianCoordinate3D<float>& crystal_position,
+                                                          const float alpha) const;
+
 private:
   //! Get rotation matrix for a given angle around z axis
   stir::Array<2, float> get_rotation_matrix(float alpha) const;

--- a/src/include/stir/Scanner.h
+++ b/src/include/stir/Scanner.h
@@ -5,7 +5,8 @@
     Copyright (C) 2016, University of Hull
     Copyright (C) 2016, 2019, 2021, 2023 UCL
     Copyright 2017 ETH Zurich, Institute of Particle Physics and Astrophysics
-    Copyright (C 2017-2018, University of Leeds
+    Copyright (C) 2017-2018, University of Leeds
+    Copyright (C) 2024, Prescient Imaging
     This file is part of STIR.
 
     SPDX-License-Identifier: Apache-2.0 AND License-ref-PARAPET-license
@@ -28,6 +29,7 @@
   \author Palak Wadhwa
   \author PARAPET project
   \author Parisa Khateri
+  \author Robert Twyman Skelly
 
 */
 #ifndef __stir_buildblock_SCANNER_H__
@@ -332,7 +334,7 @@ public:
       algorithm. It uses the same coordinate system as ProjDataInfo::get_phi().
   */
   inline float get_intrinsic_azimuthal_tilt() const;
-  //! \name Info on crystals per block etc.
+  //! \name Info on crystals per block/bucket etc.
   //@{
   //! get number of transaxial blocks per bucket
   inline int get_num_transaxial_blocks_per_bucket() const;
@@ -348,6 +350,10 @@ public:
   inline int get_num_axial_crystals_per_bucket() const;
   //! get number of crystal layers (for DOI)
   inline int get_num_detector_layers() const;
+  /*! With virtual crystals between blocks, it will miss the end virtual crystals. This method takes this into account.*/
+  inline int get_num_axial_crystals() const;
+  //! get the number of transaxial crystals
+  inline int get_num_transaxial_crystals() const;
   //! get number of axial blocks
   inline int get_num_axial_blocks() const;
   //! get number of axial blocks
@@ -416,13 +422,13 @@ public:
   //! get scanner geometry
   /*! \see set_scanner_geometry */
   inline std::string get_scanner_geometry() const;
-  //! get crystal spacing in axial direction
+  //! get crystal spacing/pitch in axial direction in mm
   inline float get_axial_crystal_spacing() const;
-  //! get crystal spacing in transaxial direction
+  //! get crystal spacing/pitch in transaxial direction in mm
   inline float get_transaxial_crystal_spacing() const;
-  //! get block spacing in axial direction
+  //! get block spacing/pitch in axial direction in mm
   inline float get_axial_block_spacing() const;
-  //! get block spacing in transaxial direction
+  //! get block spacing/pitch in transaxial direction in mm
   inline float get_transaxial_block_spacing() const;
   //@} (end of get block geometry info)
 
@@ -478,7 +484,7 @@ public:
   inline void set_default_bin_size(const float& new_size);
   //! in degrees
   inline void set_intrinsic_azimuthal_tilt(const float new_tilt);
-  //! \name Info on crystals per block etc.
+  //! \name Info on crystals per block/bucket etc.
   //@{
   //! set number of transaxial blocks per bucket
   inline void set_num_transaxial_blocks_per_bucket(const int& new_num);

--- a/src/include/stir/Scanner.inl
+++ b/src/include/stir/Scanner.inl
@@ -22,6 +22,7 @@
   \author Long Zhang (set*() functions)
   \author PARAPET project
   \author Parisa Khateri
+  \author Robert Twyman Skelly
 
 
 */
@@ -143,13 +144,13 @@ Scanner::get_num_transaxial_crystals_per_block() const
 int
 Scanner::get_num_axial_crystals_per_bucket() const
 {
-  return get_num_axial_blocks_per_bucket() * get_num_axial_crystals_per_block();
+  return get_num_axial_crystals_per_block() * get_num_axial_blocks_per_bucket();
 }
 
 int
 Scanner::get_num_transaxial_crystals_per_bucket() const
 {
-  return get_num_transaxial_blocks_per_bucket() * get_num_transaxial_crystals_per_block();
+  return get_num_transaxial_crystals_per_block() * get_num_transaxial_blocks_per_bucket();
 }
 
 int
@@ -159,29 +160,41 @@ Scanner::get_num_detector_layers() const
 }
 
 int
+Scanner::get_num_axial_crystals() const
+{
+  // when using virtual crystals between blocks, there won't be any at the end, so we
+  // need to take this into account.
+  return num_rings + get_num_virtual_axial_crystals_per_block();
+}
+
+int
+Scanner::get_num_transaxial_crystals() const
+{
+  return num_detectors_per_ring;
+}
+
+int
 Scanner::get_num_axial_blocks() const
 {
-  // when using virtual crystals between blocks, there won't be one at the end, so we
-  // need to take this into account.
-  return (num_rings + get_num_virtual_axial_crystals_per_block()) / num_axial_crystals_per_block;
+  return get_num_axial_crystals() / get_num_axial_crystals_per_block();
 }
 
 int
 Scanner::get_num_transaxial_blocks() const
 {
-  return num_detectors_per_ring / num_transaxial_crystals_per_block;
+  return get_num_transaxial_crystals() / get_num_transaxial_crystals_per_block();
 }
 
 int
 Scanner::get_num_axial_buckets() const
 {
-  return get_num_axial_blocks() / num_axial_blocks_per_bucket;
+  return get_num_axial_blocks() / get_num_axial_blocks_per_bucket();
 }
 
 int
 Scanner::get_num_transaxial_buckets() const
 {
-  return get_num_transaxial_blocks() / num_transaxial_blocks_per_bucket;
+  return get_num_transaxial_blocks() / get_num_transaxial_blocks_per_bucket();
 }
 
 int
@@ -205,7 +218,7 @@ Scanner::get_num_axial_singles_units() const
     }
   else
     {
-      return (num_rings + get_num_virtual_axial_crystals_per_block()) / num_axial_crystals_per_singles_unit;
+      return get_num_axial_crystals() / num_axial_crystals_per_singles_unit;
     }
 }
 
@@ -218,7 +231,8 @@ Scanner::get_num_transaxial_singles_units() const
     }
   else
     {
-      return num_detectors_per_ring / num_transaxial_crystals_per_singles_unit;
+      // TODO: RTS believe this should account for virtual crystals, check!
+      return get_num_detectors_per_ring() / num_transaxial_crystals_per_singles_unit;
     }
 }
 

--- a/src/recon_test/test_geometry_blocks_on_cylindrical.cxx
+++ b/src/recon_test/test_geometry_blocks_on_cylindrical.cxx
@@ -27,6 +27,7 @@
 #include "stir/GeometryBlocksOnCylindrical.h"
 #include "stir/IO/write_to_file.h"
 #include <cmath>
+// #include <filesystem>
 
 START_NAMESPACE_STIR
 
@@ -40,12 +41,26 @@ public:
   void run_tests() override;
 
 private:
+  //! Loop through all transaxial and axial indices to ensure the coordinates are monotonic, indicating a spiralling
+  // generation of the coordinates of the coordinates around the scanner geometry
+  void run_monotonic_coordinates_generation_test();
   /*! \brief Tests multiple axial blocks/bucket configurations to ensure the detector map's axial indices and coordinates
-   * are monotonic
-   */
+   * are monotonic */
   void run_monotonic_axial_coordinates_in_detector_map_test();
   //! Tests the axial indices and coordinates are monotonic in the detector map
   static Succeeded monotonic_axial_coordinates_in_detector_map_test(const shared_ptr<Scanner>& scanner_sptr);
+
+  //! Sets up the scanner for the test
+  static Succeeded setup_scanner_for_test(shared_ptr<stir::Scanner> scanner_sptr);
+
+  void run_assert_scanner_centred_on_origin_test();
+
+  /*! This is a test of the start_z position. The code was refactored and this test ensures that the new calculation is
+   * equivalent to the old calculation */
+  void validate_start_z_with_old_calculation();
+
+  void validate_first_bucket_is_centred_on_x_axis();
+  ;
 };
 
 void
@@ -53,34 +68,44 @@ GeometryBlocksOnCylindricalTests::run_monotonic_axial_coordinates_in_detector_ma
 {
   auto scanner_sptr = std::make_shared<Scanner>(Scanner::SAFIRDualRingPrototype);
   scanner_sptr->set_scanner_geometry("BlocksOnCylindrical");
-  scanner_sptr->set_transaxial_block_spacing(scanner_sptr->get_transaxial_crystal_spacing()
-                                             * scanner_sptr->get_num_transaxial_crystals_per_block());
-  int num_axial_buckets = 1; // TODO add for loop when support is added
 
-  for (int num_axial_crystals_per_blocks = 1; num_axial_crystals_per_blocks < 3; ++num_axial_crystals_per_blocks)
-    for (int num_axial_blocks_per_bucket = 1; num_axial_blocks_per_bucket < 3; ++num_axial_blocks_per_bucket)
+  //  for (int num_axial_crystals_per_blocks = 1; num_axial_crystals_per_blocks < 3; ++num_axial_crystals_per_blocks)
+  //    for (int num_axial_blocks_per_bucket = 1; num_axial_blocks_per_bucket < 3; ++num_axial_blocks_per_bucket)
+  //      for (int num_axial_buckets = 1; num_axial_buckets < 3; ++num_axial_buckets)
+
+  // TESTING CONFIG:
+  int num_axial_buckets = 2;
+  int num_axial_blocks_per_bucket = 2;
+  int num_axial_crystals_per_blocks = 2;
+  {
+    int num_rings = num_axial_crystals_per_blocks * num_axial_blocks_per_bucket * num_axial_buckets;
+    scanner_sptr->set_num_axial_crystals_per_block(num_axial_crystals_per_blocks);
+    scanner_sptr->set_num_axial_blocks_per_bucket(num_axial_blocks_per_bucket);
+    scanner_sptr->set_num_rings(num_rings);
+
+    scanner_sptr->set_axial_block_spacing(scanner_sptr->get_axial_crystal_spacing()
+                                          * (scanner_sptr->get_num_axial_crystals_per_block() + 0.5));
+
+    //    if (num_axial_buckets > 1)
+    //      scanner_sptr->set_axial_bucket_spacing(scanner_sptr->get_axial_block_spacing() * 1.5);
+    //    else
+    //      scanner_sptr->set_axial_bucket_spacing(-1);
+
+    if (monotonic_axial_coordinates_in_detector_map_test(scanner_sptr) == Succeeded::no)
       {
-        scanner_sptr->set_num_axial_crystals_per_block(num_axial_crystals_per_blocks);
-        scanner_sptr->set_num_axial_blocks_per_bucket(num_axial_blocks_per_bucket);
-        scanner_sptr->set_num_rings(scanner_sptr->get_num_axial_crystals_per_bucket() * num_axial_buckets);
-        scanner_sptr->set_axial_block_spacing(scanner_sptr->get_axial_crystal_spacing()
-                                              * (scanner_sptr->get_num_axial_crystals_per_block() + 0.5));
-
-        if (monotonic_axial_coordinates_in_detector_map_test(scanner_sptr) == Succeeded::no)
-          {
-            warning(boost::format("Monothonic axial coordinates test failed for:\n"
-                                  "\taxial_crystal_per_block =\t%1%\n"
-                                  "\taxial_blocks_per_bucket =\t%2%\n"
-                                  "\tnum_axial_buckets =\t\t\t%3%")
-                    % num_axial_crystals_per_blocks % num_axial_blocks_per_bucket % num_axial_buckets);
-            everything_ok = false;
-            return;
-          }
+        warning(boost::format("Monothonic axial coordinates test failed for:\n"
+                              "\taxial_crystal_per_block =\t%1%\n"
+                              "\taxial_blocks_per_bucket =\t%2%\n"
+                              "\tnum_axial_buckets =\t\t\t%3%")
+                % num_axial_crystals_per_blocks % num_axial_blocks_per_bucket % scanner_sptr->get_num_axial_buckets());
+        everything_ok = false;
+        return;
       }
+  }
 }
 
 Succeeded
-GeometryBlocksOnCylindricalTests::monotonic_axial_coordinates_in_detector_map_test(const shared_ptr<Scanner>& scanner_sptr)
+GeometryBlocksOnCylindricalTests::setup_scanner_for_test(shared_ptr<stir::Scanner> scanner_sptr)
 {
   if (scanner_sptr->get_scanner_geometry() != "BlocksOnCylindrical")
     {
@@ -88,10 +113,9 @@ GeometryBlocksOnCylindricalTests::monotonic_axial_coordinates_in_detector_map_te
       return Succeeded::no;
     }
 
-  shared_ptr<DetectorCoordinateMap> detector_map_sptr;
   try
     {
-      detector_map_sptr.reset(new GeometryBlocksOnCylindrical(*scanner_sptr));
+      scanner_sptr->set_up();
     }
   catch (const std::runtime_error& e)
     {
@@ -100,33 +124,243 @@ GeometryBlocksOnCylindricalTests::monotonic_axial_coordinates_in_detector_map_te
               % e.what());
       return Succeeded::no;
     }
+  return Succeeded::yes;
+}
+
+Succeeded
+GeometryBlocksOnCylindricalTests::monotonic_axial_coordinates_in_detector_map_test(const shared_ptr<Scanner>& scanner_sptr)
+{
+  if (setup_scanner_for_test(scanner_sptr) == Succeeded::no)
+    return Succeeded::no;
 
   unsigned min_axial_pos = 0;
   float prev_min_axial_coord = -std::numeric_limits<float>::max();
+  shared_ptr<const DetectorCoordinateMap> detector_map_sptr = scanner_sptr->get_detector_map_sptr();
 
   for (unsigned axial_idx = 0; axial_idx < detector_map_sptr->get_num_axial_coords(); ++axial_idx)
-    for (unsigned tangential_idx = 0; tangential_idx < detector_map_sptr->get_num_tangential_coords(); ++tangential_idx)
-      for (unsigned radial_idx = 0; radial_idx < detector_map_sptr->get_num_radial_coords(); ++radial_idx)
+    {
+      const DetectionPosition<> det_pos = DetectionPosition<>(0, axial_idx, 0);
+      CartesianCoordinate3D<float> coord = detector_map_sptr->get_coordinate_for_det_pos(det_pos);
+      //          std::cerr << "coord.z() = " << coord.z() << "\tprev_min_axial_coord = " << prev_min_axial_coord
+      //                    << "\tdelta = " << coord.z() - prev_min_axial_coord << std::endl;
+      if (coord.z() > prev_min_axial_coord)
         {
-          const DetectionPosition<> det_pos = DetectionPosition<>(tangential_idx, axial_idx, radial_idx);
-          CartesianCoordinate3D<float> coord = detector_map_sptr->get_coordinate_for_det_pos(det_pos);
-          if (coord.z() > prev_min_axial_coord)
-            {
-              min_axial_pos = axial_idx;
-              prev_min_axial_coord = coord.z();
-            }
-          else if (coord.z() < prev_min_axial_coord)
-            {
-              float delta = coord.z() - prev_min_axial_coord;
-              warning(boost::format("Axial Coordinates are not monotonic.\n"
-                                    "Next axial index =\t\t%1%, Next axial coord (mm) =\t\t%2%  (%3%)\n"
-                                    "Previous axial index =\t%4%, Previous axial coord (mm) =\t%5%")
-                      % axial_idx % coord.z() % delta % min_axial_pos % prev_min_axial_coord);
-              return Succeeded::no;
-            }
+          min_axial_pos = axial_idx;
+          prev_min_axial_coord = coord.z();
         }
+      else if (coord.z() < prev_min_axial_coord)
+        {
+          float delta = coord.z() - prev_min_axial_coord;
+          warning(boost::format("Axial Coordinates are not monotonic.\n"
+                                "Next axial index =\t\t%1%, Next axial coord (mm) =\t\t%2%  (%3%)\n"
+                                "Previous axial index =\t%4%, Previous axial coord (mm) =\t%5%")
+                  % axial_idx % coord.z() % delta % min_axial_pos % prev_min_axial_coord);
+          return Succeeded::no;
+        }
+    }
 
   return Succeeded::yes;
+}
+
+void
+GeometryBlocksOnCylindricalTests::run_assert_scanner_centred_on_origin_test()
+{
+  //  auto scanner_sptr = std::make_shared<Scanner>(Scanner::SAFIRDualRingPrototype);
+  //  scanner_sptr->set_scanner_geometry("BlocksOnCylindrical");
+  //  if (setup_scanner_for_test(scanner_sptr) == Succeeded::no)
+  //    {
+  //      warning("GeometryBlocksOnCylindricalTests::run_assert_scanner_centred_on_origin_test: "
+  //              "Scanner not set up correctly for test");
+  //      everything_ok = false;
+  //    }
+  //
+  //  auto detector_map_sptr = scanner_sptr->get_detector_map_sptr();
+  //  for (int transaxial_idx = 0; transaxial_idx < scanner_sptr->get_num_detectors_per_ring(); ++transaxial_idx)
+  //    {
+  //      const DetectionPosition<> det_pos = DetectionPosition<>(transaxial_idx, 0, 0);
+  //      auto cart_coord = detector_map_sptr->get_coordinate_for_det_pos(det_pos);
+  //      if (cart_coord.z() != 0.0)
+  //        {
+  //          warning(boost::format("Scanner Z component of the first index is > 0 \n"
+  //                                "Transaxial index =\t%1%\n"
+  //                                "Axial index =\t%2%\n"
+  //                                "Cartesian Coordinate =\t%2%")
+  //                  % transaxial_idx % cart_coord);
+  //          everything_ok = false;
+  //        }
+  //    }
+}
+
+void
+GeometryBlocksOnCylindricalTests::run_monotonic_coordinates_generation_test()
+{
+  auto scanner_sptr = std::make_shared<Scanner>(Scanner::SAFIRDualRingPrototype);
+  scanner_sptr->set_scanner_geometry("BlocksOnCylindrical");
+
+  int prev_max_axial_coord = -1;
+  int prev_max_transaxial_coord = -1;
+
+  for (int ax_bucket_num = 0; ax_bucket_num < scanner_sptr->get_num_axial_buckets(); ++ax_bucket_num)
+    for (int ax_block_num = 0; ax_block_num < scanner_sptr->get_num_axial_blocks_per_bucket(); ++ax_block_num)
+      for (int ax_crystal_num = 0; ax_crystal_num < scanner_sptr->get_num_axial_crystals_per_block(); ++ax_crystal_num)
+        for (int trans_bucket_num = 0; trans_bucket_num < scanner_sptr->get_num_transaxial_buckets(); ++trans_bucket_num)
+          for (int trans_block_num = 0; trans_block_num < scanner_sptr->get_num_transaxial_blocks_per_bucket(); ++trans_block_num)
+            for (int trans_crys_num = 0; trans_crys_num < scanner_sptr->get_num_transaxial_crystals_per_block(); ++trans_crys_num)
+              {
+                int axial_coord
+                    = GeometryBlocksOnCylindrical::get_axial_coord(*scanner_sptr, ax_bucket_num, ax_block_num, ax_crystal_num);
+                int transaxial_coord;
+                transaxial_coord = GeometryBlocksOnCylindrical::get_transaxial_coord(
+                    *scanner_sptr, trans_bucket_num, trans_block_num, trans_crys_num);
+
+                // Test that the axial coordinates are monotonic
+                if (prev_max_axial_coord > axial_coord)
+                  {
+                    warning(boost::format("Axial Coordinates are not monotonic.\n"
+                                          "Next axial index =\t\t%1%\n"
+                                          "Previous axial index =\t%2%\n"
+                                          "Next Transaxial index =\t%3%\n"
+                                          "Previous Transaxial index =\t%4%")
+                            % axial_coord % prev_max_axial_coord % transaxial_coord % prev_max_transaxial_coord);
+                    everything_ok = false;
+                    return;
+                  }
+
+                // Test that the transaxial coordinates are monotonic, it will reset to 0 when the axial index increases
+                if (prev_max_transaxial_coord > transaxial_coord && axial_coord <= prev_max_axial_coord)
+                  {
+                    warning(boost::format("Transaxial Coordinates are not monotonic.\n"
+                                          "Next axial index =\t\t%1%\n"
+                                          "Previous axial index =\t%2%\n"
+                                          "Next Transaxial index =\t%3%\n"
+                                          "Previous Transaxial index =\t%4%")
+                            % axial_coord % prev_max_axial_coord % transaxial_coord % prev_max_transaxial_coord);
+                    everything_ok = false;
+                    return;
+                  }
+              }
+}
+
+void
+GeometryBlocksOnCylindricalTests::validate_start_z_with_old_calculation()
+{
+  auto scanner_sptr = std::make_shared<Scanner>(Scanner::SAFIRDualRingPrototype);
+  scanner_sptr->set_scanner_geometry("BlocksOnCylindrical");
+
+  // calculate the start_z with the old equation.
+  // The code was moved here and slightly refactored to get values from the scanner object
+  float axial_blocks_gap = scanner_sptr->get_axial_block_spacing()
+                           - scanner_sptr->get_num_axial_crystals_per_block() * scanner_sptr->get_axial_crystal_spacing();
+  float old_code_calculation
+      = -(scanner_sptr->get_axial_block_spacing() * (scanner_sptr->get_num_axial_blocks_per_bucket())
+              * scanner_sptr->get_num_axial_buckets()
+          - scanner_sptr->get_axial_crystal_spacing()
+          - axial_blocks_gap * (scanner_sptr->get_num_axial_blocks_per_bucket() * scanner_sptr->get_num_axial_buckets() - 1))
+        / 2;
+
+  // new method to calculate start_z
+  float start_z_method = GeometryBlocksOnCylindrical::get_initial_axial_z_offset(*scanner_sptr);
+
+  if (std::abs(old_code_calculation - start_z_method) > 1e-6)
+    {
+      warning(boost::format("Old code calculation =\t%1%\n"
+                            "New code calculation =\t%2%\n"
+                            "Difference =\t%3%")
+              % old_code_calculation % start_z_method % (old_code_calculation - start_z_method));
+      everything_ok = false;
+    }
+}
+
+void
+GeometryBlocksOnCylindricalTests::validate_first_bucket_is_centred_on_x_axis()
+{
+  auto scanner_sptr = std::make_shared<Scanner>(Scanner::SAFIRDualRingPrototype);
+  scanner_sptr->set_scanner_geometry("BlocksOnCylindrical");
+  scanner_sptr->set_num_transaxial_blocks_per_bucket(1);
+  scanner_sptr->set_intrinsic_azimuthal_tilt(-0.235307813); // Required by test calculations
+
+  GeometryBlocksOnCylindrical detector_map_builder(*scanner_sptr);
+  scanner_sptr->get_num_transaxial_blocks_per_bucket();
+  int first_transaxial_index_in_first_bucket = detector_map_builder.get_transaxial_coord(*scanner_sptr, 0, 0, 0);
+  int last_transaxial_index_in_first_bucket
+      = detector_map_builder.get_transaxial_coord(*scanner_sptr,
+                                                  0,
+                                                  scanner_sptr->get_num_transaxial_blocks_per_bucket() - 1,
+                                                  scanner_sptr->get_num_transaxial_crystals_per_block());
+  auto first_transaxial_coord_in_first_bucket
+      = detector_map_builder.get_coordinate_for_det_pos(DetectionPosition<>(first_transaxial_index_in_first_bucket, 0, 0));
+  auto last_transaxial_coord_in_first_bucket
+      = detector_map_builder.get_coordinate_for_det_pos(DetectionPosition<>(last_transaxial_index_in_first_bucket, 0, 0));
+
+  { // Testing the coordinates of the first axial row of the first bucket.
+    // For this scanner, with the set intrinsic_azimuthal_tilt, the first bucket's tangential coordinates should
+    // be centered at x=0 with a constant z,y position
+
+    // Get the coordinates of the first block/bucket
+    std::vector<CartesianCoordinate3D<float>> crystal_coords(scanner_sptr->get_num_transaxial_crystals_per_bucket());
+    for (int i = 0; i < crystal_coords.size(); i++)
+      {
+        crystal_coords[i] = detector_map_builder.get_coordinate_for_det_pos(DetectionPosition<>(i, 0, 0));
+      }
+
+    {
+      float previous_x = -std::numeric_limits<float>::max();
+      for (int i = 1; i < crystal_coords.size(); i++)
+        {
+          // Check if the crystal coords are all at the same z,y position
+          check_if_equal(crystal_coords[0].z(), crystal_coords[i].z());
+          check_if_equal(crystal_coords[0].y(), crystal_coords[i].y());
+          // Check the x position is monotonic
+          check_if_less(previous_x,
+                        crystal_coords[i].x(),
+                        boost::str(boost::format("Crystal %1% x position is more than "
+                                                 "the previous crystal x position")
+                                   % i));
+        }
+    }
+
+    // Check if x position is centered on 0.0
+    for (int i = 0; i < int(crystal_coords.size() / 2); i++)
+      {
+        float left_crystal_x = crystal_coords[i].x();
+        float right_crystal_x = crystal_coords[crystal_coords.size() - 1 - i].x();
+        float offset_x = abs(left_crystal_x + right_crystal_x) / 2;
+        float acceptable_error = (abs(left_crystal_x) + abs(right_crystal_x)) * 1e-6;
+        check_if_less(offset_x,
+                      acceptable_error,
+                      boost::str(boost::format("Left and right crystal x positions are not evenly "
+                                               "distributed over x axis.\tLeft crystal x = %1%\tRight crystal x = "
+                                               "%2%\tOffset = %3%")
+                                 % left_crystal_x % right_crystal_x % offset_x));
+      }
+
+    // Check the central crystal x position is centered on the x axis if there is an odd number of crystals
+    if (crystal_coords.size() % 2 == 1)
+      {
+        float central_x = crystal_coords[crystal_coords.size() / 2].x();
+        float acceptable_error = abs(crystal_coords[0].x()) * 1e-6;
+        check_if_less(abs(central_x),
+                      acceptable_error,
+                      boost::str(boost::format("With an odd number of crystals, the central crystal x position is not "
+                                               "centered on the x axis.\tCentral crystal x = %1%\t Acceptable error = %2%")
+                                 % central_x % acceptable_error));
+      }
+  }
+
+  //  { // Loop over all transaxial buckets, blocks and crystals and save the coordinates to a csv file with the format
+  //    // tang,axial,radial,z,y,x
+  //    std::ofstream file;
+  //
+  //    const char* filename = "crystal_coords.csv";
+  //    file.open(filename);
+  //    for (int i = 0; i < scanner_sptr->get_num_detectors_per_ring(); i++)
+  //      {
+  //        auto coord = detector_map_builder.get_coordinate_for_det_pos(DetectionPosition<>(i, 0, 0));
+  //        file << i << ",0,0," << coord.z() << "," << coord.y() << "," << coord.x() << std::endl;
+  //      }
+  //    file.close();
+  //    std::cerr << "Crystal coordinates written to " << std::filesystem::current_path() / filename << std::endl;
+  //  }
 }
 
 void
@@ -134,7 +368,11 @@ GeometryBlocksOnCylindricalTests::run_tests()
 {
   HighResWallClockTimer timer;
   timer.start();
+  run_monotonic_coordinates_generation_test();
   run_monotonic_axial_coordinates_in_detector_map_test();
+  run_assert_scanner_centred_on_origin_test();
+  validate_start_z_with_old_calculation();
+  validate_first_bucket_is_centred_on_x_axis();
   timer.stop();
 }
 END_NAMESPACE_STIR


### PR DESCRIPTION
Attempts to address some issues found with GeometryBlocksOnCylindrical, as detailed here https://github.com/UCL/STIR/discussions/1388, and add gaps between buckets.


## Changes in this pull request
- Refactor of `GeometryBlocksOnCylindrical`. Significant change to the calculations of `build_crystal_maps`.
- Refactor of `Scanner`. This added a number of simplifications to the way the `get_*` methods work around buckets/block/crystal gaps and numbers

## Testing performed
- Additional testing for `GeometryBlocksOnCylindricalTests`.

## Related issues


## Checklist before requesting a review
<!--Put an x between the [] when completed. Delete a line if not applicable. -->
  - [] I have performed a self-review of my code
  - [] I have added docstrings/doxygen in line with the guidance in the developer guide
  - [] I have implemented unit tests that cover any new or modified functionality (if applicable)
  - [] The code builds and runs on my machine
  - [] `documentation/release_XXX.md` has been updated with any functionality change (if applicable)
