### PR TITLE
use conda for pre-commit/clang-format versioning

### DIFF
--- a/.github/workflows/pre-commit-check.yml
+++ b/.github/workflows/pre-commit-check.yml
@@ -8,6 +8,9 @@ jobs:
     name: pre-commit
     steps:
     - uses: actions/checkout@v4
-    - uses: actions/setup-python@v5
-    - run: sudo apt-get install -yqq clang-format
+    - uses: conda-incubator/setup-miniconda@v3
+      with:
+          activate-environment: pre-commit-env
+          environment-file: pre-commit-environment.yml
+          auto-activate-base: false
     - uses: pre-commit/action@v3.0.0

--- a/documentation/devel/git-hooks.md
+++ b/documentation/devel/git-hooks.md
@@ -1,8 +1,24 @@
 # Developer documentation: how to install (software for) git hooks
 
+We use [pre-commit](https://pre-commit.com) to check coding conventions, including
+white-space formatting rules.
+
+Unfortunately, exact formatting used depends on the `clang-format` version. Therefore,
+you do have to install the same version as what is currently used in our GitHub Action.
+
+## Installation of software
+
+We highly recommend to use `conda`:
+```sh
+cd /whereever/STIR
+conda env create --file pre-commit-environment.yml
+conda activate pre-commit-env
+```
+
+### Alternative
 You first need to have Python and pip
 
-## Install [pre-commit](https://pre-commit.com)
+### Install [pre-commit](https://pre-commit.com)
 See https://pre-commit.com/#install but the following might work.
 
     pip install pre-commit
@@ -13,13 +29,11 @@ If that fails with a message about `PyYAML` and `distutils`, try
 
     pip install --ignore-installed PyYAML
 
-## Install clang-format
-### debian/Ubuntu
+### Install clang-format (correct version)
+At the time of writing, the `clang-format` version in `pre-commit-environment.yml`
+is the same default version in Ubuntu 22.04, so if you are using that, you could do
+
     sudo apt install clang-format
-### MacOS
-    brew install clang-format
-### Others
-search the internet and tell us
 
 ## Enable pre-commit hooks
 ```sh
@@ -31,6 +45,6 @@ If you need to work with a branch that was forked prior to in inclusion of clang
 
     pre-commit uninstall
 
-or once-off with
+or one-off with
 
     git commit --no-verify

--- a/documentation/devel/git-hooks.md
+++ b/documentation/devel/git-hooks.md
@@ -15,36 +15,37 @@ conda env create --file pre-commit-environment.yml
 conda activate pre-commit-env
 ```
 
-### Alternative
-You first need to have Python and pip
+Alternative:
 
-### Install [pre-commit](https://pre-commit.com)
-See https://pre-commit.com/#install but the following might work.
+1. Install Python and pip
 
-    pip install pre-commit
+2. Install [pre-commit](https://pre-commit.com). See https://pre-commit.com/#install but the following might work.
+   ```sh
+   pip install pre-commit
+   ```
+   If this fails with a permission error, try adding `--user` to the command. If that fails with a message about `PyYAML` and `distutils`, try
+   ```sh
+   pip install --ignore-installed PyYAML
+   ```
 
-If this fails with a permission error, try adding `--user` to the command.
-
-If that fails with a message about `PyYAML` and `distutils`, try
-
-    pip install --ignore-installed PyYAML
-
-### Install clang-format (correct version)
-At the time of writing, the `clang-format` version in `pre-commit-environment.yml`
-is the same default version in Ubuntu 22.04, so if you are using that, you could do
-
+3. Install clang-format (but use correct version). At the time of writing, on Ubuntu 22.04, you can do
+   ```sh
     sudo apt install clang-format
+   ```
 
 ## Enable pre-commit hooks
+
 ```sh
 cd /whereever/STIR
 pre-commit install
 ```
 
-If you need to work with a branch that was forked prior to in inclusion of clang-format, you will need to temporarily disable/uninstall pre-commit again:
+If you need to work with a branch that was forked prior to our use of `clang-format`, you will need to temporarily disable/uninstall pre-commit again:
 
     pre-commit uninstall
 
 or one-off with
 
     git commit --no-verify
+
+You will then need to run `pre-commit run --all-files` when done before we will merge your pull request.

--- a/documentation/devel/git-hooks.md
+++ b/documentation/devel/git-hooks.md
@@ -30,7 +30,7 @@ Alternative:
 
 3. Install clang-format (but use correct version). At the time of writing, on Ubuntu 22.04, you can do
    ```sh
-    sudo apt install clang-format
+   sudo apt install clang-format
    ```
 
 ## Enable pre-commit hooks

--- a/pre-commit-environment.yml
+++ b/pre-commit-environment.yml
@@ -1,0 +1,7 @@
+name: pre-commit-env
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - pre-commit
+  - clang-format=14.0


### PR DESCRIPTION
Force version of clang-format via conda