### PR TITLE
[GHA] force ubuntu-24.04 and update compilers

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -77,8 +77,9 @@ jobs:
           ITK: "ON"
         - os: ubuntu-24.04
           compiler: gcc
-          compiler_version: 14
-          cuda_version: "12.1.0"
+          # currently CUDA doesn't support gcc 14 yet
+          compiler_version: 13
+          cuda_version: "12.6.1"
           BUILD_FLAGS: "-DSTIR_OPENMP=ON -DCMAKE_CXX_STANDARD=17"
           BUILD_TYPE: "Release"
           parallelproj: "ON"
@@ -180,7 +181,7 @@ jobs:
           echo CXX="$CXX" >> $GITHUB_ENV
 
     - if: matrix.cuda_version != '0'
-      uses: Jimver/cuda-toolkit@v0.2.11
+      uses: Jimver/cuda-toolkit@v0.2.19
       id: cuda-toolkit
       with:
           cuda: ${{ matrix.cuda_version }}

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -255,13 +255,23 @@ jobs:
              rm -rf parallelproj
           fi
 
-          # Install ROOT (warning: currently only valid on Ubuntu)
+          # Install ROOT (warning: brittle due to OS versions etc)
           if test "${{matrix.ROOT}}XX" == "ONXX"; then
-             ROOT_file=root_v6.28.12.Linux-ubuntu20-x86_64-gcc9.4.tar.gz
+             case ${{matrix.os}} in
+               (ubuntu*)
+               sudo apt install libtbb-dev libvdt-dev libgif-dev
+               ROOT_file=root_v6.34.00.Linux-ubuntu24.04-x86_64-gcc13.2.tar.gz
+               #root_v6.34.00.Linux-ubuntu24.10-x86_64-gcc14.2.tar.gz
+               ;;
+               (macOS*)
+               ROOT_file=https://root.cern/download/root_v6.34.00.macos-15.1-arm64-clang160.tar.gz
+               ;;
+             esac
              wget https://root.cern/download/"$ROOT_file"
              tar -xzvf "$ROOT_file"
              rm "$ROOT_file"
              source root/bin/thisroot.sh
+             echo ROOTSYS="$ROOTSYS" >> $GITHUB_ENV
           fi
 
           # we'll install some dependencies with shared libraries, so need to let the OS know
@@ -303,7 +313,11 @@ jobs:
           CMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install
           # make available to jobs below
           echo CMAKE_INSTALL_PREFIX="$CMAKE_INSTALL_PREFIX" >> $GITHUB_ENV
-          EXTRA_BUILD_FLAGS="-DBUILD_SWIG_PYTHON=ON -DPYTHON_EXECUTABLE=`which python`"
+          if [ -n "$ROOTSYS" ]; then
+            # make sure we find ROOT (and vdt, which is installed in the same place)
+            EXTRA_BUILD_FLAGS=-DCMAKE_PREFIX_PATH:PATH="$ROOTSYS"
+          fi
+          EXTRA_BUILD_FLAGS="${EXTRA_BUILD_FLAGS} -DBUILD_SWIG_PYTHON=ON -DPython_EXECUTABLE=`which python`"
           EXTRA_BUILD_FLAGS="${EXTRA_BUILD_FLAGS} -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX} -DCMAKE_BUILD_TYPE=${BUILD_TYPE}"
           EXTRA_BUILD_FLAGS="${EXTRA_BUILD_FLAGS} -DDOWNLOAD_ZENODO_TEST_DATA=ON"
           EXTRA_BUILD_FLAGS="${EXTRA_BUILD_FLAGS} -DDISABLE_STIR_LOCAL=OFF -DSTIR_LOCAL=${GITHUB_WORKSPACE}/examples/C++/using_STIR_LOCAL"

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -321,6 +321,13 @@ jobs:
               ;;
            esac
 
+    # Enable tmate debugging of manually-triggered workflows if the input option was provided
+    - name: Setup tmate session if triggered
+      #if: ${{ failure() }}
+      uses: mxschmitt/action-tmate@v3
+      timeout-minutes: 30
+      if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled == 'true' }}
+
     - name: build
       shell: bash
       env:
@@ -329,12 +336,6 @@ jobs:
           cd ${GITHUB_WORKSPACE}/build;
           source ${GITHUB_WORKSPACE}/my-env/bin/activate
           cmake --build . -j 2 --config ${BUILD_TYPE}} --target install
-
-    # Enable tmate debugging of manually-triggered workflows if the input option was provided
-    - name: Setup tmate session if triggered
-      uses: mxschmitt/action-tmate@v3
-      timeout-minutes: 15
-      if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled == 'true' }}
 
     - name: ctest
       shell: bash

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -38,16 +38,16 @@ jobs:
     strategy:
       matrix:
         include:
-        - os: ubuntu-latest
+        - os: ubuntu-24.04
           compiler: gcc
-          compiler_version: 9
+          # compiler_version: 9
           cuda_version: "0"
           BUILD_FLAGS: "-DSTIR_OPENMP=ON"
           BUILD_TYPE: "Release"
           parallelproj: "ON"
           ROOT: "ON"
           ITK: "OFF"
-        - os: ubuntu-latest
+        - os: ubuntu-24.04
           compiler: clang
           #compiler_version:
           cuda_version: "0"
@@ -57,7 +57,7 @@ jobs:
           ROOT: "OFF"
           # currently using ITK 5.2 which doesn't like clang 14
           ITK: "OFF"
-        - os: ubuntu-latest
+        - os: ubuntu-24.04
           compiler: gcc
           compiler_version: 10
           cuda_version: "0"
@@ -66,18 +66,18 @@ jobs:
           parallelproj: "OFF"
           ROOT: "OFF"
           ITK: "ON"
-        - os: ubuntu-latest
+        - os: ubuntu-24.04
           compiler: gcc
-          compiler_version: 12
+          compiler_version: 14
           cuda_version: "0"
           BUILD_FLAGS: "-DSTIR_OPENMP=ON -DCMAKE_CXX_STANDARD=20"
           BUILD_TYPE: "RelWithDebInfo"
           parallelproj: "ON"
           ROOT: "OFF"
           ITK: "ON"
-        - os: ubuntu-latest
+        - os: ubuntu-24.04
           compiler: gcc
-          compiler_version: 12
+          compiler_version: 14
           cuda_version: "12.1.0"
           BUILD_FLAGS: "-DSTIR_OPENMP=ON -DCMAKE_CXX_STANDARD=17"
           BUILD_TYPE: "Release"

--- a/documentation/release_6.3.htm
+++ b/documentation/release_6.3.htm
@@ -79,7 +79,11 @@
     </ul>
 
 <h3>Build system</h3>
-
+<ul>
+  <li>Enable more diagnostics in CMake when finding CERN's ROOT (we used to silence them)<br>
+    <a href=https://github.com/UCL/STIR/pull/1552>PR #1552</a>
+  </li>
+</ul>
 
 <h3>Known problems</h3>
     <p>See <a href=https://github.com/UCL/STIR/labels/bug>our issue tracker</a>.</p>
@@ -97,7 +101,11 @@
 
 
 <h3>Bug fixes</h3>
-
+<ul>
+  <li>Fixed minor incompatibility with gcc-14 and clang-18 buy adding an extra include file<br>
+    <a href=https://github.com/UCL/STIR/pull/1552>PR #1552</a>
+  </li>
+</ul>
 
 <h3>Other code changes</h3>
 

--- a/src/cmake/FindCERN_ROOT.cmake
+++ b/src/cmake/FindCERN_ROOT.cmake
@@ -14,8 +14,9 @@
 ## FINDING ROOT 
 #
 # Attempts to `find_package(ROOT)`, If that fails, use root-config.
-# The primary method for ROOT being found is to use the `find_package(ROOT ${CERN_ROOT_FIND_VERSION} QUIET)` call. 
-# This process utilizes the `ROOT_DIR` variable to find the relevant CMake files. 
+# The primary method for ROOT being found is to use the `find_package(ROOT ${CERN_ROOT_FIND_VERSION} CONFIG)` call. 
+# This process utilizes the `ROOT_DIR` variable to find the relevant ROOTConfig*.cmake files (which are
+# part of the ROOT distribution).
 # There are two methods by which this variable can be set:
 # 1. Set the `ROOT_DIR` CMake argument. Point to `<ROOT_install_dir>/cmake` directory.
 # 2. Use the `ROOTSYS` CMake or environment variable. If `ROOT_DIR` is not provided, we will determine set `ROOT_DIR` to `${ROOTSYS}/cmake`. 
@@ -53,7 +54,7 @@ if (DEFINED ROOT_DIR)
   endif()
 endif()
 
-find_package(ROOT ${CERN_ROOT_FIND_VERSION} QUIET)
+find_package(ROOT ${CERN_ROOT_FIND_VERSION} CONFIG)
 if (ROOT_FOUND)
   if (CERN_ROOT_DEBUG)
     message(STATUS "Found ROOTConfig.cmake, so translating to old CERN_ROOT variable names")

--- a/src/include/stir/modelling/PlasmaData.inl
+++ b/src/include/stir/modelling/PlasmaData.inl
@@ -21,6 +21,7 @@
 #include "stir/warning.h"
 #include "stir/error.h"
 #include <functional>
+#include <algorithm>
 
 START_NAMESPACE_STIR
 


### PR DESCRIPTION
Using ubuntu-latest as part of the "key" for ccache means we don't catch changes in the VM.

Taking the opportunity to test gcc-14.

Fixes #1550 