### PR TITLE
Add warning if name not found in get_scanner_from_name

### DIFF
--- a/src/buildblock/Scanner.cxx
+++ b/src/buildblock/Scanner.cxx
@@ -2206,6 +2206,7 @@ Scanner::get_scanner_from_name(const string& name)
       type = static_cast<Type>(int_type);
     }
   // it's not in the list
+  warning("Scanner::get_scanner_from_name: scanner %s not found", name.c_str());
   return new Scanner(Unknown_scanner);
 }
 

--- a/src/buildblock/Scanner.cxx
+++ b/src/buildblock/Scanner.cxx
@@ -2206,7 +2206,7 @@ Scanner::get_scanner_from_name(const string& name)
       type = static_cast<Type>(int_type);
     }
   // it's not in the list
-  warning("Scanner::get_scanner_from_name: scanner %s not found", name.c_str());
+  warning(std::string("Scanner::get_scanner_from_name: scanner'") + name + "' not found");
   return new Scanner(Unknown_scanner);
 }
 


### PR DESCRIPTION
<!-- Fill in most of this text, and delete what is not appropriate.
Please read and adhere to the [contribution guidelines](https://github.com/UCL/STIR/blob/master/CONTRIBUTING.md).
Did you sign the STIR Contribution License Agreement?
-->

## Changes in this pull request

Logs a warning message if scanner name is not present in the list of scanner name available.

## Testing performed


## Related issues
<!-- Use keywords such as "fixes", "closes", see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

Fixes #1520 

## Checklist before requesting a review
<!--Put an x between the [] when completed. Delete a line if not applicable. -->
  - [x] I have performed a self-review of my code
  - [] I have added docstrings/doxygen in line with the guidance in the developer guide
  - [] I have implemented unit tests that cover any new or modified functionality (if applicable)
  - [x] The code builds and runs on my machine
  - [] `documentation/release_XXX.md` has been updated with any functionality change (if applicable)
