### PR TITLE
Fix missing BinNormalisation*::apply/undo(ProjData&)

### DIFF
--- a/src/include/stir/Array.h
+++ b/src/include/stir/Array.h
@@ -143,7 +143,7 @@ public:
        \c data_sptr.get() block. Therefore, any modifications to the array will modify the data at \c data_sptr.get().
     This will be true until the Array is resized.
 
-    The C-array \data_ptr will be accessed with the last dimension running fastest
+    The C-array \a data_ptr will be accessed with the last dimension running fastest
     ("row-major" order).
   */
   inline Array(const IndexRange<num_dimensions>& range, shared_ptr<elemT[]> data_sptr);

--- a/src/include/stir/recon_buildblock/BinNormalisationFromAttenuationImage.h
+++ b/src/include/stir/recon_buildblock/BinNormalisationFromAttenuationImage.h
@@ -89,7 +89,10 @@ public:
   */
   Succeeded set_up(const shared_ptr<const ExamInfo>& exam_info_sptr, const shared_ptr<const ProjDataInfo>&) override;
 
+  // import all apply/undo methods from base-class (we'll override some below)
   using base_type::apply;
+  using base_type::undo;
+
   //! Normalise some data
   /*!
     This means \c multiply with the data in the projdata object

--- a/src/include/stir/recon_buildblock/BinNormalisationFromProjData.h
+++ b/src/include/stir/recon_buildblock/BinNormalisationFromProjData.h
@@ -81,12 +81,15 @@ public:
       with the ProjDataInfo supplied. */
   Succeeded set_up(const shared_ptr<const ExamInfo>& exam_info_sptr, const shared_ptr<const ProjDataInfo>&) override;
 
+  // import all apply/undo methods from base-class (we'll override some below)
+  using base_type::apply;
+  using base_type::undo;
+
   //! Normalise some data
   /*!
     This means \c multiply with the data in the projdata object
     passed in the constructor.
   */
-
   void apply(RelatedViewgrams<float>& viewgrams) const override;
 
   //! Undo the normalisation of some data

--- a/src/include/stir/recon_buildblock/BinNormalisationPETFromComponents.h
+++ b/src/include/stir/recon_buildblock/BinNormalisationPETFromComponents.h
@@ -98,11 +98,14 @@ public:
   /*! Compares the stored ProjDataInfo  with the ProjDataInfo supplied. */
   Succeeded set_up(const shared_ptr<const ExamInfo>& exam_info_sptr, const shared_ptr<const ProjDataInfo>&) override;
 
+  // import all apply/undo methods from base-class (we'll override some below)
+  using base_type::apply;
+  using base_type::undo;
+
   //! Normalise some data
   /*!
     This means \c divide with the efficiency model. 0/0 is set to 0.
   */
-
   void apply(RelatedViewgrams<float>& viewgrams) const override;
 
   using base_type::apply;

--- a/src/include/stir/recon_buildblock/BinNormalisationPETFromComponents.h
+++ b/src/include/stir/recon_buildblock/BinNormalisationPETFromComponents.h
@@ -108,13 +108,12 @@ public:
   */
   void apply(RelatedViewgrams<float>& viewgrams) const override;
 
-  using base_type::apply;
   //! Undo the normalisation of some data
   /*!
     This means \c multiply with the efficiency model.
   */
   void undo(RelatedViewgrams<float>& viewgrams) const override;
-  using base_type::undo;
+
   float get_bin_efficiency(const Bin& bin) const override;
 
 #if 0

--- a/src/include/stir/recon_buildblock/BinNormalisationSPECT.h
+++ b/src/include/stir/recon_buildblock/BinNormalisationSPECT.h
@@ -58,6 +58,10 @@ public:
 
   float get_dead_time_efficiency(const DetectionPosition<>& det_pos, const double start_time, const double end_time) const;
 
+  // import all apply/undo methods from base-class (we'll override some below)
+  using base_type::apply;
+  using base_type::undo;
+
   void apply(RelatedViewgrams<float>& viewgrams) const override;
 
   void undo(RelatedViewgrams<float>& viewgrams) const override;

--- a/src/include/stir/recon_buildblock/ChainedBinNormalisation.h
+++ b/src/include/stir/recon_buildblock/ChainedBinNormalisation.h
@@ -90,11 +90,14 @@ public:
   /*! Calls set_up for the BinNormalisation members. */
   Succeeded set_up(const shared_ptr<const ExamInfo>& exam_info_sptr, const shared_ptr<const ProjDataInfo>&) override;
 
+  // import all apply/undo methods from base-class (we'll override some below)
+  using base_type::apply;
+  using base_type::undo;
+
   //! Normalise some data
   /*!
     This calls apply() of the 2 BinNormalisation members
   */
-
   void apply(RelatedViewgrams<float>& viewgrams) const override;
 #if 0
   virtual void apply(ProjData&) const override;

--- a/src/swig/CMakeLists.txt
+++ b/src/swig/CMakeLists.txt
@@ -92,9 +92,11 @@ set(swig_stir_dependencies
   stir_coordinates.i
   stir_dataprocessors.i
   stir_exam.i
+  stir_LOR.i
   stir_normalisation.i
   stir_objectivefunctions.i
   stir_priors.i
+  stir_projdata_coords.i
   stir_projdata.i
   stir_listmode.i
   stir_projectors.i

--- a/src/swig/stir.i
+++ b/src/swig/stir.i
@@ -1036,9 +1036,10 @@ ADD_REPR(stir::Succeeded, %arg($self->succeeded() ? "yes" : "no"));
 %include "stir_exam.i"
 
 %shared_ptr(stir::DataSymmetriesForViewSegmentNumbers);
+%include "stir_projdata_coords.i"
+%include "stir/DataSymmetriesForViewSegmentNumbers.h"
 %include "stir_projdata.i"
 %include "stir_listmode.i"
-%include "stir/DataSymmetriesForViewSegmentNumbers.h"
 
 %include "stir_voxels.i"
 %include "stir_voxels_IO.i"

--- a/src/swig/stir_projdata.i
+++ b/src/swig/stir_projdata.i
@@ -34,39 +34,6 @@
 %shared_ptr(stir::Sinogram<float>);
 %shared_ptr(stir::Viewgram<float>);
 
-%shared_ptr(stir::DetectionPosition<unsigned int>);
-%shared_ptr(stir::DetectionPositionPair<unsigned int>);
-
-%attributeref(stir::DetectionPosition<unsigned int>, unsigned int, tangential_coord);
-%attributeref(stir::DetectionPosition<unsigned int>, unsigned int, axial_coord);
-%attributeref(stir::DetectionPosition<unsigned int>, unsigned int, radial_coord);
-%include "stir/DetectionPosition.h"
-ADD_REPR(stir::DetectionPosition, %arg(*$self))
-%template(DetectionPosition) stir::DetectionPosition<unsigned int>;
-
-%attributeref(stir::DetectionPositionPair<unsigned int>, int, timing_pos);
-%attributeref(stir::DetectionPositionPair<unsigned int>, stir::DetectionPosition<unsigned int>, pos1);
-%attributeref(stir::DetectionPositionPair<unsigned int>, stir::DetectionPosition<unsigned int>, pos2);
-%include "stir/DetectionPositionPair.h"
-ADD_REPR(stir::DetectionPositionPair, %arg(*$self))
-%template(DetectionPositionPair) stir::DetectionPositionPair<unsigned int>;
-
-%attributeref(stir::SegmentIndices, int, segment_num);
-%attributeref(stir::SegmentIndices, int, timing_pos_num);
-%attributeref(stir::ViewgramIndices, int, view_num);
-%attributeref(stir::SinogramIndices, int, axial_pos_num);
-%attributeref(stir::Bin, int, axial_pos_num);
-%attributeref(stir::Bin, int, tangential_pos_num);
-%attributeref(stir::Bin, int, timing_pos_num);
-%attributeref(stir::Bin, int, time_frame_num);
-%attribute(stir::Bin, float, bin_value, get_bin_value, set_bin_value);
-%include "stir/SegmentIndices.h"
-%include "stir/ViewgramIndices.h"
-%include "stir/SinogramIndices.h"
-%include "stir/Bin.h"
-ADD_REPR(stir::Bin, %arg(*$self))
-
-
 %newobject stir::Scanner::get_scanner_from_name;
 %include "stir/Scanner.h"
 
@@ -264,6 +231,7 @@ namespace stir {
 
 namespace stir { 
   %template(FloatViewgram) Viewgram<float>;
+  %template(FloatRelatedViewgrams) RelatedViewgrams<float>;
   %template(FloatSinogram) Sinogram<float>;
   // TODO don't want to give a name
   %template(FloatSegment) Segment<float>;

--- a/src/swig/stir_projdata_coords.i
+++ b/src/swig/stir_projdata_coords.i
@@ -1,0 +1,46 @@
+/*
+    Copyright (C) 2023, 2024 University College London
+    This file is part of STIR.
+
+    SPDX-License-Identifier: Apache-2.0
+
+    See STIR/LICENSE.txt for details
+*/
+/*!
+  \file
+  \brief Interface file for SWIG: stir::Bin, stir:DetectionPosition etc
+
+  \author Kris Thielemans
+*/
+
+%shared_ptr(stir::DetectionPosition<unsigned int>);
+%shared_ptr(stir::DetectionPositionPair<unsigned int>);
+
+%attributeref(stir::DetectionPosition<unsigned int>, unsigned int, tangential_coord);
+%attributeref(stir::DetectionPosition<unsigned int>, unsigned int, axial_coord);
+%attributeref(stir::DetectionPosition<unsigned int>, unsigned int, radial_coord);
+%include "stir/DetectionPosition.h"
+ADD_REPR(stir::DetectionPosition, %arg(*$self))
+%template(DetectionPosition) stir::DetectionPosition<unsigned int>;
+
+%attributeref(stir::DetectionPositionPair<unsigned int>, int, timing_pos);
+%attributeref(stir::DetectionPositionPair<unsigned int>, stir::DetectionPosition<unsigned int>, pos1);
+%attributeref(stir::DetectionPositionPair<unsigned int>, stir::DetectionPosition<unsigned int>, pos2);
+%include "stir/DetectionPositionPair.h"
+ADD_REPR(stir::DetectionPositionPair, %arg(*$self))
+%template(DetectionPositionPair) stir::DetectionPositionPair<unsigned int>;
+
+%attributeref(stir::SegmentIndices, int, segment_num);
+%attributeref(stir::SegmentIndices, int, timing_pos_num);
+%attributeref(stir::ViewgramIndices, int, view_num);
+%attributeref(stir::SinogramIndices, int, axial_pos_num);
+%attributeref(stir::Bin, int, axial_pos_num);
+%attributeref(stir::Bin, int, tangential_pos_num);
+%attributeref(stir::Bin, int, timing_pos_num);
+%attributeref(stir::Bin, int, time_frame_num);
+%attribute(stir::Bin, float, bin_value, get_bin_value, set_bin_value);
+%include "stir/SegmentIndices.h"
+%include "stir/ViewgramIndices.h"
+%include "stir/SinogramIndices.h"
+%include "stir/Bin.h"
+ADD_REPR(stir::Bin, %arg(*$self))


### PR DESCRIPTION
Only the members with `RelatedViewgrams` were there.

Fixes #1175