### PR TITLE
TOF mashing = TOF bins fixes

### DIFF
--- a/src/buildblock/ProjDataInfo.cxx
+++ b/src/buildblock/ProjDataInfo.cxx
@@ -177,41 +177,9 @@ ProjDataInfo::set_tof_mash_factor(const int new_num)
     {
       tof_mash_factor = new_num;
       if (tof_mash_factor > scanner_ptr->get_max_num_timing_poss())
-        {
         error("ProjDataInfo::set_tof_mash_factor: TOF mashing factor (" + std::to_string(tof_mash_factor)
               + +") must be smaller than or equal to the scanner's number of max timing bins ("
               + std::to_string(scanner_ptr->get_max_num_timing_poss()) + ").");
-        }
-      else if (tof_mash_factor == num_tof_bins)
-        // This is a special case that we just want boundaries for the coincidence window.
-        {
-
-          Bin bin;
-          bin.timing_pos_num() = min_tof_pos_num;
-          //Get lowest low
-          float cur_low = get_k(bin) - get_sampling_in_k(bin) / 2.f;
-          //Get highest high
-          bin.timing_pos_num() = max_tof_pos_num;
-          float cur_high = get_k(bin) + get_sampling_in_k(bin) / 2.f;
-
-
-          min_tof_pos_num = 0;
-          max_tof_pos_num = 0;
-          num_tof_bins = 1;
-          // Upper and lower boundaries of the timing poss;
-          tof_bin_boundaries_mm.recycle();
-          tof_bin_boundaries_mm.grow(min_tof_pos_num, max_tof_pos_num);
-          tof_bin_boundaries_ps.recycle();
-          tof_bin_boundaries_ps.grow(min_tof_pos_num, max_tof_pos_num);
-
-          tof_bin_boundaries_mm[0].low_lim = cur_low;
-          tof_bin_boundaries_mm[0].high_lim = cur_high;
-
-          tof_bin_boundaries_ps[0].low_lim = static_cast<float>(mm_to_tof_delta_time(tof_bin_boundaries_mm[0].low_lim));
-          tof_bin_boundaries_ps[0].high_lim = static_cast<float>(mm_to_tof_delta_time(tof_bin_boundaries_mm[0].high_lim));
-
-          return;
-        }
 
 #if 0
         // KT: code disabled as buggy but currently not needed
@@ -320,7 +288,7 @@ ProjDataInfo::ProjDataInfo(const shared_ptr<Scanner>& scanner_ptr_v,
   max_tof_pos_num = 0;
   tof_increament_in_mm = 0.f;
   tof_mash_factor = 0;
-  num_tof_bins = 0;
+  num_tof_bins = 1;
 }
 
 // TOF version.

--- a/src/buildblock/Scanner.cxx
+++ b/src/buildblock/Scanner.cxx
@@ -1231,63 +1231,65 @@ Scanner::Scanner(Type scanner_type)
       );
       break;
 
-
     case PSMR_3rings_scanner:
       set_params(PSMR_3rings_scanner,
                  string_list("PSMR_3rings_scanner"),
-                 3 * 14 * 6,// + 8,
+                 3 * 14 * 6, // + 8,
                  411,
                  401,
                  24 * 7 * 5,
-                 405.0 - 18/2,
+                 405.0 - 18 / 2,
                  7.0F,
                  2.85F,
                  2.08626F,
                  static_cast<float>(-0.137), //-0.18
-                 14,//            int num_axial_blocks_per_bucket_v,
-                 5,  //            int num_transaxial_blocks_per_bucket_v,
-                 6, //            int num_axial_crystals_per_block_v,
-                 7,//            int num_transaxial_crystals_per_block_v,
-                 84, //            int num_axial_crystals_per_singles_unit_v,
-                 35,  //            int num_transaxial_crystals_per_singles_unit_v,
+                 14,                         //            int num_axial_blocks_per_bucket_v,
+                 5,                          //            int num_transaxial_blocks_per_bucket_v,
+                 6,                          //            int num_axial_crystals_per_block_v,
+                 7,                          //            int num_transaxial_crystals_per_block_v,
+                 84,                         //            int num_axial_crystals_per_singles_unit_v,
+                 35,                         //            int num_transaxial_crystals_per_singles_unit_v,
                  1,
-                 0.0F, 511.F,
+                 0.0F,
+                 511.F,
 #ifdef STIR_TOF
                  1,
-                 2011.5F*2.F, // Size of coincidence window
+                 2011.5F * 2.F, // Size of coincidence window
                  0.F
 #endif
-                 );
+      );
       break;
 
-  case PSMR_3rings_scanner_TOF:
-    set_params(PSMR_3rings_scanner_TOF,
-               string_list("PSMR_3rings_scanner_TOF"),
-               3 * 14 * 6,// + 8,
-               344, 344,
-               24 * 7 * 5,
-               405.0 - 18/2,
-               7.0F,
-               2.85F,
-               2.08626F,
-               static_cast<float>(-0.137),
-               14,//            int num_axial_blocks_per_bucket_v,
-               5,  //            int num_transaxial_blocks_per_bucket_v,
-               6, //            int num_axial_crystals_per_block_v,
-               7,//            int num_transaxial_crystals_per_block_v,
-               252, //            int num_axial_crystals_per_singles_unit_v,
-               35,  //            int num_transaxial_crystals_per_singles_unit_v,
-               1,
-               0.0F, 511.F,
+    case PSMR_3rings_scanner_TOF:
+      set_params(PSMR_3rings_scanner_TOF,
+                 string_list("PSMR_3rings_scanner_TOF"),
+                 3 * 14 * 6, // + 8,
+                 344,
+                 344,
+                 24 * 7 * 5,
+                 405.0 - 18 / 2,
+                 7.0F,
+                 2.85F,
+                 2.08626F,
+                 static_cast<float>(-0.137),
+                 14, //            int num_axial_blocks_per_bucket_v,
+                 5,  //            int num_transaxial_blocks_per_bucket_v,
+                 6,  //            int num_axial_crystals_per_block_v,
+                 7,  //            int num_transaxial_crystals_per_block_v,
+                 84, //            int num_axial_crystals_per_singles_unit_v,
+                 35, //            int num_transaxial_crystals_per_singles_unit_v,
+                 1,
+                 0.0F,
+                 511.F,
 #ifdef STIR_TOF
-               //               (short int)(2*3.51*1000 -1),
-               //               (float)(1.f),
-               (short int)(13), // 13 TOF bins
-               (float)(2011.5F*2.F/13), //
-               (float)(500.F)
+                 //               (short int)(2*3.51*1000 -1),
+                 //               (float)(1.f),
+                 (short int)(13),             // 13 TOF bins
+                 (float)(2011.5F * 2.F / 13), //
+                 (float)(500.F)
 #endif
-               );
-    break;
+      );
+      break;
 
     case User_defined_scanner: // zlong, 08-04-2004, Userdefined support
 

--- a/src/include/stir/ProjDataInfo.inl
+++ b/src/include/stir/ProjDataInfo.inl
@@ -48,7 +48,7 @@ shared_ptr<ProjDataInfo>
 ProjDataInfo::create_single_tof_clone() const
 {
   shared_ptr<ProjDataInfo> sptr(this->clone());
-  int a  = sptr->get_num_tof_poss();
+  int a = sptr->get_num_tof_poss();
   if (a > 0)
     sptr->set_tof_mash_factor(a);
   // - TODO: remove this later
@@ -90,8 +90,12 @@ ProjDataInfo::get_num_tof_poss() const
 int
 ProjDataInfo::get_tof_bin(const double delta) const
 {
-  if (!is_tof_data())
-    return 0;
+  if (this->get_num_tof_poss() == 1)
+    {
+      assert(min_tof_pos_num == 0);
+      assert(max_tof_pos_num == 0);
+      return 0;
+    }
 
   for (int i = min_tof_pos_num; i <= max_tof_pos_num; ++i)
     {
@@ -198,7 +202,8 @@ ProjDataInfo::is_tof_data() const
     {
       if (num_tof_bins != 1)
         {
-          warning("Non-TOF data with inconsistent Time-of-Flight bin number - Note. As we are updating the scanner template style please make sure to have one TOF position (whole coincidence window for nonTOF scanners).");
+          warning("Non-TOF data with inconsistent Time-of-Flight bin number - Note. As we are updating the scanner template "
+                  "style please make sure to have one TOF position (whole coincidence window for nonTOF scanners).");
         }
       return false;
     }


### PR DESCRIPTION
@NikEfth As per my review. I need these changes to all tests to work. In addition, the code should still do what you want it to.

One particular change that I need is in `ProjDataInfo::get_tof_bin` where we can no longer check on `is_tof_data`, as when that is `false`, it goes into the next part of the code, but that fails as the relevant arrays are not set-up.

Sorry for the white-space changes, but this is due to precommit. If you're running Ubuntu 22.04, consider installing `clang-format` and `pre-commit` as https://github.com/UCL/STIR/blob/master/documentation/devel/git-hooks.md