### PR TITLE
Prevent `std::normal_distribution` being called with `sigma=0.0`

### DIFF
--- a/src/include/stir/DetectorCoordinateMap.h
+++ b/src/include/stir/DetectorCoordinateMap.h
@@ -123,6 +123,8 @@ protected:
   explicit DetectorCoordinateMap(double sigma = 0.0)
       : sigma(sigma)
   {
+    if (sigma == 0.0)
+      return;
 #  ifdef STIR_OPENMP
     generators.resize(omp_get_max_threads());
     distributions.resize(omp_get_max_threads());


### PR DESCRIPTION
<!-- Fill in most of this text, and delete what is not appropriate.
Please read and adhere to the [contribution guidelines](https://github.com/UCL/STIR/blob/master/CONTRIBUTING.md).
Did you sign the STIR Contribution License Agreement?
-->

## Changes in this pull request

Add a guard to `DetectorCoordinateMap` to prevent `std::normal_distribution<double>(0.0, 0.0)` being called.

## Testing performed

Built STIR in debug on windows machine and build project using STIR in debug. Fixes assert `0.0 < sigma` issue observed in #1485.


## Related issues
<!-- Use keywords such as "fixes", "closes", see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

Fixes #1485

## Checklist before requesting a review
<!--Put an x between the [] when completed. Delete a line if not applicable. -->
  - [x] I have performed a self-review of my code
  - [x] I have added docstrings/doxygen in line with the guidance in the developer guide
  - [] I have implemented unit tests that cover any new or modified functionality (if applicable)
  - [x] The code builds and runs on my machine
  - [] `documentation/release_XXX.md` has been updated with any functionality change (if applicable)
