### PR TITLE
added ScatterEstimation::set_recompute_mask_*()

### DIFF
--- a/src/include/stir/scatter/ScatterEstimation.h
+++ b/src/include/stir/scatter/ScatterEstimation.h
@@ -167,6 +167,9 @@ public:
   /*! \c arg will not be modified */
   inline void set_mask_proj_data_sptr(const shared_ptr<ProjData> arg);
 
+  void set_recompute_mask_image(bool arg);
+  void set_recompute_mask_projdata(bool arg);
+
   inline void set_scatter_simulation_method_sptr(const shared_ptr<ScatterSimulation>);
 
   inline void set_num_iterations(int);

--- a/src/include/stir/scatter/ScatterEstimation.inl
+++ b/src/include/stir/scatter/ScatterEstimation.inl
@@ -42,6 +42,7 @@ ScatterEstimation::set_mask_image_sptr(const shared_ptr<const DiscretisedDensity
 {
   this->_already_setup = false;
   this->mask_image_sptr = arg;
+  this->set_recompute_mask_image(false);
 }
 
 void
@@ -49,6 +50,7 @@ ScatterEstimation::set_mask_proj_data_sptr(const shared_ptr<ProjData> arg)
 {
   this->_already_setup = false;
   this->mask_projdata_sptr = arg;
+  this->set_recompute_mask_projdata(false);
 }
 
 void

--- a/src/scatter_buildblock/ScatterEstimation.cxx
+++ b/src/scatter_buildblock/ScatterEstimation.cxx
@@ -432,6 +432,18 @@ ScatterEstimation::set_normalisation_sptr(const shared_ptr<BinNormalisation> arg
   this->multiplicative_binnorm_sptr.reset();
 }
 
+void
+ScatterEstimation::set_recompute_mask_image(bool arg)
+{
+  this->recompute_mask_image = arg;
+}
+
+void
+ScatterEstimation::set_recompute_mask_projdata(bool arg)
+{
+  this->recompute_mask_projdata = arg;
+}
+
 bool
 ScatterEstimation::already_setup() const
 {


### PR DESCRIPTION
useful for use in Python
