### PR TITLE
small rationalising of warnings

### DIFF
--- a/src/IO/InterfileHeader.cxx
+++ b/src/IO/InterfileHeader.cxx
@@ -1032,7 +1032,7 @@ InterfilePDFSHeader::post_processing()
         {
           warning("Inconsistent number of TOF bins (" + std::to_string(this->num_timing_poss)
                   + ") and size of the 'TOF bin order' list (" + std::to_string(this->timing_poss_sequence.size()) + ").");
-          // return true;
+          return true;
         }
     }
 
@@ -1042,8 +1042,8 @@ InterfilePDFSHeader::post_processing()
   bool originating_system_was_recognised = guessed_scanner_ptr->get_type() != Scanner::Unknown_scanner;
   if (!originating_system_was_recognised)
     {
-      warning("Interfile warning: I did not recognise the scanner from 'originating_system' ("
-              + get_exam_info().originating_system + ")");
+      info("Interfile warning: I did not recognise the scanner from 'originating_system' (" + get_exam_info().originating_system
+           + "). Hopefully there is enough information present. I will check this now.");
     }
 
   bool mismatch_between_header_and_guess = false;
@@ -1313,35 +1313,37 @@ InterfilePDFSHeader::post_processing()
       // warn if the Interfile header does not provide enough info
 
       if (num_rings < 1)
-        warning("Interfile warning: 'number of rings' invalid.\n");
+        warning("Interfile warning: 'number of rings' invalid.");
       if (num_detectors_per_ring < 1)
-        warning("Interfile warning: 'num_detectors_per_ring' invalid.\n");
+        warning("Interfile warning: 'num_detectors_per_ring' invalid.");
 #if 0
     if (transaxial_FOV_diameter_in_cm < 0)
-      warning("Interfile warning: 'transaxial FOV diameter (cm)' invalid.\n");
+      warning("Interfile warning: 'transaxial FOV diameter (cm)' invalid.");
 #endif
       if (inner_ring_diameter_in_cm <= 0)
-        warning("Interfile warning: 'inner ring diameter (cm)' invalid. This might disastrous\n");
-      if (average_depth_of_interaction_in_cm <= 0)
-        warning("Interfile warning: 'average depth of interaction (cm)' invalid. This might be disastrous.\n");
+        warning("Interfile warning: 'inner ring diameter (cm)' invalid. This might be disastrous.");
+      if (average_depth_of_interaction_in_cm < 0)
+        warning("Interfile warning: 'average depth of interaction (cm)' invalid. This might be disastrous.");
       if (distance_between_rings_in_cm <= 0)
-        warning("Interfile warning: 'distance between rings (cm)' invalid.\n");
+        warning("Interfile warning: 'distance between rings (cm)' invalid.");
       if (default_bin_size_in_cm <= 0)
-        warning("Interfile warning: 'default_bin size (cm)' invalid.\n");
+        warning("Interfile warning: 'default_bin size (cm)' invalid. This will likely cause problems in image reconstruction "
+                "when setting image sizes via 'zoom' etc.");
       if (num_axial_crystals_per_singles_unit <= 0)
-        warning("Interfile warning: 'axial crystals per singles unit' invalid.\n");
+        warning("Interfile warning: 'axial crystals per singles unit' invalid (but currently only used for ECAT dead-time).");
       if (num_transaxial_crystals_per_singles_unit <= 0)
-        warning("Interfile warning: 'transaxial crystals per singles unit' invalid.\n");
-      // new variables for block geometry
-      if (axial_distance_between_crystals_in_cm <= 0)
-        warning("Interfile warning: 'distance between crystals in axial direction (cm)' invalid.\n");
-      if (transaxial_distance_between_crystals_in_cm <= 0)
-        warning("Interfile warning: 'distance between crystals in transaxial direction (cm)' invalid.\n");
-      if (axial_distance_between_blocks_in_cm <= 0)
-        warning("Interfile warning: 'distance between blocks in axial direction (cm)' invalid.\n");
-      if (transaxial_distance_between_blocks_in_cm <= 0)
-        warning("Interfile warning: 'distance between blocks in transaxial direction (cm)' invalid.\n");
-      // end of new variables for block geometry
+        warning("Interfile warning: 'transaxial crystals per singles unit' invalid (but currently only used for ECAT dead-time)");
+      if (scanner_geometry == "BlocksOnCylindrical")
+        {
+          if (axial_distance_between_crystals_in_cm <= 0)
+            warning("Interfile warning: 'distance between crystals in axial direction (cm)' invalid.");
+          if (transaxial_distance_between_crystals_in_cm <= 0)
+            warning("Interfile warning: 'distance between crystals in transaxial direction (cm)' invalid.");
+          if (axial_distance_between_blocks_in_cm <= 0)
+            warning("Interfile warning: 'distance between blocks in axial direction (cm)' invalid.");
+          if (transaxial_distance_between_blocks_in_cm <= 0)
+            warning("Interfile warning: 'distance between blocks in transaxial direction (cm)' invalid.");
+        }
     }
 
   // finally, we construct a new scanner object with
@@ -1382,8 +1384,8 @@ InterfilePDFSHeader::post_processing()
       || scanner_sptr_from_file->get_type() == Scanner::User_defined_scanner || mismatch_between_header_and_guess
       || !is_consistent)
     {
-      warning(boost::format("Interfile parsing ended up with the following scanner:\n%s\n")
-              % scanner_sptr_from_file->parameter_info());
+      info(boost::format("Interfile parsing ended up with the following scanner:\n%s\n")
+           % scanner_sptr_from_file->parameter_info());
     }
 
   // float azimuthal_angle_sampling =_PI/num_views;

--- a/src/recon_buildblock/DataSymmetriesForBins_PET_CartesianGrid.cxx
+++ b/src/recon_buildblock/DataSymmetriesForBins_PET_CartesianGrid.cxx
@@ -334,7 +334,7 @@ DataSymmetriesForBins_PET_CartesianGrid::DataSymmetriesForBins_PET_CartesianGrid
       if (fabs(proj_data_info_ptr->get_phi(Bin(0, 0, 0, 0))) > 1.E-4F
           && (this->do_symmetry_90degrees_min_phi || this->do_symmetry_180degrees_min_phi))
         {
-          warning("Disabling symmetries as image is rotated due to phi offset of the scanner.");
+          info("Disabling symmetries for the projector as image is rotated due to phi offset of the scanner.");
           this->do_symmetry_90degrees_min_phi = false;
           this->do_symmetry_180degrees_min_phi = false;
         }
@@ -344,20 +344,20 @@ DataSymmetriesForBins_PET_CartesianGrid::DataSymmetriesForBins_PET_CartesianGrid
         {
           if (this->do_symmetry_90degrees_min_phi || this->do_symmetry_180degrees_min_phi)
             {
-              warning("Disabling rotational symmetries with TOF data as this is untested.");
+              info("Disabling rotational symmetries for the projector with TOF data as this is untested.");
               this->do_symmetry_90degrees_min_phi = false;
               this->do_symmetry_180degrees_min_phi = false;
             }
 
           if (this->do_symmetry_swap_segment)
             {
-              warning("Disabling segment swapping with TOF data as this is untested.");
+              info("Disabling segment swapping for the projector with TOF data as this is untested.");
               this->do_symmetry_swap_segment = false;
             }
 
           if (this->do_symmetry_swap_s)
             {
-              warning("Disabling swap s with TOF data as this is untested.");
+              info("Disabling swap s symmetry for the projector with TOF data as this is untested.");
               this->do_symmetry_swap_s = false;
             }
         }
@@ -368,7 +368,7 @@ DataSymmetriesForBins_PET_CartesianGrid::DataSymmetriesForBins_PET_CartesianGrid
           if (this->do_symmetry_90degrees_min_phi || this->do_symmetry_180degrees_min_phi || this->do_symmetry_swap_segment
               || this->do_symmetry_swap_s)
             {
-              warning("Disabling symmetries in transaxial plane as image is shifted");
+              info("Disabling symmetries for the projector in transaxial plane as image is shifted");
               this->do_symmetry_90degrees_min_phi = this->do_symmetry_180degrees_min_phi = this->do_symmetry_swap_segment
                   = this->do_symmetry_swap_s = false;
             }
@@ -405,7 +405,8 @@ DataSymmetriesForBins_PET_CartesianGrid::DataSymmetriesForBins_PET_CartesianGrid
       if (this->do_symmetry_90degrees_min_phi || this->do_symmetry_180degrees_min_phi || this->do_symmetry_swap_segment
           || this->do_symmetry_swap_s)
         {
-          warning("Disabling all symmetries except for symmtery_z since they are not implemented in block geometry yet.");
+          info("Disabling all symmetries for the projector except for symmetry_z since they are not implemented in block "
+               "geometry yet.");
           this->do_symmetry_90degrees_min_phi = this->do_symmetry_180degrees_min_phi = this->do_symmetry_swap_segment
               = this->do_symmetry_swap_s = this->do_symmetry_shift_z = false;
         }
@@ -447,7 +448,7 @@ DataSymmetriesForBins_PET_CartesianGrid::DataSymmetriesForBins_PET_CartesianGrid
       if (this->do_symmetry_90degrees_min_phi || this->do_symmetry_180degrees_min_phi || this->do_symmetry_swap_segment
           || this->do_symmetry_swap_s || this->do_symmetry_shift_z)
         {
-          warning("Disabling all symmetries since they are not implemented in generic geometry.");
+          info("Disabling all symmetries for the projector since they are not implemented in generic geometry.");
           this->do_symmetry_90degrees_min_phi = this->do_symmetry_180degrees_min_phi = this->do_symmetry_swap_segment
               = this->do_symmetry_swap_s = this->do_symmetry_shift_z = false;
         }


### PR DESCRIPTION
- remove warnings related to block variables when parsing a cylindrical scanner
- some explanation in warnings
- convert warnings on disabled symmetries to info()
