### PR TITLE
Use contiguous Arrays more

### DIFF
--- a/src/buildblock/ProjDataInMemory.cxx
+++ b/src/buildblock/ProjDataInMemory.cxx
@@ -24,6 +24,7 @@
 */
 
 #include "stir/ProjDataInMemory.h"
+#include "stir/copy_fill.h"
 #include "stir/shared_ptr.h"
 #include "stir/Succeeded.h"
 #include "stir/SegmentByView.h"
@@ -94,7 +95,7 @@ copy_data_from_buffer(const Array<1, float>& buffer, Array<num_dimensions, float
 #endif
   {
     const float* ptr = buffer.get_const_data_ptr() + offset;
-    std::copy(ptr, ptr + array.size_all(), array.begin_all());
+    fill_from(array, ptr, ptr + array.size_all());
     buffer.release_const_data_ptr();
   }
 }
@@ -108,7 +109,7 @@ copy_data_to_buffer(Array<1, float>& buffer, const Array<num_dimensions, float>&
 #endif
   {
     float* ptr = buffer.get_data_ptr() + offset;
-    std::copy(array.begin_all(), array.end_all(), ptr);
+    copy_to(array, ptr);
     buffer.release_data_ptr();
   }
 }

--- a/src/buildblock/ProjDataInMemory.cxx
+++ b/src/buildblock/ProjDataInMemory.cxx
@@ -14,7 +14,7 @@
     Copyright (C) 2002 - 2011-02-23, Hammersmith Imanet Ltd
     Copyright (C) 2011, Kris Thielemans
     Copyright (C) 2016, University of Hull
-    Copyright (C) 2016, 2019, 2020, 2023, UCL
+    Copyright (C) 2016, 2019, 2020, 2023, 2024, UCL
     Copyright (C) 2020,  Rutherford Appleton Laboratory STFC
     This file is part of STIR.
 
@@ -117,30 +117,11 @@ copy_data_to_buffer(Array<1, float>& buffer, const Array<num_dimensions, float>&
 Viewgram<float>
 ProjDataInMemory::get_viewgram(const int view_num,
                                const int segment_num,
-                               const bool make_num_tangential_poss_odd
-#ifdef STIR_TOF
-                               ,
-                               const int timing_pos
-#endif
-) const
+                               const bool make_num_tangential_poss_odd,
+                               const int timing_pos) const
 {
-  Viewgram<float> viewgram(proj_data_info_sptr,
-                           view_num,
-                           segment_num
-#ifdef STIR_TOF
-                           ,
-                           timing_pos
-#endif
-  );
-  Bin bin(segment_num,
-          view_num,
-          this->get_min_axial_pos_num(segment_num),
-          this->get_min_tangential_pos_num()
-#ifdef STIR_TOF
-              ,
-          timing_pos
-#endif
-  );
+  Bin bin(segment_num, view_num, this->get_min_axial_pos_num(segment_num), this->get_min_tangential_pos_num(), timing_pos);
+  Viewgram<float> viewgram(proj_data_info_sptr, bin);
 
   for (bin.axial_pos_num() = get_min_axial_pos_num(segment_num); bin.axial_pos_num() <= get_max_axial_pos_num(segment_num);
        bin.axial_pos_num()++)
@@ -176,19 +157,9 @@ ProjDataInMemory::set_viewgram(const Viewgram<float>& v)
     }
   const int segment_num = v.get_segment_num();
   const int view_num = v.get_view_num();
-#ifdef STIR_TOF
   const int timing_pos = v.get_timing_pos_num();
-#endif
 
-  Bin bin(segment_num,
-          view_num,
-          this->get_min_axial_pos_num(segment_num),
-          this->get_min_tangential_pos_num()
-#ifdef STIR_TOF
-              ,
-          timing_pos
-#endif
-  );
+  Bin bin(segment_num, view_num, this->get_min_axial_pos_num(segment_num), this->get_min_tangential_pos_num(), timing_pos);
 
   for (bin.axial_pos_num() = get_min_axial_pos_num(segment_num); bin.axial_pos_num() <= get_max_axial_pos_num(segment_num);
        bin.axial_pos_num()++)
@@ -208,10 +179,8 @@ ProjDataInMemory::get_index(const Bin& this_bin) const
   if (!(this_bin.axial_pos_num() >= get_min_axial_pos_num(this_bin.segment_num())
         && this_bin.axial_pos_num() <= get_max_axial_pos_num(this_bin.segment_num())))
     error("ProjDataInMemory::this->get_index: axial_pos_num out of range : %d", this_bin.axial_pos_num());
-#ifdef STIR_TOF
   if (!(this_bin.timing_pos_num() >= get_min_tof_pos_num() && this_bin.timing_pos_num() <= get_max_tof_pos_num()))
     error("ProjDataInMemory::this->get_index: timing_pos_num out of range : %d", this_bin.timing_pos_num());
-#endif
 
   const int index = static_cast<int>(std::find(segment_sequence.begin(), segment_sequence.end(), this_bin.segment_num())
                                      - segment_sequence.begin());
@@ -225,7 +194,6 @@ ProjDataInMemory::get_index(const Bin& this_bin) const
 
   // Now we are just in front of  the correct segment
   {
-#ifdef STIR_TOF
     if (proj_data_info_sptr->get_num_tof_poss() > 1)
       {
         const int timing_index
@@ -235,7 +203,6 @@ ProjDataInMemory::get_index(const Bin& this_bin) const
         assert(offset_3d_data > 0);
         segment_offset += static_cast<streamoff>(timing_index) * offset_3d_data;
       }
-#endif
     // skip axial positions
     const streamoff ax_pos_offset = (this_bin.axial_pos_num() - get_min_axial_pos_num(this_bin.segment_num())) * get_num_views()
                                     * get_num_tangential_poss();
@@ -255,30 +222,11 @@ ProjDataInMemory::get_index(const Bin& this_bin) const
 Sinogram<float>
 ProjDataInMemory::get_sinogram(const int ax_pos_num,
                                const int segment_num,
-                               const bool make_num_tangential_poss_odd
-#ifdef STIR_TOF
-                               ,
-                               const int timing_pos
-#endif
-) const
+                               const bool make_num_tangential_poss_odd,
+                               const int timing_pos) const
 {
-  Sinogram<float> sinogram(proj_data_info_sptr,
-                           ax_pos_num,
-                           segment_num
-#ifdef STIR_TOF
-                           ,
-                           timing_pos
-#endif
-  );
-  Bin bin(segment_num,
-          this->get_min_view_num(),
-          ax_pos_num,
-          this->get_min_tangential_pos_num()
-#ifdef STIR_TOF
-              ,
-          timing_pos
-#endif
-  );
+  Sinogram<float> sinogram(proj_data_info_sptr, ax_pos_num, segment_num, timing_pos);
+  Bin bin(segment_num, this->get_min_view_num(), ax_pos_num, this->get_min_tangential_pos_num(), timing_pos);
 
   detail::copy_data_from_buffer(this->buffer, sinogram, this->get_index(bin));
 
@@ -307,66 +255,31 @@ ProjDataInMemory::set_sinogram(const Sinogram<float>& s)
     }
   int segment_num = s.get_segment_num();
   int ax_pos_num = s.get_axial_pos_num();
-#ifdef STIR_TOF
   int timing_pos = s.get_timing_pos_num();
-#endif
-  Bin bin(segment_num,
-          this->get_min_view_num(),
-          ax_pos_num,
-          this->get_min_tangential_pos_num()
-#ifdef STIR_TOF
-              ,
-          timing_pos
-#endif
-  );
+  Bin bin(segment_num, this->get_min_view_num(), ax_pos_num, this->get_min_tangential_pos_num(), timing_pos);
 
   detail::copy_data_to_buffer(this->buffer, s, this->get_index(bin));
   return Succeeded::yes;
 }
 
 SegmentBySinogram<float>
-ProjDataInMemory::get_segment_by_sinogram(const int segment_num
-#ifdef STIR_TOF
-                                          ,
-                                          const int timing_pos_num
-#endif
-) const
+ProjDataInMemory::get_segment_by_sinogram(const int segment_num, const int timing_pos_num) const
 {
-  SegmentBySinogram<float> segment(proj_data_info_sptr,
-                                   segment_num
-#ifdef STIR_TOF
-                                   ,
-                                   timing_pos_num
-#endif
-  );
   const Bin bin(segment_num,
                 this->get_min_view_num(),
                 this->get_min_axial_pos_num(segment_num),
-                this->get_min_tangential_pos_num()
-#ifdef STIR_TOF
-                    ,
-                timing_pos_num
-#endif
-  );
+                this->get_min_tangential_pos_num(),
+                timing_pos_num);
+  SegmentBySinogram<float> segment(proj_data_info_sptr, bin);
   detail::copy_data_from_buffer(this->buffer, segment, this->get_index(bin));
   return segment;
 }
 
 SegmentByView<float>
-ProjDataInMemory::get_segment_by_view(const int segment_num
-#ifdef STIR_TOF
-                                      ,
-                                      const int timing_pos
-#endif
-) const
+ProjDataInMemory::get_segment_by_view(const int segment_num, const int timing_pos) const
 {
   // TODO rewrite in terms of get_sinogram as this doubles memory temporarily
-  return SegmentByView<float>(get_segment_by_sinogram(segment_num
-#ifdef STIR_TOF
-                                                      ,
-                                                      timing_pos
-#endif
-                                                      ));
+  return SegmentByView<float>(get_segment_by_sinogram(segment_num, timing_pos));
 }
 
 Succeeded
@@ -387,12 +300,8 @@ ProjDataInMemory::set_segment(const SegmentBySinogram<float>& segmentbysinogram_
   const Bin bin(segment_num,
                 this->get_min_view_num(),
                 this->get_min_axial_pos_num(segment_num),
-                this->get_min_tangential_pos_num()
-#ifdef STIR_TOF
-                    ,
-                segmentbysinogram_v.get_timing_pos_num()
-#endif
-  );
+                this->get_min_tangential_pos_num(),
+                segmentbysinogram_v.get_timing_pos_num());
 
   detail::copy_data_to_buffer(this->buffer, segmentbysinogram_v, this->get_index(bin));
   return Succeeded::yes;

--- a/src/include/stir/Array.h
+++ b/src/include/stir/Array.h
@@ -229,13 +229,15 @@ public:
   //! return minimum of all the elements
   inline elemT find_min() const;
 
-  //! Fill elements with value n (overrides VectorWithOffset::fill)
+  //! Fill elements with value \c n
+  /*!
+    hides VectorWithOffset::fill
+   */
   inline void fill(const elemT& n);
-
-  //! Sets elements below value to the value (overrides VectorWithOffset::fill)
+  //! Sets elements below value to the value
   inline void apply_lower_threshold(const elemT& l);
 
-  //! Sets elements above value to the value (overrides VectorWithOffset::fill)
+  //! Sets elements above value to the value
   inline void apply_upper_threshold(const elemT& u);
 
   //! checks if the index range is 'regular'

--- a/src/test/test_Array.cxx
+++ b/src/test/test_Array.cxx
@@ -43,7 +43,9 @@
 
 #include "stir/ArrayFunction.h"
 #include "stir/array_index_functions.h"
+#include "stir/copy_fill.h"
 #include <functional>
+#include <algorithm>
 
 // for open_read/write_binary
 #include "stir/utilities.h"
@@ -730,6 +732,28 @@ ArrayTests::run_tests()
       {
         Array<3, float>::full_iterator titer = test.begin_all();
         Array<3, float>::const_full_iterator ctiter = titer; // this should compile
+      }
+    }
+    // fill_from/copy_to
+    {
+      // make data a bit more interesting
+      std::iota(test3.begin_all(), test3.end_all(), 1.5F);
+      // regular
+      {
+        Array<3, float> data_to_fill(test3.get_index_range());
+        fill_from(data_to_fill, test3.begin_all(), test3.end_all());
+        check_if_equal(test3, data_to_fill, "test on 3D fill_from");
+        copy_to(test3, data_to_fill.begin_all());
+        check_if_equal(test3, data_to_fill, "test on 3D copy_to");
+      }
+      // irregular
+      {
+        test3[0][1].resize(-1, 2);
+        Array<3, float> data_to_fill(test3.get_index_range());
+        fill_from(data_to_fill, test3.begin_all(), test3.end_all());
+        check_if_equal(test3, data_to_fill, "test on 3D fill_from, irregular range");
+        copy_to(test3, data_to_fill.begin_all());
+        check_if_equal(test3, data_to_fill, "test on 3D copy_to, irregular range");
       }
     }
   }

--- a/src/test/test_proj_data.cxx
+++ b/src/test/test_proj_data.cxx
@@ -2,6 +2,7 @@
 
   \file
   \ingroup test
+  \ingroup projdata
 
   \brief Test program for stir::ProjData and stir::ProjDataInMemory
 
@@ -10,7 +11,7 @@
 
 */
 /*
-    Copyright (C) 2015, 2020, 2022 University College London
+    Copyright (C) 2015, 2020, 2022, 2024 University College London
     Copyright (C) 2020, National Physical Laboratory
     This file is part of STIR.
 
@@ -115,6 +116,18 @@ ProjDataTests::run_tests_on_proj_data(ProjData& proj_data)
     proj_data3.sapyb(1.F, proj_data2, -1.F);
     check(norm(proj_data3.begin(), proj_data3.end()) <= 0.0001F * norm(proj_data2.begin(), proj_data2.end()),
           "fill(ProjDataInMemory&");
+    // test fill_from
+    fill_from(proj_data3, proj_data2.begin_all(), proj_data2.end_all());
+    // check if equal by subtracting
+    proj_data3.sapyb(1.F, proj_data2, -1.F);
+    check(norm(proj_data3.begin(), proj_data3.end()) <= 0.0001F * norm(proj_data2.begin(), proj_data2.end()),
+          "fill_from(ProjDataInMemory&");
+    // test copy_to
+    copy_to(proj_data2, proj_data3.begin_all());
+    // check if equal by subtracting
+    proj_data3.sapyb(1.F, proj_data2, -1.F);
+    check(norm(proj_data3.begin(), proj_data3.end()) <= 0.0001F * norm(proj_data2.begin(), proj_data2.end()),
+          "copy_to(ProjDataInMemory&");
   }
   timer.stop();
   std::cerr << "-- CPU Time " << timer.value() << '\n';


### PR DESCRIPTION
- add `copy_to`/`fill_from` specialisations for `Array` that check if they are contigous. This enhances the likelihood that the compiler will recognise that it can call `memove` as opposed to doing a loop. (related to #1259 )
- use that in `ProjDataInMemory`
