### PR TITLE
enable branching ratio in BinNormalisationWithCalibration

### DIFF
--- a/documentation/release_6.0.htm
+++ b/documentation/release_6.0.htm
@@ -44,7 +44,16 @@
     <h2> Summary for end users (also to be read by developers)</h2>
 
     <h3>Changes breaking backwards compatibility from a user-perspective</h3>
-   <ul>
+    <ul>
+      <li>
+        When using ECAT7, ECAT8, GEHDF5 or SPECT normalisation, it will
+        now take the branching ratio of the radionuclide into account, if the radionuclide
+        for the data is known (you can check with <tt>list_projdata_info</tt> and <tt>list_lm_info</tt>.
+        For instance, for F-18 this will make reconstructed images 1/0.9686 larger, but
+        the factor is larger for other radionuclides, certainly in SPECT.
+        <br>
+        This was actually already supposed to be the case in previous version, but a bug disabled it.
+        </li>
      <li>
        When parsing Interfile headers for projection data and the <tt>originating system</tt>
        is not recognised, the previous version of STIR tried to guess the scanner based on the
@@ -241,8 +250,11 @@
         <code>virtual ListModeData::get_scanner_ptr()</code> is replaced by <code>ListModeData::get_scanner()</code>.
       </li>
       <li>
-        <code>ProjDataInfo*NoArcCorr::get_bin_for_det_pair</code> is now private.
+       <code>ProjDataInfo*NoArcCorr::get_bin_for_det_pair</code> is now private.
         Use <code>get_bin_for_det_pos_pair</code> instead.
+      </li>
+      <li><code>BinNormalisatoonWithCalibration::get/set_branching_ratio</code> members have
+        been removed, as they shouldn't really be part of the normalisation object.
       </li>
     </ul>
 

--- a/src/include/stir/recon_buildblock/BinNormalisationWithCalibration.h
+++ b/src/include/stir/recon_buildblock/BinNormalisationWithCalibration.h
@@ -1,7 +1,7 @@
 //
 //
 /*
-    Copyright (C) 2020-2021, University College London
+    Copyright (C) 2020-2021, 2024, University College London
     Copyright (C) 2020, National Physical Laboratory
     This file is part of STIR.
 
@@ -34,11 +34,16 @@ START_NAMESPACE_STIR
 
 /*!
   \ingroup normalisation
-This class provides the facility to use a calibration factor and (isotope) branching ratio when normalising data.
+  This class provides the facility to use a calibration factor and (isotope) branching ratio when normalising data.
   Therefore, if they are set correctly, the reconstructed image will be calibrated as well.
   
   Note that it is the responsibility of the derived classes to set the calibration factor.
   The branching ratio is obtained from the radionuclide set in \c ExamInfo (passed by set_up()).
+
+  Efficiency is computed as
+  <pre>
+  calibration_factor * branching_ratio * uncalibrated_efficiency
+  </pre>
   */
 class BinNormalisationWithCalibration : 
         public  BinNormalisation
@@ -55,10 +60,8 @@ public:
   //! product of calibration factor etc
   float get_calib_decay_branching_ratio_factor(const Bin&) const; // TODO find a better name
   float get_calibration_factor() const override;
-  float get_branching_ratio() const;
   
   void set_calibration_factor(const float);
-  void set_radionuclide(const Radionuclide&);
   
   // needs to be implemented by derived class
   virtual float get_uncalibrated_bin_efficiency(const Bin&) const  = 0;
@@ -81,7 +84,6 @@ private:
   //  need to be added to the parsing keywords
 //  bool use_calibration_factor; // default to true
   float calibration_factor;
-  Radionuclide radionuclide;
   //! product of various factors
   /*! computed by set_up() */
   float _calib_decay_branching_ratio;


### PR DESCRIPTION
We were not using the radionuclide in the exam_info used for set_up, but an (uninitialised) class radionuclide class member, therefore always defaulting to 1 (afer writing a warning).

However, this fix means that images will now have a different scale.

Also, remove the get/set_branching_ratio members, as they shouldn't really be part of the normalisation object.

This therefore breaks backwards-compatibility!

(There are currently still some typos here.)

***This branch will undergo forced pushes, so be careful where you merge it!***