### PR TITLE
FIX Without OPENMP, LM_distributable_computation doesn't write output.

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -94,15 +94,15 @@ jobs:
           BUILD_TYPE: "Debug"
           ROOT: "OFF"
           ITK: "OFF"
-        # Currently disabled due to problems with listmode recon, see https://github.com/UCL/STIR/issues/1200
-        #- os: macOS-latest
-        #  compiler: clang
-        #  compiler_version: 16
-        #  BUILD_FLAGS: "-DSTIR_OPENMP=OFF"
-        #  parallelproj: "OFF"
-        #  BUILD_TYPE: "Release"
-        #  ROOT: "OFF"
-        #  ITK: "OFF"
+        - os: macOS-latest
+          compiler: clang
+          compiler_version: 16
+          cuda_version: "0"
+          BUILD_FLAGS: "-DSTIR_OPENMP=OFF"
+          parallelproj: "OFF"
+          BUILD_TYPE: "Release"
+          ROOT: "OFF"
+          ITK: "OFF"
 
       # let's run all of them, as opposed to aborting when one fails
       fail-fast: false
@@ -168,11 +168,12 @@ jobs:
               if test XX${HOMEBREW_PREFIX} = XX; then
                 HOMEBREW_PREFIX=/usr/local
               fi
-              LDFLAGS="-L$HOMEBREW_PREFIX/opt/llvm/lib/c++ -Wl,-rpath,$HOMEBREW_PREFIX/opt/llvm/lib/c++"
+              LLVMDIR=$HOMEBREW_PREFIX/opt/llvm@${{ matrix.compiler_version }}
+              LDFLAGS="-L${LLVMDIR}/lib/c++ -Wl,-rpath,${LLVMDIR}/lib/c++"
               # make available to jobs below
               echo LDFLAGS="$LDFLAGS" >> $GITHUB_ENV
-              CC="$HOMEBREW_PREFIX/opt/llvm/bin/clang"
-              CXX="$HOMEBREW_PREFIX/opt/llvm/bin/clang++"
+              CC="${LLVMDIR}/bin/clang"
+              CXX="${LLVMDIR}/bin/clang++"
             fi
           fi
           export CC CXX
@@ -359,7 +360,7 @@ jobs:
           set -vx
           cd ${GITHUB_WORKSPACE}/build
           # find test exclusions. Complicated due to need of single -E argument and | pattern
-          if test ${{matrix.cuda_version}} != "0"; then
+          if test "${{matrix.cuda_version}}" != "0"; then
               # No CUDA drivers on GitHub Actions
               EXCLUDE="parallelproj|test_blocks_on_cylindrical_projectors"
           fi

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -48,6 +48,15 @@ jobs:
           ROOT: "ON"
           ITK: "OFF"
         - os: ubuntu-24.04
+          compiler: gcc
+          # compiler_version: 9
+          cuda_version: "0"
+          BUILD_FLAGS: "-DSTIR_OPENMP=OFF"
+          BUILD_TYPE: "Release"
+          parallelproj: "ON"
+          ROOT: "OFF"
+          ITK: "OFF"
+        - os: ubuntu-24.04
           compiler: clang
           #compiler_version:
           cuda_version: "0"

--- a/documentation/release_6.3.htm
+++ b/documentation/release_6.3.htm
@@ -76,6 +76,10 @@
             See <a href="https://github.com/UCL/STIR/issues/1532">Issue #1532</a> for more detail. Fixed by using averaging functionality of SSRB instead of adding segments for attenuation correction factors.
             <a href=https://github.com/UCL/STIR/pull/1531>PR #1531</a>
         </li>
+        <li>
+            Fixed a bug in the distributed LM computation code (introduced in 6.1) that neglected to accumulate outputs when not build with OpenMP.
+            See <a href="https://github.com/UCL/STIR/pull/1566"">PR #1566</a>".
+        </li>
     </ul>
 
 <h3>Build system</h3>

--- a/src/include/stir/recon_buildblock/distributable.txx
+++ b/src/include/stir/recon_buildblock/distributable.txx
@@ -1,6 +1,7 @@
 /*
     Copyright (C) 2024 University College London
     Copyright (C) 2020, 2022, Univeristy of Pennsylvania
+    Copyright (C) 2025, Commonweath Scientific and Industrial Research Organisation
     This file is part of STIR.
 
     SPDX-License-Identifier: Apache-2.0 AND License-ref-PARAPET-license
@@ -16,6 +17,7 @@
 
   \author Nikos Efthimiou
   \author Kris Thielemans
+  \author Ashley Gillman
 */
 #include "stir/shared_ptr.h"
 #include "stir/recon_buildblock/distributable.h"
@@ -139,8 +141,7 @@ LM_distributable_computation(const shared_ptr<ProjMatrixByBin> PM_sptr,
                   local_double_out_ptrs[thread_num]);
       }
   }
-#ifdef STIR_OPENMP
-  // flatten data constructed by threads
+  // flatten data constructed by threads (or collapse unitary dim if no threading)
   {
     if (double_out_ptr != NULL)
       {
@@ -157,7 +158,6 @@ LM_distributable_computation(const shared_ptr<ProjMatrixByBin> PM_sptr,
             *output_image_ptr += *(local_output_image_sptrs[i]);
       }
   }
-#endif
   CPU_timer.stop();
   wall_clock_timer.stop();
   info(boost::format("Computation times for distributable_computation, CPU %1%s, wall-clock %2%s") % CPU_timer.value()


### PR DESCRIPTION
Should fix #1422 #1491, maybe #1200. 

G'day! Long time no see.

I'm having a little explore into the gantry shift PR to see what is required, but first step is to get master building on my machine (OSX).

I'm not familiar with this code, but it looks like the idea was to store the outputs per thread in `local_ooutput_image_sptrs` and sum them up at the end. Without OpenMP (required if Clang), it is treated as one thread, but the writing back out never happend.

## Testing performed
I've tested with `ctest`, and tests now passing.


## Checklist before requesting a review
<!--Put an x between the [] when completed. Delete a line if not applicable. -->
  - [X] I have performed a self-review of my code
  - [-] I have added docstrings/doxygen in line with the guidance in the developer guide
  - [] I have implemented unit tests that cover any new or modified functionality (if applicable)
  - [X] The code builds and runs on my machine
  - [] `documentation/release_XXX.md` has been updated with any functionality change (if applicable)
