### PR TITLE
add fall-through for Array::is_contiguous()

### DIFF
--- a/src/include/stir/Array.inl
+++ b/src/include/stir/Array.inl
@@ -49,6 +49,7 @@ Array<num_dimensions, elemT>::is_contiguous() const
       if (mem != &(*(*this)[i + 1].begin_all()))
         return false;
     }
+  return true;
 }
 
 template <int num_dimensions, typename elemT>


### PR DESCRIPTION
Make sure it always returns `true` when getting out of the loop.

Fixing my suggestion to @markus-jehl (sorry!)