### PR TITLE
Tangential position range consistency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,7 @@ install_manifest.txt
 build/
 install/
 .vscode/
+build_safir_updates/
 
 # MATLAB
 

--- a/src/buildblock/ProjDataInfoCylindricalNoArcCorr.cxx
+++ b/src/buildblock/ProjDataInfoCylindricalNoArcCorr.cxx
@@ -178,8 +178,8 @@ ProjDataInfoCylindricalNoArcCorr::initialise_uncompressed_view_tangpos_to_det1de
   assert(fabs(get_phi(Bin(0, 0, 0, 0)) - v_offset) < 1.E-4);
   assert(fabs(get_phi(Bin(0, get_num_views(), 0, 0)) - v_offset - _PI) < 1.E-4);
 #endif
-  const int min_tang_pos_num = -(num_detectors / 2) + 1;
-  const int max_tang_pos_num = -(num_detectors / 2) + num_detectors;
+  const int min_tang_pos_num = -(num_detectors / 2);
+  const int max_tang_pos_num = -(num_detectors / 2) + num_detectors - 1;
 
   if (this->get_min_tangential_pos_num() < min_tang_pos_num || this->get_max_tangential_pos_num() > max_tang_pos_num)
     {

--- a/src/buildblock/ProjDataInfoGenericNoArcCorr.cxx
+++ b/src/buildblock/ProjDataInfoGenericNoArcCorr.cxx
@@ -149,8 +149,8 @@ ProjDataInfoGenericNoArcCorr::initialise_uncompressed_view_tangpos_to_det1det2()
   const int num_detectors = get_scanner_ptr()->get_num_detectors_per_ring();
   assert(num_detectors % 2 == 0);
 
-  const int min_tang_pos_num = -(num_detectors / 2) + 1;
-  const int max_tang_pos_num = -(num_detectors / 2) + num_detectors;
+  const int min_tang_pos_num = -(num_detectors / 2);
+  const int max_tang_pos_num = -(num_detectors / 2) + num_detectors - 1;
 
   if (this->get_min_tangential_pos_num() < min_tang_pos_num || this->get_max_tangential_pos_num() > max_tang_pos_num)
     {

--- a/src/recon_buildblock/ProjMatrixByBinUsingRayTracing.cxx
+++ b/src/recon_buildblock/ProjMatrixByBinUsingRayTracing.cxx
@@ -273,9 +273,11 @@ ProjMatrixByBinUsingRayTracing::set_up(
 
   voxel_size = image_info_ptr->get_voxel_size();
   origin = image_info_ptr->get_origin();
-  if (std::abs(origin.x()) > .05F || std::abs(origin.y()) > .05F)
+  if (std::abs(origin.x()) > .05F || std::abs(origin.y()) > .05F){
     error("ProjMatrixByBinUsingRayTracing sadly doesn't support shifted x/y origin yet");
   image_info_sptr->get_regular_range(min_index, max_index);
+  std::cout << "OriginX : " << origin.x() << " ; OriginY : " << origin.y() << "\n";
+  }
 
   symmetries_sptr.reset(new DataSymmetriesForBins_PET_CartesianGrid(proj_data_info_sptr,
                                                                     density_info_sptr_v,


### PR DESCRIPTION
## Changes in this pull request
Changed min/max_tang_pos_num definitions in two classes to be consistent with ProjDataInfo.cxx. 

## Testing performed
It is built successfully but fails in 8 tests (in make test). Probably needs more modification?
I could handle projection files with tang180 (with lm_to_projdata and convert_projdata_types) without error. Before implementing above changes, I got below error:
"ERROR: The tangential_pos range (-90 to 89) for this projection data is too large. Maximum supported range is from -89 to 90"

## Related issues
#1507

 ## Checklist before requesting a review
  - [x] I have performed a self-review of my code
  - [] I have added docstrings/doxygen in line with the guidance in the developer guide
  - [x] I have implemented unit tests that cover any new or modified functionality (if applicable)
  - [x] The code builds and runs on my machine
  - [] `documentation/release_XXX.md` has been updated with any functionality change (if applicable)
