### PR TITLE
Adds ProjDataInMemory::read_from_file to return a ProjDataInMemory object

### DIFF
--- a/documentation/release_6.3.htm
+++ b/documentation/release_6.3.htm
@@ -48,6 +48,11 @@
 
 <H2>What is new for developers (aside from what should be obvious from the above):</H2>
 
+<h3>New functionality</h3>
+
+<li>
+  <code>ProjDataInMemory</code> <code>read_from_file</code> method now returns a <code>ProjDataInMemory</code> object.
+</li>
 
 <h3>Changed functionality</h3>
 

--- a/src/buildblock/ProjDataInMemory.cxx
+++ b/src/buildblock/ProjDataInMemory.cxx
@@ -353,13 +353,7 @@ ProjDataInMemory::ProjDataInMemory(const ProjDataInMemory& proj_data)
 shared_ptr<ProjDataInMemory>
 ProjDataInMemory::read_from_file(const std::string& filename, const std::ios::openmode openmode)
 {
-#if 1
-  const auto proj_data = ProjData::read_from_file(filename, openmode);
-  return std::make_shared<ProjDataInMemory>(*proj_data);
-#else
-  // Alternative implementation
   return std::make_shared<ProjDataInMemory>(*ProjData::read_from_file(filename, openmode));
-#endif
 }
 
 float

--- a/src/buildblock/ProjDataInMemory.cxx
+++ b/src/buildblock/ProjDataInMemory.cxx
@@ -350,6 +350,18 @@ ProjDataInMemory::ProjDataInMemory(const ProjDataInMemory& proj_data)
   std::copy(proj_data.begin_all(), proj_data.end_all(), this->begin_all());
 }
 
+shared_ptr<ProjDataInMemory>
+ProjDataInMemory::read_from_file(const std::string& filename, const std::ios::openmode openmode)
+{
+#if 1
+  const auto proj_data = ProjData::read_from_file(filename, openmode);
+  return std::make_shared<ProjDataInMemory>(*proj_data);
+#else
+  // Alternative implementation
+  return std::make_shared<ProjDataInMemory>(*ProjData::read_from_file(filename, openmode));
+#endif
+}
+
 float
 ProjDataInMemory::get_bin_value(Bin& bin)
 {

--- a/src/buildblock/ProjDataInMemory.cxx
+++ b/src/buildblock/ProjDataInMemory.cxx
@@ -351,9 +351,9 @@ ProjDataInMemory::ProjDataInMemory(const ProjDataInMemory& proj_data)
 }
 
 shared_ptr<ProjDataInMemory>
-ProjDataInMemory::read_from_file(const std::string& filename, const std::ios::openmode openmode)
+ProjDataInMemory::read_from_file(const std::string& filename)
 {
-  return std::make_shared<ProjDataInMemory>(*ProjData::read_from_file(filename, openmode));
+  return std::make_shared<ProjDataInMemory>(*ProjData::read_from_file(filename));
 }
 
 float

--- a/src/include/stir/ProjDataInMemory.h
+++ b/src/include/stir/ProjDataInMemory.h
@@ -63,7 +63,7 @@ public:
   ProjDataInMemory(const ProjDataInMemory& proj_data);
 
   //! A static member to get the projection data in memory from a file
-  static shared_ptr<ProjDataInMemory> read_from_file(const std::string& filename, std::ios::openmode open_mode = std::ios::in);
+  static shared_ptr<ProjDataInMemory> read_from_file(const std::string& filename);
 
   Viewgram<float> get_viewgram(const int view_num,
                                const int segment_num,

--- a/src/include/stir/ProjDataInMemory.h
+++ b/src/include/stir/ProjDataInMemory.h
@@ -62,6 +62,9 @@ public:
   //! Copy constructor
   ProjDataInMemory(const ProjDataInMemory& proj_data);
 
+  //! A static member to get the projection data in memory from a file
+  static shared_ptr<ProjDataInMemory> read_from_file(const std::string& filename, std::ios::openmode open_mode = std::ios::in);
+
   Viewgram<float> get_viewgram(const int view_num,
                                const int segment_num,
                                const bool make_num_tangential_poss_odd = false,


### PR DESCRIPTION
<!-- Fill in most of this text, and delete what is not appropriate.
Please read and adhere to the [contribution guidelines](https://github.com/UCL/STIR/blob/master/CONTRIBUTING.md).
Did you sign the STIR Contribution License Agreement?
-->

## Changes in this pull request


Previously, 
``` cpp
auto pd1 = ProjData::read_from_file(fname);
auto pd2 = ProjDataInMemory::read_from_file(fname);
```
would both return a `ProjData` object.

This change, overwrites the `ProjData::read_from_file()` method for `ProjDataInMemory`. This allows `ProjDataInMemory::read_from_file()` to return a `ProjDataInMemory` object.


## Testing performed
CI

## Related issues
<!-- Use keywords such as "fixes", "closes", see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->


## Checklist before requesting a review
<!--Put an x between the [] when completed. Delete a line if not applicable. -->
  - [] I have performed a self-review of my code
  - [] I have added docstrings/doxygen in line with the guidance in the developer guide
  - [] I have implemented unit tests that cover any new or modified functionality (if applicable)
  - [] The code builds and runs on my machine
  - [] `documentation/release_XXX.md` has been updated with any functionality change (if applicable)
