### PR TITLE
[CMake] fix HDF5 version number in STIRConfig.cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -290,6 +290,8 @@ endforeach()
 set(STIR_REGISTRIES ${INSTALLED_STIR_REGISTRIES})
 
 # New create STIRConfig.cmake
+# First strip patch info from HDF5_VERSION, as on some systems it might be set as x.y.z-something, which causes problems for find_package.
+string(REGEX MATCH "^([0-9]+)\\.([0-9]+)" HDF5_VERSION_FOR_CONFIG "${HDF5_VERSION}")
 CONFIGURE_PACKAGE_CONFIG_FILE(
   src/cmake/STIRConfig.cmake.in
   "${CMAKE_BINARY_DIR}/STIRConfig.cmake"

--- a/src/cmake/STIRConfig.cmake.in
+++ b/src/cmake/STIRConfig.cmake.in
@@ -99,9 +99,9 @@ if (@HDF5_FOUND@)
     # We try to work-around this by first looking for both C and CXX, and then only for CXX.
     # Note that this only solves the problem if in the "client" code,
     # find_package(STIR) is called BEFORE find_package(HDF5)
-    find_package(HDF5 @HDF5_VERSION@ QUIET COMPONENTS C CXX)
+    find_package(HDF5 @HDF5_VERSION_FOR_CONFIG@ QUIET COMPONENTS C CXX)
   endif()
-  find_package(HDF5 @HDF5_VERSION@ REQUIRED COMPONENTS CXX )
+  find_package(HDF5 @HDF5_VERSION_FOR_CONFIG@ REQUIRED COMPONENTS CXX )
 
   set(STIR_BUILT_WITH_HDF5 TRUE)
 endif()


### PR DESCRIPTION
We now only require version major.minor for HDF5, as `HDF5_VERSION` could otherwise contain extra patch info, causing problems with `find_package(STIR)`.

Fixes #1557