### PR TITLE
Relative Difference Prior Abs fix

### DIFF
--- a/documentation/release_6.1.htm
+++ b/documentation/release_6.1.htm
@@ -59,8 +59,9 @@ improvements to the documentation.
 
 <h3>Changed functionality</h3>
 <ul>
-<li>
-</li>
+  <li>
+    Accumulation in computation of priors now uses doubles, which could result in slightly better precision. <a href=https://github.com/UCL/STIR/pull/1410>Part of PR #1410</a>.
+  </li>
 </ul>
 
 

--- a/documentation/release_6.1.htm
+++ b/documentation/release_6.1.htm
@@ -66,8 +66,9 @@ improvements to the documentation.
 
 <h3>Bug fixes</h3>
 <ul>
-<li>
-</li>
+  <li>The Relative Difference Prior gave incorrect results, probably since switching to C++-14 in version 6.0, although we are not sure.
+    See <a href=https://github.com/UCL/STIR/pull/1410>PR #1410</a> and associated <a href=https://github.com/UCL/STIR/pull/1409>issue #1409</a>.
+  </li>
 </ul>
 
 <h3>Known problems</h3>

--- a/src/include/stir/recon_buildblock/RelativeDifferencePrior.h
+++ b/src/include/stir/recon_buildblock/RelativeDifferencePrior.h
@@ -51,8 +51,12 @@ START_NAMESPACE_STIR
   "A Concave Prior Penalizing Relative Differences for Maximum-a-Posteriori Reconstruction in Emission Tomography,"
   vol. 49, no. 1, pp. 56-60, 2002. </em>
 
-  Note that if \f$ \epsilon=0 \f$, we resolve 0/0 by using the limit, ensuring continuity. Note that
-  the Hessian explodes to infinity when both voxel values approach 0, and we currently return INFINITY.
+  If \f$ \epsilon=0 \f$, we attempt to resolve 0/0 at \f$ \lambda_r = \lambda_{r+dr}=0 \f$ by using the limit.
+  Note that the Hessian explodes to infinity when both voxel values approach 0, and we currently return \c INFINITY.
+  Also, as the RDP is not differentiable at this point, we have chosen to return 0 for the gradient
+  (such that a zero background is not modified).
+
+  \warning the default value for \f$ \epsilon \f$ is zero, which can be problematic for gradient-based algorithms.
 
   The \f$\kappa\f$ image can be used to have spatially-varying penalties such as in
   Jeff Fessler's papers. It should have identical dimensions to the image for which the
@@ -61,6 +65,10 @@ START_NAMESPACE_STIR
 
   By default, a 3x3 or 3x3x3 neighbourhood is used where the weights are set to
   x-voxel_size divided by the Euclidean distance between the points.
+
+  The prior computation excludes voxel-pairs where one voxel is outside the volume. This is
+  effectively the same as extending the volume by replicating the edges (which is different
+  from zero boundary conditions).
 
 \par Parsing
   These are the keywords that can be used in addition to the ones in GeneralPrior.
@@ -203,7 +211,7 @@ protected:
    In the instance x_j, x_k and epsilon equal 0.0, these functions get ill-defined due to 0/0 computations.
    We currently return 0 for the value, 0 for derivative_10, and INFINITY for the second order
    derivatives. These follow by taking the limit, i.e. by assuming continuity. Note however that
-   when epsilon=0, derivative_10(x,0) limits to\f$ 1/(1+\gamma) \f$, while derivative_10(x,x) limits to \f$ 0 \f$.
+   when epsilon=0, derivative_10(x,0) limits to \f$ 1/(1+\gamma) \f$, while derivative_10(x,x) limits to \f$ 0 \f$.
 
    * @param x_j is the target voxel.
    * @param x_k is the voxel in the neighbourhood.

--- a/src/include/stir/recon_buildblock/RelativeDifferencePrior.h
+++ b/src/include/stir/recon_buildblock/RelativeDifferencePrior.h
@@ -185,21 +185,25 @@ protected:
   void initialise_keymap() override;
   bool post_processing() override;
 
-private:
+protected:
   shared_ptr<DiscretisedDensity<3, elemT>> kappa_ptr;
 
-  //! The second partial derivatives of the Relative Difference Prior
+  //! The value and partial derivatives of the Relative Difference Prior
   /*!
-   derivative_20 refers to the second derivative w.r.t. x_j only (i.e. diagonal elements of the Hessian)
-   derivative_11 refers to the second derivative w.r.t. x_j and x_k (i.e. off-diagonal elements of the Hessian)
-   See J. Nuyts, et al., 2002, Equation 7.
+   * derivative_10 refers to the derivative w.r.t. x_j only
+   * derivative_20 refers to the second derivative w.r.t. x_j only (i.e. diagonal elements of the Hessian)
+   * derivative_11 refers to the second derivative w.r.t. x_j and x_k (i.e. off-diagonal elements of the Hessian)
+
+   See J. Nuyts, et al., 2002, Equation 7 etc, but here an epsilon is added.
    In the instance x_j, x_k and epsilon equal 0.0, these functions return 0.0 to prevent returning an undefined value
-   due to 0/0 computation. This is a "reasonable" solution to this issue.
+   due to 0/0 computation. This is a "reasonable" solution to this issue, although not necessarily continuous.
    * @param x_j is the target voxel.
    * @param x_k is the voxel in the neighbourhood.
    * @return the second order partial derivatives of the Relative Difference Prior
    */
   //@{
+  double value(const elemT x_j, const elemT x_k) const;
+  elemT derivative_10(const elemT x, const elemT y) const;
   elemT derivative_20(const elemT x_j, const elemT x_k) const;
   elemT derivative_11(const elemT x_j, const elemT x_k) const;
   //@}

--- a/src/include/stir/recon_buildblock/RelativeDifferencePrior.h
+++ b/src/include/stir/recon_buildblock/RelativeDifferencePrior.h
@@ -51,6 +51,9 @@ START_NAMESPACE_STIR
   "A Concave Prior Penalizing Relative Differences for Maximum-a-Posteriori Reconstruction in Emission Tomography,"
   vol. 49, no. 1, pp. 56-60, 2002. </em>
 
+  Note that if \f$ \epsilon=0 \f$, we resolve 0/0 by using the limit, ensuring continuity. Note that
+  the Hessian explodes to infinity when both voxel values approach 0, and we currently return INFINITY.
+
   The \f$\kappa\f$ image can be used to have spatially-varying penalties such as in
   Jeff Fessler's papers. It should have identical dimensions to the image for which the
   penalty is computed. If \f$\kappa\f$ is not set, this class will effectively
@@ -190,13 +193,18 @@ protected:
 
   //! The value and partial derivatives of the Relative Difference Prior
   /*!
+   * value refers to its value
    * derivative_10 refers to the derivative w.r.t. x_j only
    * derivative_20 refers to the second derivative w.r.t. x_j only (i.e. diagonal elements of the Hessian)
    * derivative_11 refers to the second derivative w.r.t. x_j and x_k (i.e. off-diagonal elements of the Hessian)
 
    See J. Nuyts, et al., 2002, Equation 7 etc, but here an epsilon is added.
-   In the instance x_j, x_k and epsilon equal 0.0, these functions return 0.0 to prevent returning an undefined value
-   due to 0/0 computation. This is a "reasonable" solution to this issue, although not necessarily continuous.
+
+   In the instance x_j, x_k and epsilon equal 0.0, these functions get ill-defined due to 0/0 computations.
+   We currently return 0 for the value, 0 for derivative_10, and INFINITY for the second order
+   derivatives. These follow by taking the limit, i.e. by assuming continuity. Note however that
+   when epsilon=0, derivative_10(x,0) limits to\f$ 1/(1+\gamma) \f$, while derivative_10(x,x) limits to \f$ 0 \f$.
+
    * @param x_j is the target voxel.
    * @param x_k is the voxel in the neighbourhood.
    * @return the second order partial derivatives of the Relative Difference Prior

--- a/src/recon_buildblock/LogcoshPrior.cxx
+++ b/src/recon_buildblock/LogcoshPrior.cxx
@@ -289,12 +289,12 @@ LogcoshPrior<elemT>::compute_value(const DiscretisedDensity<3, elemT>& current_i
                   for (int dx = min_dx; dx <= max_dx; ++dx)
                     {
                       // 1/scalar^2 * log(cosh(x * scalar))
-                      elemT voxel_diff = current_image_estimate[z][y][x] - current_image_estimate[z + dz][y + dy][x + dx];
-                      elemT current
+                      double voxel_diff = current_image_estimate[z][y][x] - current_image_estimate[z + dz][y + dy][x + dx];
+                      double current
                           = weights[dz][dy][dx] * 1 / (this->scalar * this->scalar) * logcosh(this->scalar * voxel_diff);
                       if (do_kappa)
                         current *= (*kappa_ptr)[z][y][x] * (*kappa_ptr)[z + dz][y + dy][x + dx];
-                      result += static_cast<double>(current);
+                      result += current;
                     }
             }
         }
@@ -349,21 +349,21 @@ LogcoshPrior<elemT>::compute_gradient(DiscretisedDensity<3, elemT>& prior_gradie
               const int min_dx = max(weights[0][0].get_min_index(), min_x - x);
               const int max_dx = min(weights[0][0].get_max_index(), max_x - x);
 
-              elemT gradient = 0;
+              double gradient = 0;
               for (int dz = min_dz; dz <= max_dz; ++dz)
                 for (int dy = min_dy; dy <= max_dy; ++dy)
                   for (int dx = min_dx; dx <= max_dx; ++dx)
                     {
                       // 1/scalar * tanh(x * scalar)
-                      elemT voxel_diff = current_image_estimate[z][y][x] - current_image_estimate[z + dz][y + dy][x + dx];
-                      elemT current = weights[dz][dy][dx] * (1 / this->scalar) * tanh(this->scalar * voxel_diff);
+                      double voxel_diff = current_image_estimate[z][y][x] - current_image_estimate[z + dz][y + dy][x + dx];
+                      double current = weights[dz][dy][dx] * (1 / this->scalar) * tanh(this->scalar * voxel_diff);
 
                       if (do_kappa)
                         current *= (*kappa_ptr)[z][y][x] * (*kappa_ptr)[z + dz][y + dy][x + dx];
 
                       gradient += current;
                     }
-              prior_gradient[z][y][x] = gradient * this->penalisation_factor;
+              prior_gradient[z][y][x] = static_cast<elemT>(gradient * this->penalisation_factor);
             }
         }
     }

--- a/src/recon_buildblock/PLSPrior.cxx
+++ b/src/recon_buildblock/PLSPrior.cxx
@@ -498,12 +498,12 @@ PLSPrior<elemT>::compute_value(const DiscretisedDensity<3, elemT>& current_image
                  (penalty[z][y][x]) * (*kappa_ptr)[z][y][x];
               */
 
-              elemT current = (*penalty_sptr)[z][y][x];
+              double current = (*penalty_sptr)[z][y][x];
 
               if (do_kappa)
                 current *= (*kappa_ptr)[z][y][x];
 
-              result += static_cast<double>(current);
+              result += current;
             }
         }
     }

--- a/src/recon_buildblock/QuadraticPrior.cxx
+++ b/src/recon_buildblock/QuadraticPrior.cxx
@@ -278,14 +278,14 @@ QuadraticPrior<elemT>::compute_value(const DiscretisedDensity<3, elemT>& current
                 for (int dy = min_dy; dy <= max_dy; ++dy)
                   for (int dx = min_dx; dx <= max_dx; ++dx)
                     {
-                      elemT current = weights[dz][dy][dx]
-                                      * square(current_image_estimate[z][y][x] - current_image_estimate[z + dz][y + dy][x + dx])
-                                      / 4;
+                      double current = weights[dz][dy][dx]
+                                       * square(current_image_estimate[z][y][x] - current_image_estimate[z + dz][y + dy][x + dx])
+                                       / 4;
 
                       if (do_kappa)
                         current *= (*kappa_ptr)[z][y][x] * (*kappa_ptr)[z + dz][y + dy][x + dx];
 
-                      result += static_cast<double>(current);
+                      result += current;
                     }
             }
         }
@@ -348,65 +348,20 @@ QuadraticPrior<elemT>::compute_gradient(DiscretisedDensity<3, elemT>& prior_grad
                  (current_image_estimate[z][y][x] - current_image_estimate[z+dz][y+dy][x+dx]) *
                  (*kappa_ptr)[z][y][x] * (*kappa_ptr)[z+dz][y+dy][x+dx];
               */
-#if 1
-              elemT gradient = 0;
+              double gradient = 0.;
               for (int dz = min_dz; dz <= max_dz; ++dz)
                 for (int dy = min_dy; dy <= max_dy; ++dy)
                   for (int dx = min_dx; dx <= max_dx; ++dx)
                     {
-                      elemT current = weights[dz][dy][dx]
-                                      * (current_image_estimate[z][y][x] - current_image_estimate[z + dz][y + dy][x + dx]);
+                      double current = weights[dz][dy][dx]
+                                       * (current_image_estimate[z][y][x] - current_image_estimate[z + dz][y + dy][x + dx]);
 
                       if (do_kappa)
                         current *= (*kappa_ptr)[z][y][x] * (*kappa_ptr)[z + dz][y + dy][x + dx];
 
                       gradient += current;
                     }
-#else
-              // attempt to speed up by precomputing the sum of weights.
-              // The current code gives identical results but is actually slower
-              // than the above, at least when kappas are present.
-
-              // precompute sum of weights
-              // TODO without kappas, this is just weights.sum() most of the time,
-              // but not near edges
-              float sum_of_weights = 0;
-              {
-                if (do_kappa)
-                  {
-                    for (int dz = min_dz; dz <= max_dz; ++dz)
-                      for (int dy = min_dy; dy <= max_dy; ++dy)
-                        for (int dx = min_dx; dx <= max_dx; ++dx)
-                          sum_of_weights += weights[dz][dy][dx] * (*kappa_ptr)[z + dz][y + dy][x + dx];
-                  }
-                else
-                  {
-                    for (int dz = min_dz; dz <= max_dz; ++dz)
-                      for (int dy = min_dy; dy <= max_dy; ++dy)
-                        for (int dx = min_dx; dx <= max_dx; ++dx)
-                          sum_of_weights += weights[dz][dy][dx];
-                  }
-              }
-              // now compute contribution of central term
-              elemT gradient = sum_of_weights * current_image_estimate[z][y][x];
-
-              // subtract the rest
-              for (int dz = min_dz; dz <= max_dz; ++dz)
-                for (int dy = min_dy; dy <= max_dy; ++dy)
-                  for (int dx = min_dx; dx <= max_dx; ++dx)
-                    {
-                      elemT current = weights[dz][dy][dx] * current_image_estimate[z + dz][y + dy][x + dx];
-
-                      if (do_kappa)
-                        current *= (*kappa_ptr)[z + dz][y + dy][x + dx];
-
-                      gradient -= current;
-                    }
-              // multiply with central kappa
-              if (do_kappa)
-                gradient *= (*kappa_ptr)[z][y][x];
-#endif
-              prior_gradient[z][y][x] = gradient * this->penalisation_factor;
+              prior_gradient[z][y][x] = static_cast<elemT>(gradient * this->penalisation_factor);
             }
         }
     }

--- a/src/recon_buildblock/RelativeDifferencePrior.cxx
+++ b/src/recon_buildblock/RelativeDifferencePrior.cxx
@@ -340,7 +340,7 @@ RelativeDifferencePrior<elemT>::compute_value(const DiscretisedDensity<3, elemT>
                 for (int dy = min_dy; dy <= max_dy; ++dy)
                   for (int dx = min_dx; dx <= max_dx; ++dx)
                     {
-                      elemT current;
+                      double current;
                       if (this->epsilon == 0.0 && current_image_estimate[z][y][x] == 0.0
                           && current_image_estimate[z + dz][y + dy][x + dx] == 0.0)
                         {
@@ -355,7 +355,7 @@ RelativeDifferencePrior<elemT>::compute_value(const DiscretisedDensity<3, elemT>
                       if (do_kappa)
                         current *= (*kappa_ptr)[z][y][x] * (*kappa_ptr)[z + dz][y + dy][x + dx];
 
-                      result += static_cast<double>(current);
+                      result += current;
                     }
             }
         }
@@ -412,12 +412,12 @@ RelativeDifferencePrior<elemT>::compute_gradient(DiscretisedDensity<3, elemT>& p
               const int min_dx = max(weights[0][0].get_min_index(), min_x - x);
               const int max_dx = min(weights[0][0].get_max_index(), max_x - x);
 
-              elemT gradient = 0;
+              double gradient = 0;
               for (int dz = min_dz; dz <= max_dz; ++dz)
                 for (int dy = min_dy; dy <= max_dy; ++dy)
                   for (int dx = min_dx; dx <= max_dx; ++dx)
                     {
-                      elemT current
+                      double current
                           = weights[dz][dy][dx]
                             * derivative_10(current_image_estimate[z][y][x], current_image_estimate[z + dz][y + dy][x + dx]);
                       if (do_kappa)
@@ -426,7 +426,7 @@ RelativeDifferencePrior<elemT>::compute_gradient(DiscretisedDensity<3, elemT>& p
                       gradient += current;
                     }
 
-              prior_gradient[z][y][x] = gradient * this->penalisation_factor;
+              prior_gradient[z][y][x] = static_cast<elemT>(gradient * this->penalisation_factor);
             }
         }
     }

--- a/src/recon_test/test_priors.cxx
+++ b/src/recon_test/test_priors.cxx
@@ -1,6 +1,6 @@
 /*
     Copyright (C) 2011, Hammersmith Imanet Ltd
-    Copyright (C) 2020-2023 University College London
+    Copyright (C) 2020-2024 University College London
     This file is part of STIR.
 
     SPDX-License-Identifier: Apache-2.0
@@ -69,8 +69,6 @@ public:
   explicit GeneralisedPriorTests(char const* density_filename = nullptr);
   typedef DiscretisedDensity<3, float> target_type;
   void construct_input_data(shared_ptr<target_type>& density_sptr);
-
-  void run_tests() override;
 
   //! Set methods that control which tests are run.
   void configure_prior_tests(bool gradient, bool Hessian_convexity, bool Hessian_numerical);
@@ -442,8 +440,20 @@ GeneralisedPriorTests::construct_input_data(shared_ptr<target_type>& density_spt
     }
 }
 
+/*!
+ \brief tests for QuadraticPrior
+ \ingroup recontest
+ \ingroup priors
+*/
+class QuadraticPriorTests : public GeneralisedPriorTests
+{
+public:
+  using GeneralisedPriorTests::GeneralisedPriorTests;
+  void run_tests() override;
+};
+
 void
-GeneralisedPriorTests::run_tests()
+QuadraticPriorTests::run_tests()
 {
   shared_ptr<target_type> density_sptr;
   construct_input_data(density_sptr);
@@ -454,6 +464,26 @@ GeneralisedPriorTests::run_tests()
     this->configure_prior_tests(true, true, true);
     this->run_tests_for_objective_function("Quadratic_no_kappa", objective_function, density_sptr);
   }
+}
+
+/*!
+ \brief tests for RelativeDifferencePrior
+ \ingroup recontest
+ \ingroup priors
+*/
+class RelativeDifferencePriorTests : public GeneralisedPriorTests
+{
+public:
+  using GeneralisedPriorTests::GeneralisedPriorTests;
+  void run_tests() override;
+};
+
+void
+RelativeDifferencePriorTests::run_tests()
+{
+  shared_ptr<target_type> density_sptr;
+  construct_input_data(density_sptr);
+
   std::cerr << "\n\nTests for Relative Difference Prior with epsilon = 0\n";
   {
     // gamma is default and epsilon is 0.0
@@ -468,6 +498,25 @@ GeneralisedPriorTests::run_tests()
     this->configure_prior_tests(true, true, true); // With a large enough epsilon the RDP Hessian numerical test will pass
     this->run_tests_for_objective_function("RDP_no_kappa_with_eps", objective_function, density_sptr);
   }
+}
+
+/*!
+ \brief tests for PLSPrior
+ \ingroup recontest
+ \ingroup priors
+*/
+class PLSPriorTests : public GeneralisedPriorTests
+{
+public:
+  using GeneralisedPriorTests::GeneralisedPriorTests;
+  void run_tests() override;
+};
+
+void
+PLSPriorTests::run_tests()
+{
+  shared_ptr<target_type> density_sptr;
+  construct_input_data(density_sptr);
 
   std::cerr << "\n\nTests for PLSPrior\n";
   {
@@ -479,6 +528,26 @@ GeneralisedPriorTests::run_tests()
     this->configure_prior_tests(false, false, false);
     this->run_tests_for_objective_function("PLS_no_kappa_flat_anatomical", objective_function, density_sptr);
   }
+}
+
+/*!
+ \brief tests for LogCoshPrior
+ \ingroup recontest
+ \ingroup priors
+*/
+class LogCoshPriorTests : public GeneralisedPriorTests
+{
+public:
+  using GeneralisedPriorTests::GeneralisedPriorTests;
+  void run_tests() override;
+};
+
+void
+LogCoshPriorTests::run_tests()
+{
+  shared_ptr<target_type> density_sptr;
+  construct_input_data(density_sptr);
+
   std::cerr << "\n\nTests for Logcosh Prior\n";
   {
     // scalar is off
@@ -497,7 +566,29 @@ main(int argc, char** argv)
 {
   set_default_num_threads();
 
-  GeneralisedPriorTests tests(argc > 1 ? argv[1] : nullptr);
-  tests.run_tests();
-  return tests.main_return_value();
+  bool everything_ok = true;
+
+  {
+    QuadraticPriorTests tests(argc > 1 ? argv[1] : nullptr);
+    tests.run_tests();
+    everything_ok = everything_ok && tests.is_everything_ok();
+  }
+  {
+    RelativeDifferencePriorTests tests(argc > 1 ? argv[1] : nullptr);
+    tests.run_tests();
+    everything_ok = everything_ok && tests.is_everything_ok();
+  }
+  {
+    PLSPriorTests tests(argc > 1 ? argv[1] : nullptr);
+    tests.run_tests();
+    everything_ok = everything_ok && tests.is_everything_ok();
+  }
+  {
+    PLSPriorTests tests(argc > 1 ? argv[1] : nullptr);
+    tests.run_tests();
+    everything_ok = everything_ok && tests.is_everything_ok();
+  }
+
+
+  return everything_ok ? EXIT_SUCCESS : EXIT_FAILURE;
 }


### PR DESCRIPTION
## Changes in this pull request
- replace `abs()` (leading to integer calculations) with `std::abs()`
- introduce `value()` and `derivative_10` functions
- change handling of 0/0 at x=y=0 (when `epsilon==0`) by imposing continuity. This means that <strike>the derivative now returns 1/(1+gamma) and </strike> the Hessian returns `INFINITY`.

This PR is backwards incompatible as RDP has changed drastically. However, it is a bug-fix.

## Testing performed
Added extra tests based on Mathematica analysis

## Related issues
Fixes #1409
