### PR TITLE
Replace Boost_VERSION with Boost_VERSION_STRING in STIRConfig.cmake

### DIFF
--- a/src/cmake/STIRConfig.cmake.in
+++ b/src/cmake/STIRConfig.cmake.in
@@ -79,7 +79,7 @@ else()
   SET(STIR_FIND_TYPE "REQUIRED")
 endif()
 
-find_package(Boost @Boost_VERSION@ REQUIRED)
+find_package(Boost @Boost_VERSION_STRING@ REQUIRED)
 
 if (@ITK_FOUND@)
   message(STATUS "ITK support in STIR enabled.")


### PR DESCRIPTION
<!-- Fill in most of this text, and delete what is not appropriate.
Please read and adhere to the [contribution guidelines](https://github.com/UCL/STIR/blob/master/CONTRIBUTING.md).
Did you sign the STIR Contribution License Agreement?
-->

## Changes in this pull request

This pull request includes a modification to the `src/cmake/STIRConfig.cmake.in` file to correct the version specification for the Boost library.


## Testing performed

Fixes my issue in #1541 

## Related issues
<!-- Use keywords such as "fixes", "closes", see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

Fixes #1541 


## Checklist before requesting a review
<!--Put an x between the [] when completed. Delete a line if not applicable. -->
  - [x] I have performed a self-review of my code
  - [] I have added docstrings/doxygen in line with the guidance in the developer guide
  - [] I have implemented unit tests that cover any new or modified functionality (if applicable)
  - [x] The code builds and runs on my machine
  - [] `documentation/release_XXX.md` has been updated with any functionality change (if applicable)
