### PR TITLE
BUILD: Add Nix flake with package and devShell

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,6 +87,10 @@ install/
 .project
 .settings
 
+# Nix
+result
+outputs
+
 # other stuff
 .cache
 *.idea

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,86 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, cmake , boost , itk , swig, libGL
+, buildPython ? true, python ? null, numpy ? null
+, buildLibs ? true,
+}:
+
+let
+  ver = "6.2.0";
+  # Uncomment and update this if you want to build from GitHub
+  #sha256 = "0fzfm3ki0v2g09jqjakrq3asz69snmnydm3iwcqi6k9rabgn4g7z";
+
+in stdenv.mkDerivation {
+  name = "stir-${ver}";
+
+  src = lib.cleanSource ./.;
+  # Uncomment and update this if you want to build from GitHub
+#   src = fetchFromGitHub {
+#     owner = "UCL";
+#     repo = "STIR";
+#     rev = "rel_${ver}";
+#     inherit sha256;
+#   };
+
+  buildInputs = [ boost cmake itk /*openmpi*/ ];
+  propagatedBuildInputs = [ swig ]
+    ++ lib.optional buildPython [ python numpy ];
+
+  # This is a hackaround because STIR requires source available at runtime.
+  setSourceRoot = ''
+    actualSourceRoot=;
+    for i in *;
+    do
+        if [ -d "$i" ]; then
+            case $dirsBefore in
+                *\ $i\ *)
+
+                ;;
+                *)
+                    if [ -n "$actualSourceRoot" ]; then
+                        echo "unpacker produced multiple directories";
+                        exit 1;
+                    fi;
+                    actualSourceRoot="$i"
+                ;;
+            esac;
+        fi;
+    done;
+
+    # "Install" location for source
+    sourceRoot=$prefix/src
+    mkdir -p $sourceRoot
+    # Put the actual source there
+    cp -r $actualSourceRoot -T $sourceRoot
+  '';
+  cmakeFlags = [
+    "-DBUILD_TESTING=ON"
+    "-DGRAPHICS=PGM"
+    "-DSTIR_MPI=OFF"
+    "-DSTIR_OPENMP=${if stdenv.isDarwin then "OFF" else "ON"}"
+   ] ++ lib.optionals (buildLibs) [
+    "-DBUILD_SHARED_LIBS=ON"
+   ] ++ lib.optionals (buildPython) [
+    "-DBUILD_SWIG_PYTHON=ON"
+   ] ++ lib.optionals (!stdenv.hostPlatform.isDarwin) [
+    "-DOPENGL_INCLUDE_DIR=${lib.getInclude libGL}/include"  # Borrowed from vtk
+  ];
+  preConfigure = lib.optionalString buildPython ''
+    cmakeFlags="-DPYTHON_DEST=$out/${python.sitePackages} $cmakeFlags"
+  '';
+  postInstall = ''
+    # add scripts to bin
+    find $src/scripts -type f ! -path "*maintenance*" -name "*.sh"  -exec cp -fn {} $out/bin \;
+    find $src/scripts -type f ! -path "*maintenance*" ! -name "*.*" -exec cp -fn {} $out/bin \;
+  '';
+
+  pythonPath = "";  # Makes python.buildEnv include libraries
+  enableParallelBuilding = true;
+
+  meta = with lib; {
+    description = "STIR - Software for Tomographic Image Reconstruction";
+    homepage = http://stir.sourceforge.net;
+    license = with licenses; [ lgpl21 gpl2 free ];  # free = custom PARAPET license
+  };
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1739758141,
+        "narHash": "sha256-uq6A2L7o1/tR6VfmYhZWoVAwb3gTy7j4Jx30MIrH0rE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "c618e28f70257593de75a7044438efc1c1fc0791",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-24.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,46 @@
+{
+  description = "Software for Tomographic Image Reconstruction";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.11";
+  };
+
+  outputs = { self, nixpkgs }:
+    let
+      supportedSystems = [ "x86_64-linux" "x86_64-darwin" "aarch64-linux" "aarch64-darwin" ];
+      forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
+      nixpkgsFor = forAllSystems (system: import nixpkgs { inherit system; });
+    in
+    {
+      # STIR Builds available: nix run /path/to/stir#stir-nolibs
+      packages = forAllSystems (system:
+        let pkgs = nixpkgsFor.${system}; in with pkgs; rec {
+          stir = callPackage ./default.nix { inherit (python3Packages) python numpy; };
+          stir-nolibs = callPackage ./default.nix { buildLibs = false; buildPython = false; };
+          default = stir;
+        }
+      );
+
+      # Development environment
+      devShells = forAllSystems (system:
+        let
+          pkgs = nixpkgsFor.${system};
+          # Which STIR package to use
+          package = self.packages.${system}.stir-nolibs;
+
+        in {
+          default = pkgs.mkShell {
+            buildInputs = package.buildInputs ++ [
+              # Extra dependencies for the shell
+              pkgs.cmakeCurses
+            ];
+            nativeBuildInputs = package.nativeBuildInputs or [];
+
+            shellHook = ''
+              echo "Development shell for STIR is ready!"
+            '';
+          };
+        }
+      );
+    };
+}


### PR DESCRIPTION
[Nix](https://nixos.org/nix) is a package manager. I've been [using it for a long-while, including for STIR/SIRF development](https://github.com/ashgillman/SIRF-NixBuild/). You can declaratively (i.e., using a .nix file) set up the dependencies of a file, and then drop into an environment with it (so a bit like docker to the end user) or install it to your system (like a normal package manager).

So with Nix, a user could run `nix shell github:UCL/STIR` and have STIR available (after waiting for the build, locally).

I don't necessarily advocate adoption - it would be tricky to maintain if no-one is using it and I've been AWOL for a long time. This PR is (1) for visibility; so that some new user could copy the .nix files locally (say they want to try STIR and are familiar with Nix), and (2) to let you know I do have it running if it is of interest.