### PR TITLE
Expose current_time in LmToProjData.

### DIFF
--- a/src/include/stir/listmode/LmToProjData.h
+++ b/src/include/stir/listmode/LmToProjData.h
@@ -202,6 +202,7 @@ public:
   bool get_store_prompts() const;
   void set_store_delayeds(bool);
   bool get_store_delayeds() const;
+  double get_current_time() const;
   void set_num_segments_in_memory(int);
   int get_num_segments_in_memory() const;
   void set_num_events_to_store(long int);

--- a/src/listmode_buildblock/LmToProjData.cxx
+++ b/src/listmode_buildblock/LmToProjData.cxx
@@ -184,6 +184,12 @@ LmToProjData::get_output_filename_prefix() const
   return output_filename_prefix;
 }
 
+double
+LmToProjData::get_current_time() const
+{
+  return this->current_time;
+}
+
 void
 LmToProjData::set_output_projdata_sptr(shared_ptr<ProjData>& arg)
 {


### PR DESCRIPTION
## Changes in this pull request
Exposed one variable in LmToProjData

## Testing performed


## Related issues
Fixes https://github.com/UCL/STIR/issues/1523

## Checklist before requesting a review
  - [x] I have performed a self-review of my code
  - [] I have added docstrings/doxygen in line with the guidance in the developer guide
  - [] I have implemented unit tests that cover any new or modified functionality (if applicable)
  - [x] The code builds and runs on my machine
  - [] `documentation/release_XXX.md` has been updated with any functionality change (if applicable)
