### PR TITLE
Change bins in mask for sinogram message to use info()

### DIFF
--- a/src/scatter_buildblock/CreateTailMaskFromACFs.cxx
+++ b/src/scatter_buildblock/CreateTailMaskFromACFs.cxx
@@ -147,8 +147,7 @@ CreateTailMaskFromACFs::process_data()
               count += mask_left_size + mask_right_size;
 #endif
             }
-          std::cout << count << " bins in mask for sinogram at segment " << bin.segment_num() << ", axial_pos "
-                    << bin.axial_pos_num() << "\n";
+          info(boost::format("%1% bins in mask for sinogram at segment %2%, axial_pos %3%") % count % bin.segment_num() % bin.axial_pos_num());
           if (this->mask_proj_data->set_sinogram(mask_sinogram) != Succeeded::yes)
             return Succeeded::no;
         }

--- a/src/scatter_buildblock/CreateTailMaskFromACFs.cxx
+++ b/src/scatter_buildblock/CreateTailMaskFromACFs.cxx
@@ -147,7 +147,8 @@ CreateTailMaskFromACFs::process_data()
               count += mask_left_size + mask_right_size;
 #endif
             }
-          info(boost::format("%1% bins in mask for sinogram at segment %2%, axial_pos %3%") % count % bin.segment_num() % bin.axial_pos_num());
+          info(boost::format("%1% bins in mask for sinogram at segment %2%, axial_pos %3%") % count % bin.segment_num()
+               % bin.axial_pos_num());
           if (this->mask_proj_data->set_sinogram(mask_sinogram) != Succeeded::yes)
             return Succeeded::no;
         }

--- a/src/scatter_buildblock/CreateTailMaskFromACFs.cxx
+++ b/src/scatter_buildblock/CreateTailMaskFromACFs.cxx
@@ -11,6 +11,7 @@
 #include "stir/scatter/CreateTailMaskFromACFs.h"
 #include "stir/Bin.h"
 #include "boost/lambda/lambda.hpp"
+#include "boost/format.hpp"
 #include "stir/error.h"
 
 START_NAMESPACE_STIR


### PR DESCRIPTION
<!-- Fill in most of this text, and delete what is not appropriate.
Please read and adhere to the [contribution guidelines](https://github.com/UCL/STIR/blob/master/CONTRIBUTING.md).
Did you sign the STIR Contribution License Agreement?
-->

## Changes in this pull request

This pull request includes a change to the `CreateTailMaskFromACFs::process_data()` function in the `src/scatter_buildblock/CreateTailMaskFromACFs.cxx` file to improve logging by replacing `std::cout` with the `info` function from the Boost library.


## Testing performed
Works on my machine 😄 

## Related issues
<!-- Use keywords such as "fixes", "closes", see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->


## Checklist before requesting a review
<!--Put an x between the [] when completed. Delete a line if not applicable. -->
  - [] I have performed a self-review of my code
  - [] I have added docstrings/doxygen in line with the guidance in the developer guide
  - [] I have implemented unit tests that cover any new or modified functionality (if applicable)
  - [] The code builds and runs on my machine
  - [] `documentation/release_XXX.md` has been updated with any functionality change (if applicable)
