### PR TITLE
Add support for get_axial_length for cylindrical scanners.

### DIFF
--- a/src/include/stir/Scanner.h
+++ b/src/include/stir/Scanner.h
@@ -426,6 +426,7 @@ public:
   inline float get_transaxial_block_spacing() const;
   /*! get total axial length covered by the detectors (incl. any gaps between blocks etc.)
     \todo Need to update this function when enabling different spacing between blocks and buckets etc.
+    For cylindrical scanners, calculates the length by the ring spacing.
   */
   inline float get_axial_length() const;
   //@} (end of get block geometry info)

--- a/src/include/stir/Scanner.inl
+++ b/src/include/stir/Scanner.inl
@@ -298,6 +298,10 @@ Scanner::get_axial_block_spacing() const
 float
 Scanner::get_axial_length() const
 {
+  if (get_scanner_geometry() == "Cylindrical")
+  {
+    return get_num_rings() * get_ring_spacing();
+  }
   return get_num_axial_buckets() * get_num_axial_blocks_per_bucket() * get_axial_block_spacing()
          - (get_axial_block_spacing() - (get_num_axial_crystals_per_block() - 1) * get_axial_crystal_spacing());
 }

--- a/src/include/stir/Scanner.inl
+++ b/src/include/stir/Scanner.inl
@@ -299,9 +299,13 @@ float
 Scanner::get_axial_length() const
 {
   if (get_scanner_geometry() == "Cylindrical")
-  {
-    return get_num_rings() * get_ring_spacing();
-  }
+    {
+      return get_num_rings() * get_ring_spacing();
+    }
+  else if (get_scanner_geometry() == "Generic")
+    {
+      error("get_axial_length not yet implemented for Generic scanner geometry");
+    }
   return get_num_axial_buckets() * get_num_axial_blocks_per_bucket() * get_axial_block_spacing()
          - (get_axial_block_spacing() - (get_num_axial_crystals_per_block() - 1) * get_axial_crystal_spacing());
 }


### PR DESCRIPTION
<!-- Fill in most of this text, and delete what is not appropriate.
Please read and adhere to the [contribution guidelines](https://github.com/UCL/STIR/blob/master/CONTRIBUTING.md).
Did you sign the STIR Contribution License Agreement?
-->

## Changes in this pull request

Adds support for cylindrical scanners to call `get_axial_length()` and return a sensible value.

I believe
```
get_num_rings() * get_ring_spacing();
```
is the correct implementation over
```
get_ring_spacing() * (get_num_rings() - 1);
```
because a scanner with 1 ring will have an axial length of that ring. That is, unless axial bin size should be incorporated into the calculation.

## Related issues
<!-- Use keywords such as "fixes", "closes", see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

Fixes #1493

## Checklist before requesting a review
<!--Put an x between the [] when completed. Delete a line if not applicable. -->
  - [x] I have performed a self-review of my code
  - [x] I have added docstrings/doxygen in line with the guidance in the developer guide
  - [] I have implemented unit tests that cover any new or modified functionality (if applicable)
  - [x] The code builds and runs on my machine
  - [] `documentation/release_XXX.md` has been updated with any functionality change (if applicable)
