### PR TITLE
Set clang-format version as part of pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
--   repo: https://github.com/doublify/pre-commit-clang-format
-    rev: '62302476'
-    hooks:
-    -   id: clang-format
-        files: \.(c|cc|cxx|cpp|cu|h|hpp|hxx|inl|txx)$
+- repo: https://github.com/pre-commit/mirrors-clang-format
+  rev: v14.0.6
+  hooks:
+  - id: clang-format
+    files: \.(c|cc|cxx|cpp|cu|h|hpp|hxx|inl|txx)$

--- a/documentation/devel/editor-settings.md
+++ b/documentation/devel/editor-settings.md
@@ -1,5 +1,9 @@
 # Developer documentation: editor settings
 
 White-spaces and indentation with multiple developers are a pain. Please adhere to
-our white-space policy, which we try to enforce via [clang-format](https://clang.llvm.org/docs/ClangFormat.html).
-Check that site for integration with your editor/IDE.
+our white-space policy, which we enforce via [pre-commit](https://pre-commit.com/), including
+running of [clang-format](https://clang.llvm.org/docs/ClangFormat.html).
+See [git-hooks.md](git-hooks.md) for more information.
+
+Developer experience will be best if you set your editor/IDE to use the same settings,
+including versions of the formatters (`clang-format` in particular).

--- a/documentation/devel/git-hooks.md
+++ b/documentation/devel/git-hooks.md
@@ -3,10 +3,26 @@
 We use [pre-commit](https://pre-commit.com) to check coding conventions, including
 white-space formatting rules.
 
-Unfortunately, exact formatting used depends on the `clang-format` version. Therefore,
-you do have to install the same version as what is currently used in our GitHub Action.
+Unfortunately, exact formatting used depends on the `clang-format` (and others?) version. Therefore,
+you might need to install the same version as what is currently used in our
+[.pre-commit-config.yaml](../../.pre-commit-config.yaml) for your editor to pick up
+the same version.
 
 ## Installation of software
+
+### TL;DR
+
+```sh
+pip/conda install pre-commit
+git add blabla
+pre-commit run
+# optionally check files
+# "add" changes made by the hooks
+git add blabla
+git commit
+```
+
+### More detail
 
 We highly recommend to use `conda`:
 ```sh


### PR DESCRIPTION
Previously, the pre-commit check would use whatever `clang-format` is in the path of the user, which might be different from what we're using in CI.

Potentially, we could remove `clang-format` from `pre-commit-environment.yml`, but I'm leaving it in for now, as it might affect editor settings, until I understand better how/if editors pick up versions from `.pre-commit-config.yaml`.