### PR TITLE
Automatically set use-time-of-flight-sensitivities in Poisson...ProjData

### DIFF
--- a/documentation/release_6.2.htm
+++ b/documentation/release_6.2.htm
@@ -118,6 +118,9 @@ from the above):</H2>
   <li>
     Changes to allow reading Siemens Biograph Vision data: iSSRB and SSRB are now included in the SWIG interface; minor changes to a shell script altering e7tools headers.
   </li>
+  <li>
+    Allows automatic detection if TOF sensitivities are being used.
+  </li>
 </ul>
 
 <h3>Build system</h3>

--- a/src/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMeanAndProjData.cxx
+++ b/src/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMeanAndProjData.cxx
@@ -53,6 +53,7 @@
 #include "stir/recon_buildblock/ProjectorByBinPairUsingSeparateProjectors.h"
 #include "stir/recon_buildblock/find_basic_vs_nums_in_subsets.h"
 #include "stir/recon_buildblock/BinNormalisationWithCalibration.h"
+#include "stir/recon_buildblock/BinNormalisationFromProjData.h"
 
 #include "stir/ProjDataInMemory.h"
 
@@ -636,6 +637,15 @@ PoissonLogLikelihoodWithLinearModelForMeanAndProjData<TargetT>::set_up_before_se
   this->distributable_computation_already_setup = false;
   // similar for norm
   this->norm_already_setup = false;
+
+  if (auto norm_pd_ptr = dynamic_cast<BinNormalisationFromProjData const*>(this->normalisation_sptr.get()))
+    {
+      if (!this->use_tofsens && norm_pd_ptr->get_norm_proj_data_sptr()->get_num_tof_poss() > 1)
+        {
+          info("Detected TOF normalisation data, so using time-of-flight sensitivities");
+          this->use_tofsens = true;
+        }
+    }
 
   if (this->get_recompute_sensitivity())
     {


### PR DESCRIPTION
<!-- Fill in most of this text, and delete what is not appropriate.
Please read and adhere to the [contribution guidelines](https://github.com/UCL/STIR/blob/master/CONTRIBUTING.md).
Did you sign the STIR Contribution License Agreement?
-->

## Changes in this pull request


## Testing performed


## Related issues
<!-- Use keywords such as "fixes", "closes", see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->


## Checklist before requesting a review
<!--Put an x between the [] when completed. Delete a line if not applicable. -->
  - [x] I have performed a self-review of my code
  - [] I have added docstrings/doxygen in line with the guidance in the developer guide
  - [] I have implemented unit tests that cover any new or modified functionality (if applicable)
  - [x] The code builds and runs on my machine
  - [] `documentation/release_XXX.md` has been updated with any functionality change (if applicable)
