### PR TITLE
no longer use default for radionuclide if name is empty

### DIFF
--- a/documentation/release_6.3.htm
+++ b/documentation/release_6.3.htm
@@ -62,6 +62,11 @@
 <h3>Changed functionality</h3>
     <ul>
       <li>
+        In previous versions, when reading data/images where the radionuclide was not set, a default was used (F18 for PET, Tcm99 for SPECT).
+        This led to surprising (and sometimes wrong) behaviour. The radionuclide is now kept as "unknown".<br>
+        <a href=https://github.com/UCL/STIR/pull/1574>PR #1574</a>
+      </li>
+      <li>
         Default ECAT scanner configurations updated to use a negative intrinsic tilt.
       </li>
     </ul>

--- a/src/buildblock/RadionuclideDB.cxx
+++ b/src/buildblock/RadionuclideDB.cxx
@@ -68,7 +68,7 @@ std::string
 RadionuclideDB::get_radionuclide_name_from_lookup_table(const std::string& rname) const
 {
   if (rname.empty())
-    return "default";
+    return "unknown";
 
 #ifdef nlohmann_json_FOUND
   if (this->radionuclide_lookup_table_filename.empty())
@@ -227,8 +227,11 @@ RadionuclideDB::get_radionuclide_from_json(ImagingModality rmodality, const std:
 Radionuclide
 RadionuclideDB::get_radionuclide(ImagingModality rmodality, const std::string& rname)
 {
+  if (rname == "unknown" || rname == "Unknown" || rname.empty())
+    return Radionuclide();
+
   // handle default case
-  if (rname.empty() || rname == "default")
+  if (rname == "default")
     {
       if (rmodality.get_modality() == ImagingModality::PT)
         return get_radionuclide(rmodality, "^18^Fluorine");

--- a/src/test/test_radionuclide.cxx
+++ b/src/test/test_radionuclide.cxx
@@ -65,19 +65,13 @@ RadionuclideTest::run_tests()
   {
     // PET
     {
-      const auto rnuclide = db.get_radionuclide(pt_mod, "");
+      const auto rnuclide = db.get_radionuclide(pt_mod, "default");
       check(rnuclide == F18_rnuclide, "check \"empty\" radionuclide for PET is F-18");
-
-      const auto def_rnuclide = db.get_radionuclide(pt_mod, "default");
-      check(rnuclide == def_rnuclide, "check equality of \"empty\" and \"default\" radionuclide for PET");
     }
     // NM
     {
-      const auto rnuclide = db.get_radionuclide(nm_mod, "");
+      const auto rnuclide = db.get_radionuclide(nm_mod, "default");
       check(rnuclide == Tc99m_rnuclide, "check \"empty\" radionuclide for NM is Tc-99m");
-
-      const auto def_rnuclide = db.get_radionuclide(nm_mod, "default");
-      check(rnuclide == def_rnuclide, "check equality of \"empty\" and \"default\" radionuclide for NM");
     }
   }
 


### PR DESCRIPTION
we were assuming default values, but it's better to just state explicitly it's unknown.

Fixes #1480 

***Warning: this branch will be rebased on `master`***