### PR TITLE
lower default min-scale-factor for scatter tail-fitting

### DIFF
--- a/documentation/release_6.2.htm
+++ b/documentation/release_6.2.htm
@@ -8,7 +8,8 @@
     <h1>Summary of changes in STIR release 6.2</h1>
 
     <p>
-      This version is 100% backwards compatible with STIR 6.1. However, C++-17 is now required.
+      This version is 100% backwards compatible with STIR 6.1, aside from the default of the
+      tail-fitting of the scatter estimator (see below). However, C++-17 is now required.
     </p>
 
 <h2>Overall summary</h2>
@@ -55,6 +56,15 @@
 
 <h3>Changed functionality</h3>
 <ul>
+  <li>
+    The default minimum scale factor for tail-fitting in the scatter estimation is now 0.05 (was 0.4).
+    This (temporarily) resolves a problem that for the Siemens mMR, the default factor was too large
+    (see <a href=https://github.com/UCL/STIR/issues/1280>issue #1280</a>.<br>
+    <strong>WARNING:</strong><i>This potentially changes your scatter estimates</i>. (You can check log files
+    of the scatter estimation to see what the scaling factors are.) However,
+    the Siemens mMR example files already lowered the default scale factor to .1, so if you used
+    those, you will get identical results.
+  </li>
   <li>
     <code>Array::sum()</code> (and hence images etc) now accumulates in a variable at higher precision to avoid loss of precision.<br>
     <a href=https://github.com/UCL/STIR/pull/1439>PR #1439</a>

--- a/examples/samples/scatter_estimation_par_files/scatter_estimation.par
+++ b/examples/samples/scatter_estimation_par_files/scatter_estimation.par
@@ -75,8 +75,10 @@ export scatter estimates of each iteration := 1
 output scatter estimate name prefix := ${scatter_prefix}
 output additive estimate name prefix:= ${total_additive_prefix}
 
-maximum scatter scaling factor := 2 ;10
-minimum scatter scaling factor := 0.4 ;0.1
+; Optionally set thresholds for tail-fitting. For most scanners, the scale factors should be a
+; bit larger than 1, but this is not always the case.
+maximum scatter scaling factor := 2
+minimum scatter scaling factor := 0.1
 
 ;Upsample and fit 
 ; defaults to 3.

--- a/src/scatter_buildblock/ScatterEstimation.cxx
+++ b/src/scatter_buildblock/ScatterEstimation.cxx
@@ -85,7 +85,7 @@ ScatterEstimation::set_defaults()
   this->output_scatter_estimate_prefix = "";
   this->output_additive_estimate_prefix = "";
   this->num_scatter_iterations = 5;
-  this->min_scale_value = 0.4f;
+  this->min_scale_value = 0.05f;
   this->max_scale_value = 100.f;
   this->half_filter_width = 3;
 }


### PR DESCRIPTION
Set default to 0.05 (was .4). This prevents problems with the mMR (and others?).

Addresses https://github.com/UCL/STIR/issues/1280

@markus-jehl does this affect you?
