### PR TITLE
Force use_actual_detector_boundaries to true for BlocksOnCylindrical

### DIFF
--- a/src/recon_buildblock/ProjMatrixByBinUsingRayTracing.cxx
+++ b/src/recon_buildblock/ProjMatrixByBinUsingRayTracing.cxx
@@ -264,6 +264,13 @@ ProjMatrixByBinUsingRayTracing::set_up(
 
   ProjMatrixByBin::set_up(proj_data_info_sptr_v, density_info_sptr_v);
 
+  if (proj_data_info_sptr->get_scanner_ptr()->get_scanner_geometry() == "BlocksOnCylindrical" && !use_actual_detector_boundaries)
+    {
+      warning("Setting use_actual_detector_boundaries to true, since this is the only supported setting for "
+              "BlocksOnCylindrical geometry");
+      use_actual_detector_boundaries = true;
+    }
+
   voxel_size = image_info_ptr->get_voxel_size();
   origin = image_info_ptr->get_origin();
   if (std::abs(origin.x()) > .05F || std::abs(origin.y()) > .05F)


### PR DESCRIPTION
## Changes in this pull request
Forced use_actual_detector_boundaries to true for BlocksOnCylindrical (in set_up).

## Testing performed
Unit tests.

## Related issues
Fixes https://github.com/UCL/STIR/issues/1428


## Checklist before requesting a review
<!--Put an x between the [] when completed. Delete a line if not applicable. -->
  - [] I have performed a self-review of my code
  - [] I have added docstrings/doxygen in line with the guidance in the developer guide
  - [] I have implemented unit tests that cover any new or modified functionality (if applicable)
  - [] The code builds and runs on my machine
  - [] `documentation/release_XXX.md` has been updated with any functionality change (if applicable)
