### PR TITLE
Changing all occurrences of abs() to std::abs()

### DIFF
--- a/src/buildblock/ExamInfo.cxx
+++ b/src/buildblock/ExamInfo.cxx
@@ -55,14 +55,14 @@ ExamInfo::parameter_info() const
 bool
 ExamInfo::operator==(const ExamInfo& p1) const
 {
-  return abs(this->up_energy_thres - p1.up_energy_thres) <= 1 &&   // keV
-         abs(this->low_energy_thres - p1.low_energy_thres) <= 1 && // keV
+  return std::abs(this->up_energy_thres - p1.up_energy_thres) <= 1 &&   // keV
+         std::abs(this->low_energy_thres - p1.low_energy_thres) <= 1 && // keV
          this->radionuclide == p1.radionuclide && this->time_frame_definitions == p1.time_frame_definitions &&
          //              this->branching_ratio==p1.branching_ratio &&
          ((this->calibration_factor <= 0 && p1.calibration_factor <= 0)
-          || abs(this->calibration_factor / p1.calibration_factor - 1.) <= 1E-3)
+          || std::abs(this->calibration_factor / p1.calibration_factor - 1.) <= 1E-3)
          && this->imaging_modality == p1.imaging_modality && this->patient_position == p1.patient_position
-         && abs(this->start_time_in_secs_since_1970 - p1.start_time_in_secs_since_1970) <= .5; // sec
+         && std::abs(this->start_time_in_secs_since_1970 - p1.start_time_in_secs_since_1970) <= .5; // sec
 }
 
 END_NAMESPACE_STIR

--- a/src/buildblock/ProjDataInfo.cxx
+++ b/src/buildblock/ProjDataInfo.cxx
@@ -93,7 +93,7 @@ float
 ProjDataInfo::get_sampling_in_t(const Bin& bin) const
 {
   return std::abs(get_t(Bin(bin.segment_num(), bin.view_num(), bin.axial_pos_num() + 1, bin.tangential_pos_num()))
-             - get_t(Bin(bin.segment_num(), bin.view_num(), bin.axial_pos_num() - 1, bin.tangential_pos_num())))
+                  - get_t(Bin(bin.segment_num(), bin.view_num(), bin.axial_pos_num() - 1, bin.tangential_pos_num())))
          / 2;
 }
 
@@ -101,7 +101,7 @@ float
 ProjDataInfo::get_sampling_in_m(const Bin& bin) const
 {
   return std::abs(get_m(Bin(bin.segment_num(), bin.view_num(), bin.axial_pos_num() + 1, bin.tangential_pos_num()))
-             - get_m(Bin(bin.segment_num(), bin.view_num(), bin.axial_pos_num() - 1, bin.tangential_pos_num())))
+                  - get_m(Bin(bin.segment_num(), bin.view_num(), bin.axial_pos_num() - 1, bin.tangential_pos_num())))
          / 2;
 }
 
@@ -109,7 +109,7 @@ float
 ProjDataInfo::get_sampling_in_s(const Bin& bin) const
 {
   return std::abs(get_s(Bin(bin.segment_num(), bin.view_num(), bin.axial_pos_num(), bin.tangential_pos_num() + 1))
-             - get_s(Bin(bin.segment_num(), bin.view_num(), bin.axial_pos_num(), bin.tangential_pos_num() - 1)))
+                  - get_s(Bin(bin.segment_num(), bin.view_num(), bin.axial_pos_num(), bin.tangential_pos_num() - 1)))
          / 2;
 }
 

--- a/src/buildblock/ProjDataInfo.cxx
+++ b/src/buildblock/ProjDataInfo.cxx
@@ -92,7 +92,7 @@ ProjDataInfo::get_sampling_in_k(const Bin& bin) const
 float
 ProjDataInfo::get_sampling_in_t(const Bin& bin) const
 {
-  return abs(get_t(Bin(bin.segment_num(), bin.view_num(), bin.axial_pos_num() + 1, bin.tangential_pos_num()))
+  return std::abs(get_t(Bin(bin.segment_num(), bin.view_num(), bin.axial_pos_num() + 1, bin.tangential_pos_num()))
              - get_t(Bin(bin.segment_num(), bin.view_num(), bin.axial_pos_num() - 1, bin.tangential_pos_num())))
          / 2;
 }
@@ -100,7 +100,7 @@ ProjDataInfo::get_sampling_in_t(const Bin& bin) const
 float
 ProjDataInfo::get_sampling_in_m(const Bin& bin) const
 {
-  return abs(get_m(Bin(bin.segment_num(), bin.view_num(), bin.axial_pos_num() + 1, bin.tangential_pos_num()))
+  return std::abs(get_m(Bin(bin.segment_num(), bin.view_num(), bin.axial_pos_num() + 1, bin.tangential_pos_num()))
              - get_m(Bin(bin.segment_num(), bin.view_num(), bin.axial_pos_num() - 1, bin.tangential_pos_num())))
          / 2;
 }
@@ -108,7 +108,7 @@ ProjDataInfo::get_sampling_in_m(const Bin& bin) const
 float
 ProjDataInfo::get_sampling_in_s(const Bin& bin) const
 {
-  return abs(get_s(Bin(bin.segment_num(), bin.view_num(), bin.axial_pos_num(), bin.tangential_pos_num() + 1))
+  return std::abs(get_s(Bin(bin.segment_num(), bin.view_num(), bin.axial_pos_num(), bin.tangential_pos_num() + 1))
              - get_s(Bin(bin.segment_num(), bin.view_num(), bin.axial_pos_num(), bin.tangential_pos_num() - 1)))
          / 2;
 }

--- a/src/buildblock/Radionuclide.cxx
+++ b/src/buildblock/Radionuclide.cxx
@@ -96,9 +96,9 @@ Radionuclide::get_modality(bool check) const
 bool
 Radionuclide::operator==(const Radionuclide& r) const
 {
-  return (abs(energy - r.energy) <= 1E-1 || (energy <= 0 && r.energy <= 0))
-         && (abs(branching_ratio - r.branching_ratio) <= 1E-1 || (branching_ratio <= 0 && r.branching_ratio <= 0))
-         && (abs(half_life - r.half_life) <= 1 || (r.half_life <= 0 && r.half_life <= 0)) && (modality == r.modality);
+  return (std::abs(energy - r.energy) <= 1E-1 || (energy <= 0 && r.energy <= 0))
+         && (std::abs(branching_ratio - r.branching_ratio) <= 1E-1 || (branching_ratio <= 0 && r.branching_ratio <= 0))
+         && (std::abs(half_life - r.half_life) <= 1 || (r.half_life <= 0 && r.half_life <= 0)) && (modality == r.modality);
 }
 
 END_NAMESPACE_STIR

--- a/src/buildblock/TimeFrameDefinitions.cxx
+++ b/src/buildblock/TimeFrameDefinitions.cxx
@@ -268,8 +268,8 @@ TimeFrameDefinitions::operator==(const TimeFrameDefinitions& t) const
   for (int frame = 0; frame < frame_times.size(); frame++)
     {
 
-      const bool is_identical = (abs(frame_times.at(frame).first - t.frame_times.at(frame).first) <= 10e-5)
-                                && (abs(frame_times.at(frame).second - t.frame_times.at(frame).second) <= 10e-5);
+      const bool is_identical = (std::abs(frame_times.at(frame).first - t.frame_times.at(frame).first) <= 10e-5)
+                                && (std::abs(frame_times.at(frame).second - t.frame_times.at(frame).second) <= 10e-5);
       if (!is_identical)
         return false;
     }

--- a/src/buildblock/extend_projdata.cxx
+++ b/src/buildblock/extend_projdata.cxx
@@ -74,9 +74,9 @@ extend_segment(const SegmentBySinogram<float>& segment,
   const auto average_phi_sampling = phi_range / (segment.get_proj_data_info_sptr()->get_num_views() - 1);
   // check if 360 or 180 degrees
   // use a rather large tolerance to cope with non-uniform sampling in BlocksOnCylindrical
-  if (abs(phi_range - 2 * _PI) < 5 * average_phi_sampling)
+  if (std::abs(phi_range - 2 * _PI) < 5 * average_phi_sampling)
     flip_views = false; // if views cover 360°, we can simply wrap around
-  else if ((abs(phi_range - _PI) < 5 * average_phi_sampling) && (segment.get_segment_num() == 0))
+  else if ((std::abs(phi_range - _PI) < 5 * average_phi_sampling) && (segment.get_segment_num() == 0))
     flip_views = true; // if views cover 180°, the tangential positions need to be flipped
   else
     {
@@ -97,7 +97,7 @@ extend_segment(const SegmentBySinogram<float>& segment,
             }
           else if (flip_views)
             {
-              const int sym_dim = std::min(abs(min_dim[3]), max_dim[3]);
+              const int sym_dim = std::min(std::abs(min_dim[3]), max_dim[3]);
               for (int tang_pos = -sym_dim; tang_pos <= sym_dim; tang_pos++)
                 {
                   out[axial_pos][min_dim[2] + view_edge][tang_pos]

--- a/src/buildblock/find_fwhm_in_image.cxx
+++ b/src/buildblock/find_fwhm_in_image.cxx
@@ -200,14 +200,14 @@ interpolate_line(const Array<3, elemT>& input_array,
 
     line_110 = extract_line(input_array, location_110, dimension);
     line_111 = extract_line(input_array, location_111, dimension);
-    line = line_000 * (1 - abs(z0)) * (1 - abs(y0)) * (1 - abs(x0));
-    line += line_001 * (1 - abs(z0)) * (1 - abs(y0)) * abs(x0);
-    line += line_010 * (1 - abs(z0)) * abs(y0) * (1 - abs(x0));
-    line += line_100 * abs(z0) * (1 - abs(y0)) * (1 - abs(x0));
-    line += line_011 * (1 - abs(z0)) * abs(y0) * abs(x0);
-    line += line_101 * abs(z0) * (1 - abs(y0)) * abs(x0);
-    line += line_110 * abs(z0) * abs(y0) * (1 - abs(x0));
-    line += line_111 * abs(z0) * abs(y0) * abs(x0);
+    line = line_000 * (1 - std::abs(z0)) * (1 - std::abs(y0)) * (1 - std::abs(x0));
+    line += line_001 * (1 - std::abs(z0)) * (1 - std::abs(y0)) * std::abs(x0);
+    line += line_010 * (1 - std::abs(z0)) * std::abs(y0) * (1 - std::abs(x0));
+    line += line_100 * std::abs(z0) * (1 - std::abs(y0)) * (1 - std::abs(x0));
+    line += line_011 * (1 - std::abs(z0)) * std::abs(y0) * std::abs(x0);
+    line += line_101 * std::abs(z0) * (1 - std::abs(y0)) * std::abs(x0);
+    line += line_110 * std::abs(z0) * std::abs(y0) * (1 - std::abs(x0));
+    line += line_111 * std::abs(z0) * std::abs(y0) * std::abs(x0);
   }
   return line;
 }

--- a/src/buildblock/inverse_SSRB.cxx
+++ b/src/buildblock/inverse_SSRB.cxx
@@ -87,12 +87,12 @@ inverse_SSRB(ProjData& proj_data_4D, const ProjData& proj_data_3D)
                   // for the first slice there is no previous
                   const auto distance_to_previous = in_ax_pos_num == proj_data_3D.get_min_axial_pos_num(0)
                                                         ? std::numeric_limits<float>::max()
-                                                        : abs(out_m - in_m.at(in_ax_pos_num - 1));
-                  const auto distance_to_current = abs(out_m - in_m.at(in_ax_pos_num));
+                                                        : std::abs(out_m - in_m.at(in_ax_pos_num - 1));
+                  const auto distance_to_current = std::abs(out_m - in_m.at(in_ax_pos_num));
                   // for the last slice there is no next
                   const auto distance_to_next = in_ax_pos_num == proj_data_3D.get_max_axial_pos_num(0)
                                                     ? std::numeric_limits<float>::max()
-                                                    : abs(out_m - in_m.at(in_ax_pos_num + 1));
+                                                    : std::abs(out_m - in_m.at(in_ax_pos_num + 1));
                   if (distance_to_current <= distance_to_previous && distance_to_current <= distance_to_next)
                     {
                       if (distance_to_current <= 1E-4)

--- a/src/recon_buildblock/ProjMatrixByBinSPECTUB.cxx
+++ b/src/recon_buildblock/ProjMatrixByBinSPECTUB.cxx
@@ -322,10 +322,10 @@ ProjMatrixByBinSPECTUB::set_up(const shared_ptr<const ProjDataInfo>& proj_data_i
   wmh.prj = prj;
   // wmh.NpixAngOS = vol.Npix * prj.NangOS;
 
-  if (abs(wmh.prj.thcm - vox.thcm) > .01F)
+  if (std::abs(wmh.prj.thcm - vox.thcm) > .01F)
     error(boost::format("SPECTUB Matrix (probably) only works with equal z-sampling for projection data (%1%) and image (%2%)")
           % (wmh.prj.thcm * 10) % (vol.thcm * 10));
-  if (abs(wmh.prj.Nsli - vol.Nsli) > .01F)
+  if (std::abs(wmh.prj.Nsli - vol.Nsli) > .01F)
     error(boost::format(
               "SPECTUB Matrix (probably) only works with equal number of slices for projection data (%1%) and image (%2%)")
           % wmh.prj.Nsli % vol.Nsli);

--- a/src/recon_buildblock/ProjMatrixByBinUsingRayTracing.cxx
+++ b/src/recon_buildblock/ProjMatrixByBinUsingRayTracing.cxx
@@ -266,7 +266,7 @@ ProjMatrixByBinUsingRayTracing::set_up(
 
   voxel_size = image_info_ptr->get_voxel_size();
   origin = image_info_ptr->get_origin();
-  if (abs(origin.x()) > .05F || abs(origin.y()) > .05F)
+  if (std::abs(origin.x()) > .05F || std::abs(origin.y()) > .05F)
     error("ProjMatrixByBinUsingRayTracing sadly doesn't support shifted x/y origin yet");
   image_info_sptr->get_regular_range(min_index, max_index);
 

--- a/src/recon_test/test_blocks_on_cylindrical_projectors.cxx
+++ b/src/recon_test/test_blocks_on_cylindrical_projectors.cxx
@@ -96,7 +96,7 @@ BlocksTests::set_blocks_projdata_info(shared_ptr<Scanner> scanner_sptr, int bin_
     {
       min_ring_diff_v[i] = i;
       max_ring_diff_v[i] = i;
-      num_axial_pos_per_segment[i] = scanner_sptr->get_num_rings() - abs(i);
+      num_axial_pos_per_segment[i] = scanner_sptr->get_num_rings() - std::abs(i);
     }
 
   auto proj_data_info_blocks_sptr
@@ -128,7 +128,7 @@ BlocksTests::set_direct_projdata_info(shared_ptr<Scanner> scanner_sptr, int bin_
     {
       min_ring_diff_v[i] = i;
       max_ring_diff_v[i] = i;
-      num_axial_pos_per_segment[i] = scanner_sptr->get_num_rings() - abs(i);
+      num_axial_pos_per_segment[i] = scanner_sptr->get_num_rings() - std::abs(i);
     }
 
   auto proj_data_info_blocks_sptr
@@ -369,7 +369,7 @@ BlocksTests::run_plane_symmetry_test(ForwardProjectorByBin& forw_projector1, For
     {
       Bin bin(0, i, 0, 0);
       proj_data_info_blocks_sptr->get_LOR(lorB1, bin);
-      if (abs(lorB1.phi() - phi1) / phi1 <= 1E-2)
+      if (std::abs(lorB1.phi() - phi1) / phi1 <= 1E-2)
         {
           view1_num = i;
           break;
@@ -381,7 +381,7 @@ BlocksTests::run_plane_symmetry_test(ForwardProjectorByBin& forw_projector1, For
     {
       Bin bin(0, i, 0, 0);
       proj_data_info_blocks_sptr->get_LOR(lorB2, bin);
-      if (abs(lorB2.phi() - phi2) / phi2 <= 1E-2)
+      if (std::abs(lorB2.phi() - phi2) / phi2 <= 1E-2)
         {
           view2_num = i;
           break;
@@ -821,11 +821,11 @@ BlocksTests::run_intersection_with_cylinder_test()
     const auto dot_product = line1.x() * line2.x() + line1.y() * line2.y() + line1.z() * line2.z();
     const auto length1 = sqrt(line1.x() * line1.x() + line1.y() * line1.y() + line1.z() * line1.z());
     const auto length2 = sqrt(line2.x() * line2.x() + line2.y() * line2.y() + line2.z() * line2.z());
-    return abs(dot_product) / length1 / length2 > 0.99;
+    return std::abs(dot_product) / length1 / length2 > 0.99;
   };
 
   auto point_is_on_cylinder = [](const CartesianCoordinate3D<float>& point, float radius) -> bool {
-    return abs(sqrt(point.x() * point.x() + point.y() * point.y()) - radius) < 0.1;
+    return std::abs(sqrt(point.x() * point.x() + point.y() * point.y()) - radius) < 0.1;
   };
 
   const auto segment_sequence = ProjData::standard_segment_sequence(*proj_data_info);

--- a/src/spatial_transformation_buildblock/warp_image.cxx
+++ b/src/spatial_transformation_buildblock/warp_image.cxx
@@ -43,12 +43,12 @@ warp_image(const shared_ptr<DiscretisedDensity<3, float>>& density_sptr,
   const BasicCoordinate<3, int> out_max = max;
 #if 0
   if (extend_borders==1) {
-    out_min[1]-=abs(voxel_shift_z) ;
-    out_min[2]-=abs(voxel_shift_y) ;
-    out_min[3]-=abs(voxel_shift_x) ;
-    out_max[1]+=abs(voxel_shift_z) ;
-    out_max[2]+=abs(voxel_shift_y) ;
-    out_max[3]+=abs(voxel_shift_x) ;
+    out_min[1]-=std::abs(voxel_shift_z) ;
+    out_min[2]-=std::abs(voxel_shift_y) ;
+    out_min[3]-=std::abs(voxel_shift_x) ;
+    out_max[1]+=std::abs(voxel_shift_z) ;
+    out_max[2]+=std::abs(voxel_shift_y) ;
+    out_max[3]+=std::abs(voxel_shift_x) ;
   }
 #endif
   const IndexRange<3> out_range(out_min, out_max);

--- a/src/test/test_interpolate_projdata.cxx
+++ b/src/test/test_interpolate_projdata.cxx
@@ -78,10 +78,10 @@ InterpolationTests::check_symmetry(const SegmentBySinogram<float>& segment)
         {
           for (auto tang = segment.get_min_tangential_pos_num(); tang <= segment.get_max_tangential_pos_num(); tang++)
             {
-              auto voxel1 = abs(segment[increasing_index][view][tang]);
-              auto voxel2 = abs(segment[decreasing_index][view][tang]);
-              if (abs(voxel1 - voxel2) > maxAbsDifference)
-                maxAbsDifference = abs(voxel1 - voxel2);
+              auto voxel1 = std::abs(segment[increasing_index][view][tang]);
+              auto voxel2 = std::abs(segment[decreasing_index][view][tang]);
+              if (std::abs(voxel1 - voxel2) > maxAbsDifference)
+                maxAbsDifference = std::abs(voxel1 - voxel2);
               if (voxel1 > 0)
                 {
                   sumAbsValues += voxel1;
@@ -114,8 +114,8 @@ InterpolationTests::check_symmetry(const SegmentBySinogram<float>& segment)
             {
               auto voxel1 = segment[axial][view][tang];
               auto voxel2 = segment[axial][view + segment.get_num_views() / 2][tang];
-              if (abs(voxel1 - voxel2) > maxAbsDifference)
-                maxAbsDifference = abs(voxel1 - voxel2);
+              if (std::abs(voxel1 - voxel2) > maxAbsDifference)
+                maxAbsDifference = std::abs(voxel1 - voxel2);
               if (voxel1 > 0)
                 {
                   sumAbsValues += voxel1;
@@ -149,7 +149,7 @@ InterpolationTests::compare_segment(const SegmentBySinogram<float>& segment1,
         {
           for (auto tang = segment1.get_min_tangential_pos_num(); tang <= segment1.get_max_tangential_pos_num(); tang++)
             {
-              sumAbsDifference += abs(segment1[axial][view][tang] - segment2[axial][view][tang]);
+              sumAbsDifference += std::abs(segment1[axial][view][tang] - segment2[axial][view][tang]);
             }
         }
     }

--- a/src/utilities/shift_image.cxx
+++ b/src/utilities/shift_image.cxx
@@ -74,12 +74,12 @@ main(int argc, char** argv)
   BasicCoordinate<3, int> out_max = max;
   if (extend_borders == 1)
     {
-      out_min[1] -= abs(voxel_shift_z);
-      out_min[2] -= abs(voxel_shift_y);
-      out_min[3] -= abs(voxel_shift_x);
-      out_max[1] += abs(voxel_shift_z);
-      out_max[2] += abs(voxel_shift_y);
-      out_max[3] += abs(voxel_shift_x);
+      out_min[1] -= std::abs(voxel_shift_z);
+      out_min[2] -= std::abs(voxel_shift_y);
+      out_min[3] -= std::abs(voxel_shift_x);
+      out_max[1] += std::abs(voxel_shift_z);
+      out_max[2] += std::abs(voxel_shift_y);
+      out_max[3] += std::abs(voxel_shift_x);
     }
   const IndexRange<3> out_range(out_min, out_max);
   VoxelsOnCartesianGrid<float> out_density(out_range, origin, grid_spacing);


### PR DESCRIPTION
## Changes in this pull request
Replaced all occurrences of abs() with std::abs()

## Testing performed
unit tests

## Related issues
fixes https://github.com/UCL/STIR/issues/1415


## Checklist before requesting a review
<!--Put an x between the [] when completed. Delete a line if not applicable. -->
  - [] I have performed a self-review of my code
  - [] I have added docstrings/doxygen in line with the guidance in the developer guide
  - [] I have implemented unit tests that cover any new or modified functionality (if applicable)
  - [] The code builds and runs on my machine
  - [] `documentation/release_XXX.md` has been updated with any functionality change (if applicable)
