### PR TITLE
Axial symmetry fixes for BlocksOnCylindrical

### DIFF
--- a/documentation/release_6.2.htm
+++ b/documentation/release_6.2.htm
@@ -88,7 +88,11 @@
     scanners that caused the buckets to not be symmetric. <br>
     <a href=https://github.com/UCL/STIR/pull/1462>PR #1462</a>
   </li>
-
+  <li>
+    <code>BlocksOnCylindrical</code> scanners were not axially symmetric due to a bug in how gaps were
+    handled. Also, downsampling of <code>BlocksOnCylindrical</code> scanners in scatter simulation was inaccurate.<br>
+    <a href=https://github.com/UCL/STIR/pull/1466>PR #1466</a>
+  </li>
 </ul>
 
 <h3>Build system</h3>

--- a/src/buildblock/GeometryBlocksOnCylindrical.cxx
+++ b/src/buildblock/GeometryBlocksOnCylindrical.cxx
@@ -83,14 +83,12 @@ GeometryBlocksOnCylindrical::build_crystal_maps(const Scanner& scanner)
   //    estimate the angle covered by half bucket, csi
   float csi = _PI / num_transaxial_buckets;
   float trans_blocks_gap = transaxial_block_spacing - num_transaxial_crystals_per_block * transaxial_crystal_spacing;
-  float ax_blocks_gap = axial_block_spacing - num_axial_crystals_per_block * axial_crystal_spacing;
+  float ax_blocks_gap = axial_block_spacing - (num_axial_crystals_per_block - 1) * axial_crystal_spacing;
   float csi_minus_csiGaps = csi - (csi / transaxial_block_spacing * 2) * (transaxial_crystal_spacing / 2 + trans_blocks_gap);
   //    distance between the center of the scannner and the first crystal in the bucket, r=Reffective/cos(csi)
   float r = scanner.get_effective_ring_radius() / cos(csi_minus_csiGaps);
 
-  float start_z = -(axial_block_spacing * (num_axial_blocks_per_bucket)*num_axial_buckets - axial_crystal_spacing
-                    - ax_blocks_gap * (num_axial_blocks_per_bucket * num_axial_buckets - 1))
-                  / 2;
+  float start_z = -(axial_block_spacing * num_axial_blocks_per_bucket * num_axial_buckets - ax_blocks_gap) / 2;
   float start_y = -1 * scanner.get_effective_ring_radius();
   float start_x = -1 // the first crystal in the bucket
                   * (((num_transaxial_blocks_per_bucket - 1) / 2.) * transaxial_block_spacing
@@ -121,7 +119,8 @@ GeometryBlocksOnCylindrical::build_crystal_maps(const Scanner& scanner)
 
                 // calculate cartesian coordinate for a given detector
                 stir::CartesianCoordinate3D<float> transformation_matrix(
-                    ax_block_num * axial_block_spacing + ax_crys_num * axial_crystal_spacing,
+                    (ax_block_num + ax_bucket_num * num_axial_blocks_per_bucket) * axial_block_spacing
+                        + ax_crys_num * axial_crystal_spacing,
                     0.,
                     trans_block_num * transaxial_block_spacing + trans_crys_num * transaxial_crystal_spacing);
                 float alpha = scanner.get_intrinsic_azimuthal_tilt() + trans_bucket_num * (2 * _PI) / num_transaxial_buckets

--- a/src/buildblock/Scanner.cxx
+++ b/src/buildblock/Scanner.cxx
@@ -1101,13 +1101,13 @@ Scanner::Scanner(Type scanner_type)
                  -1,    // reference_energy_v
                  (short int)1,
                  0.F,
-                 0.F,  // non-TOF
-                 "",   // scanner_geometry_v
-                 2.2,  // axial_crystal_spacing_v
-                 2.2,  // transaxial_crystal_spacing_v
-                 18.1, // axial_block_spacing_v
-                 33.6, // transaxial_block_spacing_v
-                 ""    // crystal_map_file_name_v
+                 0.F,                   // non-TOF
+                 "BlocksOnCylindrical", // scanner_geometry_v
+                 2.2,                   // axial_crystal_spacing_v
+                 2.2,                   // transaxial_crystal_spacing_v
+                 18.1,                  // axial_block_spacing_v
+                 33.6,                  // transaxial_block_spacing_v
+                 ""                     // crystal_map_file_name_v
       );
       break;
 

--- a/src/include/stir/Scanner.h
+++ b/src/include/stir/Scanner.h
@@ -656,7 +656,7 @@ private:
                   short int max_num_of_timing_poss_v = -1.0f,
                   float size_timing_pos_v = -1.0f,
                   float timing_resolution_v = -1.0f,
-                  const std::string& scanner_geometry_v = "Cylindrical",
+                  const std::string& scanner_geometry_v = "",
                   float axial_crystal_spacing_v = -1.0f,
                   float transaxial_crystal_spacing_v = -1.0f,
                   float axial_block_spacing_v = -1.0f,

--- a/src/include/stir/Scanner.h
+++ b/src/include/stir/Scanner.h
@@ -424,6 +424,10 @@ public:
   inline float get_axial_block_spacing() const;
   //! get block spacing in transaxial direction
   inline float get_transaxial_block_spacing() const;
+  /*! get total axial length covered by the detectors (incl. any gaps between blocks etc.)
+    \todo Need to update this function when enabling different spacing between blocks and buckets etc.
+  */
+  inline float get_axial_length() const;
   //@} (end of get block geometry info)
 
   //! \name functions to get generic geometry info
@@ -652,7 +656,7 @@ private:
                   short int max_num_of_timing_poss_v = -1.0f,
                   float size_timing_pos_v = -1.0f,
                   float timing_resolution_v = -1.0f,
-                  const std::string& scanner_geometry_v = "",
+                  const std::string& scanner_geometry_v = "Cylindrical",
                   float axial_crystal_spacing_v = -1.0f,
                   float transaxial_crystal_spacing_v = -1.0f,
                   float axial_block_spacing_v = -1.0f,

--- a/src/include/stir/Scanner.inl
+++ b/src/include/stir/Scanner.inl
@@ -295,6 +295,13 @@ Scanner::get_axial_block_spacing() const
   return axial_block_spacing;
 }
 
+float
+Scanner::get_axial_length() const
+{
+  return get_num_axial_buckets() * get_num_axial_blocks_per_bucket() * get_axial_block_spacing()
+         - (get_axial_block_spacing() - (get_num_axial_crystals_per_block() - 1) * get_axial_crystal_spacing());
+}
+
 std::string
 Scanner::get_crystal_map_file_name() const
 {

--- a/src/scatter_buildblock/ScatterSimulation.cxx
+++ b/src/scatter_buildblock/ScatterSimulation.cxx
@@ -820,7 +820,7 @@ ScatterSimulation::downsample_scanner(int new_num_rings, int new_num_dets)
 {
   if (new_num_rings <= 0)
     {
-      if (downsample_scanner_rings > 0)
+      if (downsample_scanner_rings > 1)
         new_num_rings = downsample_scanner_rings;
       else if (!is_null_ptr(proj_data_info_sptr))
         {
@@ -828,6 +828,7 @@ ScatterSimulation::downsample_scanner(int new_num_rings, int new_num_dets)
                                            * proj_data_info_sptr->get_scanner_sptr()->get_ring_spacing();
 
           new_num_rings = round(total_axial_length / 20.F + 0.5F);
+          new_num_rings = min(new_num_rings, 2); // set number of rings to at least 2
         }
       else
         return Succeeded::no;
@@ -842,37 +843,17 @@ ScatterSimulation::downsample_scanner(int new_num_rings, int new_num_dets)
     {
       new_num_dets = this->proj_data_info_sptr->get_scanner_ptr()->get_num_detectors_per_ring();
       approx_num_non_arccorrected_bins = this->proj_data_info_sptr->get_num_tangential_poss();
-      // preserve the length of the scanner the following includes gaps
-      float scanner_length_block
-          = old_scanner_ptr->get_num_axial_buckets() * old_scanner_ptr->get_num_axial_blocks_per_bucket()
-                * old_scanner_ptr->get_axial_block_spacing()
-            - (old_scanner_ptr->get_axial_block_spacing()
-               - old_scanner_ptr->get_num_axial_crystals_per_block() * old_scanner_ptr->get_axial_crystal_spacing());
+
+      // preserve the length of the scanner, but place crystals equidistantly
+      float scanner_length = old_scanner_ptr->get_axial_length();
+      float new_ring_spacing = scanner_length / (new_num_rings - 1);
+
       new_scanner_sptr->set_num_axial_blocks_per_bucket(1);
-      //        new_scanner_sptr->set_num_transaxial_blocks_per_bucket(1);
-
       new_scanner_sptr->set_num_rings(new_num_rings);
-      // float transaxial_bucket_spacing
-      //     = old_scanner_ptr->get_transaxial_block_spacing() * old_scanner_ptr->get_num_transaxial_blocks_per_bucket();
-      float new_ring_spacing = scanner_length_block / (new_scanner_sptr->get_num_rings() - 1);
-      // int num_trans_buckets = old_scanner_ptr->get_num_transaxial_buckets();
-      // get a new number of detectors that is a multiple of the number of buckets to preserve scanner shape
-      //        float frac,whole;
-      //        frac = std::modf(float(new_num_dets/new_scanner_sptr->get_num_transaxial_buckets()), &whole);
-      //        int newest_num_dets=whole*new_scanner_sptr->get_num_transaxial_buckets();
-      //        new_scanner_sptr->set_num_detectors_per_ring(newest_num_dets);
-      //        int new_transaxial_dets_per_bucket=newest_num_dets/num_trans_buckets;
-      //        float new_det_spacing=transaxial_bucket_spacing/new_transaxial_dets_per_bucket;
-
       new_scanner_sptr->set_axial_crystal_spacing(new_ring_spacing);
       new_scanner_sptr->set_ring_spacing(new_ring_spacing);
       new_scanner_sptr->set_num_axial_crystals_per_block(new_num_rings);
       new_scanner_sptr->set_axial_block_spacing(new_ring_spacing * new_scanner_sptr->get_num_axial_crystals_per_block());
-
-      //        new_scanner_sptr->set_num_transaxial_crystals_per_block(new_transaxial_dets_per_bucket);
-      //        new_scanner_sptr->set_transaxial_crystal_spacing(new_det_spacing);
-      //        new_scanner_sptr->set_transaxial_block_spacing(new_det_spacing
-      //                    * new_scanner_sptr->get_num_transaxial_crystals_per_block());
     }
   else
     {

--- a/src/scatter_buildblock/ScatterSimulation.cxx
+++ b/src/scatter_buildblock/ScatterSimulation.cxx
@@ -843,16 +843,19 @@ ScatterSimulation::downsample_scanner(int new_num_rings, int new_num_dets)
       new_num_dets = this->proj_data_info_sptr->get_scanner_ptr()->get_num_detectors_per_ring();
       approx_num_non_arccorrected_bins = this->proj_data_info_sptr->get_num_tangential_poss();
       // preserve the length of the scanner the following includes gaps
-      float scanner_length_block = new_scanner_sptr->get_num_axial_buckets() * new_scanner_sptr->get_num_axial_blocks_per_bucket()
-                                   * new_scanner_sptr->get_axial_block_spacing();
+      float scanner_length_block
+          = old_scanner_ptr->get_num_axial_buckets() * old_scanner_ptr->get_num_axial_blocks_per_bucket()
+                * old_scanner_ptr->get_axial_block_spacing()
+            - (old_scanner_ptr->get_axial_block_spacing()
+               - old_scanner_ptr->get_num_axial_crystals_per_block() * old_scanner_ptr->get_axial_crystal_spacing());
       new_scanner_sptr->set_num_axial_blocks_per_bucket(1);
       //        new_scanner_sptr->set_num_transaxial_blocks_per_bucket(1);
 
       new_scanner_sptr->set_num_rings(new_num_rings);
-      //        float transaxial_bucket_spacing=old_scanner_ptr->get_transaxial_block_spacing()
-      //                *old_scanner_ptr->get_num_transaxial_blocks_per_bucket();
-      float new_ring_spacing = scanner_length_block / new_scanner_sptr->get_num_rings();
-      //        int num_trans_buckets=old_scanner_ptr->get_num_transaxial_buckets();
+      // float transaxial_bucket_spacing
+      //     = old_scanner_ptr->get_transaxial_block_spacing() * old_scanner_ptr->get_num_transaxial_blocks_per_bucket();
+      float new_ring_spacing = scanner_length_block / (new_scanner_sptr->get_num_rings() - 1);
+      // int num_trans_buckets = old_scanner_ptr->get_num_transaxial_buckets();
       // get a new number of detectors that is a multiple of the number of buckets to preserve scanner shape
       //        float frac,whole;
       //        frac = std::modf(float(new_num_dets/new_scanner_sptr->get_num_transaxial_buckets()), &whole);

--- a/src/scatter_buildblock/ScatterSimulation.cxx
+++ b/src/scatter_buildblock/ScatterSimulation.cxx
@@ -828,7 +828,7 @@ ScatterSimulation::downsample_scanner(int new_num_rings, int new_num_dets)
                                            * proj_data_info_sptr->get_scanner_sptr()->get_ring_spacing();
 
           new_num_rings = round(total_axial_length / 20.F + 0.5F);
-          new_num_rings = min(new_num_rings, 2); // set number of rings to at least 2
+          new_num_rings = max(new_num_rings, 2); // set number of rings to at least 2
         }
       else
         return Succeeded::no;

--- a/src/test/test_Scanner.cxx
+++ b/src/test/test_Scanner.cxx
@@ -20,6 +20,7 @@
 
 #include "stir/RunTests.h"
 #include "stir/Scanner.h"
+#include "stir/DetectionPosition.h"
 #include "stir/Succeeded.h"
 #include "stir/shared_ptr.h"
 #include "stir/warning.h"
@@ -150,6 +151,18 @@ ScannerTests::test_scanner(const Scanner& scanner)
           scanner.get_default_bin_size(), ecat_scanner_info->binsize * 10, "bin size (spacing of transaxial elements)");
     }
 #endif
+  // check that the difference between the first and last axial position matches the scanner length
+  if (scanner.get_scanner_geometry() == "BlocksOnCylindrical")
+    {
+      auto actual_length
+          = scanner
+                .get_coordinate_for_index(
+                    DetectionPosition<unsigned int>(0 /* tangential */, scanner.get_num_rings() - 1, 0 /* radial */))
+                .z()
+            - scanner.get_coordinate_for_index(DetectionPosition<unsigned int>(0 /* tangential */, 0 /* axial */, 0 /* radial */))
+                  .z();
+      check_if_equal(actual_length, scanner.get_axial_length(), "axial length of scanner does not match dectector coordinates");
+    }
 }
 
 END_NAMESPACE_STIR

--- a/src/test/test_interpolate_projdata.cxx
+++ b/src/test/test_interpolate_projdata.cxx
@@ -264,7 +264,7 @@ InterpolationTests::scatter_interpolation_test_blocks()
                                      150,
                                      127,
                                      4.3,
-                                     20.0,
+                                     24.0,
                                      2.0,
                                      -0.38956 /* 0.0 */,
                                      1,

--- a/src/test/test_interpolate_projdata.cxx
+++ b/src/test/test_interpolate_projdata.cxx
@@ -252,9 +252,9 @@ InterpolationTests::scatter_interpolation_test_blocks()
                          01.F,
                          -1.F,
                          "BlocksOnCylindrical",
+                         4.13793, // 120 / (30 - 1)
                          4.0,
-                         4.0,
-                         24.0,
+                         24.83,
                          24.0);
   auto downsampled_scanner = Scanner(Scanner::User_defined_scanner,
                                      "Some_symmetric_scanner",
@@ -280,9 +280,9 @@ InterpolationTests::scatter_interpolation_test_blocks()
                                      01.F,
                                      -1.F,
                                      "BlocksOnCylindrical",
-                                     20.0,
+                                     24.0, // 120 / (6 - 1),
                                      4.0,
-                                     120.0,
+                                     144.0,
                                      24.0);
 
   auto proj_data_info = shared_ptr<ProjDataInfo>(

--- a/src/test/test_interpolate_projdata.cxx
+++ b/src/test/test_interpolate_projdata.cxx
@@ -236,7 +236,7 @@ InterpolationTests::scatter_interpolation_test_blocks()
                          150,
                          127,
                          4.3,
-                         4.0,
+                         4.13793, // total scanner length of 120mm divided by (rings - 1) to get the spacing
                          2.0,
                          -0.38956 /* 0.0 */,
                          5,
@@ -252,9 +252,9 @@ InterpolationTests::scatter_interpolation_test_blocks()
                          01.F,
                          -1.F,
                          "BlocksOnCylindrical",
-                         4.13793, // 120 / (30 - 1)
+                         4.13793, // total scanner length of 120mm divided by (rings - 1) to get the spacing
                          4.0,
-                         24.83,
+                         24.83, // ring spacing multiplied by number of crystals per block
                          24.0);
   auto downsampled_scanner = Scanner(Scanner::User_defined_scanner,
                                      "Some_symmetric_scanner",
@@ -264,7 +264,7 @@ InterpolationTests::scatter_interpolation_test_blocks()
                                      150,
                                      127,
                                      4.3,
-                                     24.0,
+                                     24.0, // total scanner length of 120mm divided by (rings - 1) to get the spacing
                                      2.0,
                                      -0.38956 /* 0.0 */,
                                      1,
@@ -280,9 +280,9 @@ InterpolationTests::scatter_interpolation_test_blocks()
                                      01.F,
                                      -1.F,
                                      "BlocksOnCylindrical",
-                                     24.0, // 120 / (6 - 1),
+                                     24.0, // total scanner length of 120mm divided by (rings - 1) to get the spacing
                                      4.0,
-                                     144.0,
+                                     144.0, // ring spacing multiplied by number of crystals per block
                                      24.0);
 
   auto proj_data_info = shared_ptr<ProjDataInfo>(


### PR DESCRIPTION

## Changes in this pull request
Fix axial scanner downsampling and correct handling of gaps to make BlocksOnCylindrical axially symmetric.

## Testing performed
See before and after in associated issue: https://github.com/UCL/STIR/issues/1465

## Related issues
Fixes https://github.com/UCL/STIR/issues/1465
Relates to https://github.com/UCL/STIR/pull/1291


## Checklist before requesting a review
<!--Put an x between the [] when completed. Delete a line if not applicable. -->
  - [] I have performed a self-review of my code
  - [] I have added docstrings/doxygen in line with the guidance in the developer guide
  - [] I have implemented unit tests that cover any new or modified functionality (if applicable)
  - [] The code builds and runs on my machine
  - [] `documentation/release_XXX.md` has been updated with any functionality change (if applicable)
