### PR TITLE
Future proofing

### DIFF
--- a/documentation/release_6.3.htm
+++ b/documentation/release_6.3.htm
@@ -132,6 +132,12 @@
     a <code>shared_ptr&lt;const ProjDataInfo&gt;</code>.<br>
     <a href=https://github.com/UCL/STIR/pull/1315>PR #1315</a>
   </li>
+  <li>
+    As <code>stir::Array</code> template arguments might change in the future,
+    it is now recommended to include <tt>stir/ArrayFwd.h</tt> when using forward
+    declaration and use the <code>ArrayType</code> template-alias in places where
+    a rectangular array that might live on a GPU is intended.
+  </li>
 </ul>
 
 <h3>Bug fixes</h3>

--- a/src/buildblock/centre_of_gravity.cxx
+++ b/src/buildblock/centre_of_gravity.cxx
@@ -42,14 +42,14 @@ find_unweighted_centre_of_gravity_1d(const VectorWithOffset<T>& row)
 
 template <class T>
 T
-find_unweighted_centre_of_gravity(const Array<1, T>& row)
+find_unweighted_centre_of_gravity(const ArrayType<1, T>& row)
 {
   return find_unweighted_centre_of_gravity_1d(row);
 }
 
 template <int num_dimensions, class T>
 BasicCoordinate<num_dimensions, T>
-find_unweighted_centre_of_gravity(const Array<num_dimensions, T>& array)
+find_unweighted_centre_of_gravity(const ArrayType<num_dimensions, T>& array)
 {
   if (array.size() == 0)
     return BasicCoordinate<num_dimensions, T>(0);
@@ -70,7 +70,7 @@ find_unweighted_centre_of_gravity(const Array<num_dimensions, T>& array)
     }
 
   // first term
-  Array<1, T> first_dim_sums(array.get_min_index(), array.get_max_index());
+  ArrayType<1, T> first_dim_sums(array.get_min_index(), array.get_max_index());
   for (int i = array.get_min_index(); i <= array.get_max_index(); ++i)
     {
       first_dim_sums[i] = array[i].sum();
@@ -83,7 +83,7 @@ find_unweighted_centre_of_gravity(const Array<num_dimensions, T>& array)
 
 template <int num_dimensions, class T>
 BasicCoordinate<num_dimensions, T>
-find_centre_of_gravity(const Array<num_dimensions, T>& array)
+find_centre_of_gravity(const ArrayType<num_dimensions, T>& array)
 {
   const T sum = array.sum();
 
@@ -136,7 +136,7 @@ template void find_centre_of_gravity_in_mm_per_plane(VectorWithOffset<CartesianC
 /*
 template
 BasicCoordinate<3,float>
-find_centre_of_gravity(const Array<3,float>&);
+find_centre_of_gravity(const ArrayType<3,float>&);
 */
 // this instantiates 3D versions
 template CartesianCoordinate3D<float> find_centre_of_gravity_in_mm(const VoxelsOnCartesianGrid<float>& image);

--- a/src/include/stir/Array.h
+++ b/src/include/stir/Array.h
@@ -21,21 +21,21 @@
 /*!
   \file
   \ingroup Array
-  \brief defines the Array class for multi-dimensional (numeric) arrays
+  \brief defines the stir::Array class for multi-dimensional (numeric) arrays
 
   \author Kris Thielemans (with help from Alexey Zverovich)
   \author PARAPET project
   \author Gemma Fardell
 
-  Not all compilers support the full iterators, so you could disabled them by editing
-  the file and removing the define ARRAY_FULL. Lots of other things in the library
-  won't work then.
 */
 #include "stir/NumericVectorWithOffset.h"
 #include "stir/ByteOrder.h"
 #include "stir/IndexRange.h"
 #include "stir/deprecated.h"
 #include "stir/shared_ptr.h"
+// include forward declaration to ensure consistency, as well as use of
+// default parameters (if any)
+#include "stir/ArrayFwd.h"
 
 START_NAMESPACE_STIR
 class NumericType;

--- a/src/include/stir/ArrayFilterUsingRealDFTWithPadding.h
+++ b/src/include/stir/ArrayFilterUsingRealDFTWithPadding.h
@@ -25,8 +25,6 @@
 
 START_NAMESPACE_STIR
 class Succeeded;
-template <int num_dimensions, typename elemT>
-class Array;
 
 /*!
   \ingroup Array

--- a/src/include/stir/ArrayFunctionObject.h
+++ b/src/include/stir/ArrayFunctionObject.h
@@ -23,11 +23,10 @@
 #define __stir_ArrayFunctionObject_H__
 
 #include "stir/Succeeded.h"
+#include "stir/ArrayFwd.h"
 
 START_NAMESPACE_STIR
 
-template <int num_dimensions, typename elemT>
-class Array;
 template <int num_dimensions>
 class IndexRange;
 /*!

--- a/src/include/stir/ArrayFwd.h
+++ b/src/include/stir/ArrayFwd.h
@@ -19,4 +19,8 @@ namespace stir
 {
 template <int num_dimensions, typename elemT>
 class Array;
-}
+
+//! type alias for future-proofing for "large" rectangular arrays
+template <int num_dimensions, typename elemT>
+using ArrayType = Array<num_dimensions, elemT>;
+} // namespace stir

--- a/src/include/stir/ArrayFwd.h
+++ b/src/include/stir/ArrayFwd.h
@@ -1,0 +1,22 @@
+
+/*
+    Copyright (C) 2025, University College London
+    This file is part of STIR.
+
+    SPDX-License-Identifier: Apache-2.0
+
+    See STIR/LICENSE.txt for details
+*/
+
+/*!
+  \file
+  \ingroup Array
+  \brief forward declaration of stir::Array class for multi-dimensional (numeric) arrays
+*/
+#include "stir/common.h"
+
+namespace stir
+{
+template <int num_dimensions, typename elemT>
+class Array;
+}

--- a/src/include/stir/DiscretisedDensity.h
+++ b/src/include/stir/DiscretisedDensity.h
@@ -26,9 +26,6 @@
   \author Ashley Gillman
   \author (help from Alexey Zverovich)
   \author PARAPET project
-
-
-
 */
 
 #include "stir/CartesianCoordinate3D.h"
@@ -92,7 +89,7 @@ START_NAMESPACE_STIR
 */
 
 template <int num_dimensions, typename elemT>
-class DiscretisedDensity : public ExamData, public Array<num_dimensions, elemT>
+class DiscretisedDensity : public ExamData, public ArrayType<num_dimensions, elemT>
 {
 #ifdef SWIG
   // work-around swig problem. It gets confused when using a private (or protected)

--- a/src/include/stir/DiscretisedDensity.inl
+++ b/src/include/stir/DiscretisedDensity.inl
@@ -39,7 +39,7 @@ DiscretisedDensity<num_dimensions, elemT>::DiscretisedDensity()
 template <int num_dimensions, typename elemT>
 DiscretisedDensity<num_dimensions, elemT>::DiscretisedDensity(const IndexRange<num_dimensions>& range_v,
                                                               const CartesianCoordinate3D<float>& origin_v)
-    : Array<num_dimensions, elemT>(range_v),
+    : base_type(range_v),
       origin(origin_v)
 {}
 
@@ -48,7 +48,7 @@ DiscretisedDensity<num_dimensions, elemT>::DiscretisedDensity(const shared_ptr<c
                                                               const IndexRange<num_dimensions>& range_v,
                                                               const CartesianCoordinate3D<float>& origin_v)
     : ExamData(exam_info_sptr),
-      Array<num_dimensions, elemT>(range_v),
+      base_type(range_v),
       origin(origin_v)
 {}
 

--- a/src/include/stir/IO/interfile.h
+++ b/src/include/stir/IO/interfile.h
@@ -156,7 +156,7 @@ const VectorWithOffset<unsigned long> compute_file_offsets(int number_of_time_fr
                                                            const Coordinate3D<int>& dim,
                                                            unsigned long initial_offset = 0);
 
-//! This outputs an Interfile header and data for a Array<3,elemT> object.
+//! This outputs an Interfile header and data for a ArrayType<3,elemT> object.
 /*!
   \ingroup InterfileIO
  Extension .v will be added to the parameter 'filename' (if no extension present).
@@ -165,14 +165,14 @@ const VectorWithOffset<unsigned long> compute_file_offsets(int number_of_time_fr
 
 template <class elemT>
 Succeeded write_basic_interfile(const std::string& filename,
-                                const Array<3, elemT>& image,
+                                const ArrayType<3, elemT>& image,
                                 const CartesianCoordinate3D<float>& voxel_size,
                                 const CartesianCoordinate3D<float>& origin,
                                 const NumericType output_type = NumericType::FLOAT,
                                 const float scale = 0,
                                 const ByteOrder byte_order = ByteOrder::native);
 
-//! This outputs an Interfile header and data for a Array<3,elemT> object.
+//! This outputs an Interfile header and data for a ArrayType<3,elemT> object.
 /*!
   \ingroup InterfileIO
  Extension .v will be added to the parameter 'filename' (if no extension present).
@@ -182,14 +182,14 @@ Succeeded write_basic_interfile(const std::string& filename,
 template <class elemT>
 Succeeded write_basic_interfile(const std::string& filename,
                                 const ExamInfo& exam_info,
-                                const Array<3, elemT>& image,
+                                const ArrayType<3, elemT>& image,
                                 const CartesianCoordinate3D<float>& voxel_size,
                                 const CartesianCoordinate3D<float>& origin,
                                 const NumericType output_type = NumericType::FLOAT,
                                 const float scale = 0,
                                 const ByteOrder byte_order = ByteOrder::native);
 
-//! This outputs an Interfile header and data for a Array<3,elemT> object, assuming unit voxel sizes
+//! This outputs an Interfile header and data for a ArrayType<3,elemT> object, assuming unit voxel sizes
 /*!
   \ingroup InterfileIO
  Extension .v will be added to the parameter 'filename' (if no extension present).
@@ -202,7 +202,7 @@ Succeeded write_basic_interfile(const std::string& filename,
 
 template <class elemT>
 Succeeded write_basic_interfile(const std::string& filename,
-                                const Array<3, elemT>& image,
+                                const ArrayType<3, elemT>& image,
                                 const NumericType output_type = NumericType::FLOAT,
                                 const float scale = 0,
                                 const ByteOrder byte_order = ByteOrder::native);

--- a/src/include/stir/IO/interfile.h
+++ b/src/include/stir/IO/interfile.h
@@ -31,6 +31,7 @@
 // has to include Succeeded.h (even if it doesn't use the return value).
 #include "stir/Succeeded.h"
 #include "stir/ByteOrder.h"
+#include "stir/ArrayFwd.h"
 #include <iostream>
 #include <string>
 
@@ -38,8 +39,6 @@ START_NAMESPACE_STIR
 
 template <int num_dimensions>
 class IndexRange;
-template <int num_dimensions, typename elemT>
-class Array;
 template <int num_dimensions, typename elemT>
 class DiscretisedDensity;
 template <typename elemT>

--- a/src/include/stir/IO/read_data.h
+++ b/src/include/stir/IO/read_data.h
@@ -19,6 +19,7 @@
 */
 
 #include "stir/ByteOrder.h"
+#include "stir/ArrayFwd.h"
 
 START_NAMESPACE_STIR
 
@@ -26,8 +27,6 @@ class Succeeded;
 class NumericType;
 template <class T>
 class NumericInfo;
-template <int num_dimensions, class elemT>
-class Array;
 
 /*! \ingroup Array_IO
   \brief Read the data of an Array from file.

--- a/src/include/stir/IO/read_data.h
+++ b/src/include/stir/IO/read_data.h
@@ -41,23 +41,23 @@ class NumericInfo;
   However, the data might have been partially read from \a s.
 */
 template <int num_dimensions, class IStreamT, class elemT>
-inline Succeeded read_data(IStreamT& s, Array<num_dimensions, elemT>& data, const ByteOrder byte_order = ByteOrder::native);
+inline Succeeded read_data(IStreamT& s, ArrayType<num_dimensions, elemT>& data, const ByteOrder byte_order = ByteOrder::native);
 
 /*! \ingroup Array_IO
   \brief Read the data of an Array from file as a different type.
 
   This function essentially first calls convert_data() to construct
   an array with elements of type \a InputType, and then calls
-  read_data(IStreamT&, const Array<num_dimensions,elemT>&,
+  read_data(IStreamT&, const ArrayType<num_dimensions,elemT>&,
            const ByteOrder, const bool).
-  \see read_data(IStreamT&, const Array<num_dimensions,elemT>&,
+  \see read_data(IStreamT&, const ArrayType<num_dimensions,elemT>&,
            const ByteOrder, const bool)
 
   \see find_scale_factor() for the meaning of \a scale_factor.
 */
 template <int num_dimensions, class IStreamT, class elemT, class InputType, class ScaleT>
 inline Succeeded read_data(IStreamT& s,
-                           Array<num_dimensions, elemT>& data,
+                           ArrayType<num_dimensions, elemT>& data,
                            NumericInfo<InputType> input_type,
                            ScaleT& scale_factor,
                            const ByteOrder byte_order = ByteOrder::native);
@@ -65,7 +65,7 @@ inline Succeeded read_data(IStreamT& s,
 /*! \ingroup Array_IO
   \brief Read the data of an Array from file as a different type.
 
-  \see read_data(IStreamT&, const Array<num_dimensions,elemT>&,
+  \see read_data(IStreamT&, const ArrayType<num_dimensions,elemT>&,
            NumericInfo<InputType>,
            ScaleT&,
            const ByteOrder,
@@ -74,7 +74,7 @@ inline Succeeded read_data(IStreamT& s,
 */
 template <int num_dimensions, class IStreamT, class elemT, class ScaleT>
 inline Succeeded read_data(IStreamT& s,
-                           Array<num_dimensions, elemT>& data,
+                           ArrayType<num_dimensions, elemT>& data,
                            NumericType type,
                            ScaleT& scale,
                            const ByteOrder byte_order = ByteOrder::native);

--- a/src/include/stir/IO/read_data.inl
+++ b/src/include/stir/IO/read_data.inl
@@ -33,13 +33,13 @@ namespace detail
 /* Generic implementation of read_data(). See test_if_1d.h for info why we do this.*/
 template <int num_dimensions, class IStreamT, class elemT>
 inline Succeeded
-read_data_help(is_not_1d, IStreamT& s, Array<num_dimensions, elemT>& data, const ByteOrder byte_order)
+read_data_help(is_not_1d, IStreamT& s, ArrayType<num_dimensions, elemT>& data, const ByteOrder byte_order)
 {
   if (data.is_contiguous())
     return read_data_1d(s, data, byte_order);
 
   // otherwise, recurse
-  for (typename Array<num_dimensions, elemT>::iterator iter = data.begin(); iter != data.end(); ++iter)
+  for (typename ArrayType<num_dimensions, elemT>::iterator iter = data.begin(); iter != data.end(); ++iter)
     {
       if (read_data(s, *iter, byte_order) == Succeeded::no)
         return Succeeded::no;
@@ -51,7 +51,7 @@ read_data_help(is_not_1d, IStreamT& s, Array<num_dimensions, elemT>& data, const
 // specialisation for 1D case
 template <class IStreamT, class elemT>
 inline Succeeded
-read_data_help(is_1d, IStreamT& s, Array<1, elemT>& data, const ByteOrder byte_order)
+read_data_help(is_1d, IStreamT& s, ArrayType<1, elemT>& data, const ByteOrder byte_order)
 {
   return read_data_1d(s, data, byte_order);
 }
@@ -60,7 +60,7 @@ read_data_help(is_1d, IStreamT& s, Array<1, elemT>& data, const ByteOrder byte_o
 
 template <int num_dimensions, class IStreamT, class elemT>
 inline Succeeded
-read_data(IStreamT& s, Array<num_dimensions, elemT>& data, const ByteOrder byte_order)
+read_data(IStreamT& s, ArrayType<num_dimensions, elemT>& data, const ByteOrder byte_order)
 {
   return detail::read_data_help(detail::test_if_1d<num_dimensions>(), s, data, byte_order);
 }
@@ -68,7 +68,7 @@ read_data(IStreamT& s, Array<num_dimensions, elemT>& data, const ByteOrder byte_
 template <int num_dimensions, class IStreamT, class elemT, class InputType, class ScaleT>
 inline Succeeded
 read_data(IStreamT& s,
-          Array<num_dimensions, elemT>& data,
+          ArrayType<num_dimensions, elemT>& data,
           NumericInfo<InputType> input_type,
           ScaleT& scale_factor,
           const ByteOrder byte_order)
@@ -82,7 +82,7 @@ read_data(IStreamT& s,
     }
   else
     {
-      Array<num_dimensions, InputType> in_data(data.get_index_range());
+      ArrayType<num_dimensions, InputType> in_data(data.get_index_range());
       Succeeded success = read_data(s, in_data, byte_order);
       if (success == Succeeded::no)
         return Succeeded::no;
@@ -93,7 +93,7 @@ read_data(IStreamT& s,
 
 template <int num_dimensions, class IStreamT, class elemT, class ScaleT>
 inline Succeeded
-read_data(IStreamT& s, Array<num_dimensions, elemT>& data, NumericType type, ScaleT& scale, const ByteOrder byte_order)
+read_data(IStreamT& s, ArrayType<num_dimensions, elemT>& data, NumericType type, ScaleT& scale, const ByteOrder byte_order)
 {
   switch (type.id)
     {

--- a/src/include/stir/IO/read_data_1d.h
+++ b/src/include/stir/IO/read_data_1d.h
@@ -16,15 +16,13 @@
 
     See STIR/LICENSE.txt for details
 */
-#include "stir/common.h"
+#include "stir/ArrayFwd.h"
 #include <stdio.h>
 #include <iostream>
 
 START_NAMESPACE_STIR
 class Succeeded;
 class ByteOrder;
-template <int num_dimensions, class elemT>
-class Array;
 
 namespace detail
 {

--- a/src/include/stir/IO/read_data_1d.h
+++ b/src/include/stir/IO/read_data_1d.h
@@ -33,14 +33,14 @@ namespace detail
   This function might propagate any exceptions by std::istream::read.
  */
 template <int num_dimensions, class elemT>
-inline Succeeded read_data_1d(std::istream& s, Array<num_dimensions, elemT>& data, const ByteOrder byte_order);
+inline Succeeded read_data_1d(std::istream& s, ArrayType<num_dimensions, elemT>& data, const ByteOrder byte_order);
 
 /* \ingroup Array_IO_detail
   \brief  This is the (internal) function that does the actual reading from a FILE*.
   \internal
  */
 template <int num_dimensions, class elemT>
-inline Succeeded read_data_1d(FILE*&, Array<num_dimensions, elemT>& data, const ByteOrder byte_order);
+inline Succeeded read_data_1d(FILE*&, ArrayType<num_dimensions, elemT>& data, const ByteOrder byte_order);
 
 } // end namespace detail
 END_NAMESPACE_STIR

--- a/src/include/stir/IO/read_data_1d.inl
+++ b/src/include/stir/IO/read_data_1d.inl
@@ -30,7 +30,7 @@ namespace detail
 
 template <int num_dimensions, class elemT>
 Succeeded
-read_data_1d(std::istream& s, Array<num_dimensions, elemT>& data, const ByteOrder byte_order)
+read_data_1d(std::istream& s, ArrayType<num_dimensions, elemT>& data, const ByteOrder byte_order)
 {
   if (!s || (dynamic_cast<std::ifstream*>(&s) != 0 && !dynamic_cast<std::ifstream*>(&s)->is_open())
       || (dynamic_cast<std::fstream*>(&s) != 0 && !dynamic_cast<std::fstream*>(&s)->is_open()))
@@ -66,7 +66,7 @@ read_data_1d(std::istream& s, Array<num_dimensions, elemT>& data, const ByteOrde
 
 template <int num_dimensions, class elemT>
 Succeeded
-read_data_1d(FILE*& fptr_ref, Array<num_dimensions, elemT>& data, const ByteOrder byte_order)
+read_data_1d(FILE*& fptr_ref, ArrayType<num_dimensions, elemT>& data, const ByteOrder byte_order)
 {
   FILE* fptr = fptr_ref;
   if (fptr == NULL || ferror(fptr))

--- a/src/include/stir/IO/write_data.h
+++ b/src/include/stir/IO/write_data.h
@@ -50,7 +50,7 @@ class NumericInfo;
 */
 template <int num_dimensions, class OStreamT, class elemT>
 inline Succeeded write_data(OStreamT& s,
-                            const Array<num_dimensions, elemT>& data,
+                            const ArrayType<num_dimensions, elemT>& data,
                             const ByteOrder byte_order = ByteOrder::native,
                             const bool can_corrupt_data = false);
 /*! \ingroup Array_IO
@@ -58,9 +58,9 @@ inline Succeeded write_data(OStreamT& s,
 
   This function essentially first calls convert_data() to construct
   an array with elements of type \a OutputType, and then calls
-  write_data(OstreamT&, const Array<num_dimensions,elemT>&,
+  write_data(OstreamT&, const ArrayType<num_dimensions,elemT>&,
            const ByteOrder, const bool).
-  \see write_data(OstreamT&, const Array<num_dimensions,elemT>&,
+  \see write_data(OstreamT&, const ArrayType<num_dimensions,elemT>&,
            const ByteOrder, const bool)
 
   \see find_scale_factor() for the meaning of \a scale_factor.
@@ -71,7 +71,7 @@ inline Succeeded write_data(OStreamT& s,
 */
 template <int num_dimensions, class OStreamT, class elemT, class OutputType, class ScaleT>
 inline Succeeded write_data(OStreamT& s,
-                            const Array<num_dimensions, elemT>& data,
+                            const ArrayType<num_dimensions, elemT>& data,
                             NumericInfo<OutputType> output_type,
                             ScaleT& scale_factor,
                             const ByteOrder byte_order = ByteOrder::native,
@@ -84,7 +84,7 @@ inline Succeeded write_data(OStreamT& s,
   range for \a OutputType, the writing will fail. However, data might have been
   partially written to file anyway.
 
-  \see write_data(OStreamT&, const Array<num_dimensions,elemT>&,
+  \see write_data(OStreamT&, const ArrayType<num_dimensions,elemT>&,
            NumericInfo<OutputType>,
            ScaleT&,
            const ByteOrder,
@@ -96,7 +96,7 @@ inline Succeeded write_data(OStreamT& s,
 */
 template <int num_dimensions, class OStreamT, class elemT, class OutputType, class ScaleT>
 inline Succeeded write_data_with_fixed_scale_factor(OStreamT& s,
-                                                    const Array<num_dimensions, elemT>& data,
+                                                    const ArrayType<num_dimensions, elemT>& data,
                                                     NumericInfo<OutputType> output_type,
                                                     const ScaleT scale_factor,
                                                     const ByteOrder byte_order = ByteOrder::native,
@@ -105,7 +105,7 @@ inline Succeeded write_data_with_fixed_scale_factor(OStreamT& s,
 /*! \ingroup Array_IO
   \brief Write the data of an Array to file as a different type.
 
-  \see write_data(OStreamT&, const Array<num_dimensions,elemT>&,
+  \see write_data(OStreamT&, const ArrayType<num_dimensions,elemT>&,
            NumericInfo<OutputType>,
            ScaleT&,
            const ByteOrder,
@@ -120,7 +120,7 @@ inline Succeeded write_data_with_fixed_scale_factor(OStreamT& s,
 
 template <int num_dimensions, class OStreamT, class elemT, class ScaleT>
 inline Succeeded write_data(OStreamT& s,
-                            const Array<num_dimensions, elemT>& data,
+                            const ArrayType<num_dimensions, elemT>& data,
                             NumericType type,
                             ScaleT& scale,
                             const ByteOrder byte_order = ByteOrder::native,

--- a/src/include/stir/IO/write_data.h
+++ b/src/include/stir/IO/write_data.h
@@ -18,14 +18,14 @@
 */
 
 #include "stir/ByteOrder.h"
+#include "stir/ArrayFwd.h"
+
 START_NAMESPACE_STIR
 
 class Succeeded;
 class NumericType;
 template <class T>
 class NumericInfo;
-template <int num_dimensions, class elemT>
-class Array;
 
 /*! \ingroup Array_IO
   \brief Write the data of an Array to file.

--- a/src/include/stir/IO/write_data.inl
+++ b/src/include/stir/IO/write_data.inl
@@ -36,7 +36,7 @@ template <int num_dimensions, class OStreamT, class elemT, class OutputType, cla
 inline Succeeded
 write_data_with_fixed_scale_factor_help(is_not_1d,
                                         OStreamT& s,
-                                        const Array<num_dimensions, elemT>& data,
+                                        const ArrayType<num_dimensions, elemT>& data,
                                         NumericInfo<OutputType> output_type,
                                         const ScaleT scale_factor,
                                         const ByteOrder byte_order,
@@ -55,7 +55,7 @@ template <class OStreamT, class elemT, class OutputType, class ScaleT>
 inline Succeeded
 write_data_with_fixed_scale_factor_help(is_1d,
                                         OStreamT& s,
-                                        const Array<1, elemT>& data,
+                                        const ArrayType<1, elemT>& data,
                                         NumericInfo<OutputType>,
                                         const ScaleT scale_factor,
                                         const ByteOrder byte_order,
@@ -80,7 +80,7 @@ write_data_with_fixed_scale_factor_help(is_1d,
 template <int num_dimensions, class OStreamT, class elemT, class OutputType, class ScaleT>
 Succeeded
 write_data_with_fixed_scale_factor(OStreamT& s,
-                                   const Array<num_dimensions, elemT>& data,
+                                   const ArrayType<num_dimensions, elemT>& data,
                                    NumericInfo<OutputType> output_type,
                                    const ScaleT scale_factor,
                                    const ByteOrder byte_order,
@@ -93,7 +93,7 @@ write_data_with_fixed_scale_factor(OStreamT& s,
 template <int num_dimensions, class OStreamT, class elemT, class OutputType, class ScaleT>
 Succeeded
 write_data(OStreamT& s,
-           const Array<num_dimensions, elemT>& data,
+           const ArrayType<num_dimensions, elemT>& data,
            NumericInfo<OutputType> output_type,
            ScaleT& scale_factor,
            const ByteOrder byte_order,
@@ -105,7 +105,7 @@ write_data(OStreamT& s,
 
 template <int num_dimensions, class OStreamT, class elemT>
 inline Succeeded
-write_data(OStreamT& s, const Array<num_dimensions, elemT>& data, const ByteOrder byte_order, const bool can_corrupt_data)
+write_data(OStreamT& s, const ArrayType<num_dimensions, elemT>& data, const ByteOrder byte_order, const bool can_corrupt_data)
 {
   return write_data_with_fixed_scale_factor(s, data, NumericInfo<elemT>(), 1.F, byte_order, can_corrupt_data);
 }
@@ -113,7 +113,7 @@ write_data(OStreamT& s, const Array<num_dimensions, elemT>& data, const ByteOrde
 template <int num_dimensions, class OStreamT, class elemT, class ScaleT>
 Succeeded
 write_data(OStreamT& s,
-           const Array<num_dimensions, elemT>& data,
+           const ArrayType<num_dimensions, elemT>& data,
            NumericType type,
            ScaleT& scale,
            const ByteOrder byte_order,

--- a/src/include/stir/IO/write_data_1d.h
+++ b/src/include/stir/IO/write_data_1d.h
@@ -17,15 +17,13 @@
 
     See STIR/LICENSE.txt for details
 */
-#include "stir/common.h"
+#include "stir/ArrayFwd.h"
 #include <stdio.h>
 #include <iostream>
 
 START_NAMESPACE_STIR
 class Succeeded;
 class ByteOrder;
-template <int num_dimensions, class elemT>
-class Array;
 
 namespace detail
 {

--- a/src/include/stir/IO/write_data_1d.h
+++ b/src/include/stir/IO/write_data_1d.h
@@ -45,8 +45,10 @@ write_data_1d(std::ostream& s, const Array<num_dimensions, elemT>& data, const B
 
  */
 template <int num_dimensions, class elemT>
-inline Succeeded
-write_data_1d(FILE*& fptr_ref, const Array<num_dimensions, elemT>& data, const ByteOrder byte_order, const bool can_corrupt_data);
+inline Succeeded write_data_1d(FILE*& fptr_ref,
+                               const ArrayType<num_dimensions, elemT>& data,
+                               const ByteOrder byte_order,
+                               const bool can_corrupt_data);
 } // namespace detail
 
 END_NAMESPACE_STIR

--- a/src/include/stir/centre_of_gravity.h
+++ b/src/include/stir/centre_of_gravity.h
@@ -49,7 +49,7 @@ T find_unweighted_centre_of_gravity_1d(const VectorWithOffset<T>& row);
    \f]
 */
 template <int num_dimensions, class T>
-BasicCoordinate<num_dimensions, T> find_unweighted_centre_of_gravity(const Array<num_dimensions, T>&);
+BasicCoordinate<num_dimensions, T> find_unweighted_centre_of_gravity(const ArrayType<num_dimensions, T>&);
 
 //! Compute centre of gravity of a 1D Array but without dividing by its sum
 /*! \ingroup Array
@@ -57,7 +57,7 @@ BasicCoordinate<num_dimensions, T> find_unweighted_centre_of_gravity(const Array
   BasicCoordinate\<1,T\>.
 */
 template <class T>
-T find_unweighted_centre_of_gravity(const Array<1, T>&);
+T find_unweighted_centre_of_gravity(const ArrayType<1, T>&);
 
 //! Compute centre of gravity of an Array
 /*! \ingroup Array
@@ -68,7 +68,7 @@ T find_unweighted_centre_of_gravity(const Array<1, T>&);
     \todo better error handling
 */
 template <int num_dimensions, class T>
-BasicCoordinate<num_dimensions, T> find_centre_of_gravity(const Array<num_dimensions, T>&);
+BasicCoordinate<num_dimensions, T> find_centre_of_gravity(const ArrayType<num_dimensions, T>&);
 
 //! Computes centre of gravity for each plane
 /*! \ingroup Array

--- a/src/include/stir/centre_of_gravity.h
+++ b/src/include/stir/centre_of_gravity.h
@@ -17,16 +17,14 @@
   \author Kris Thielemans
 */
 
-#include "stir/common.h"
+#include "stir/ArrayFwd.h"
 
 START_NAMESPACE_STIR
 // predeclerations to avoid having to include the files and create unnecessary
 // dependencies
 template <int num_dimensions, class T>
 class BasicCoordinate;
-template <int num_dimensions, class T>
-class Array;
-template <class elemT>
+template <typename elemT>
 class VectorWithOffset;
 template <class coordT>
 class CartesianCoordinate3D;

--- a/src/include/stir/convert_array.h
+++ b/src/include/stir/convert_array.h
@@ -25,14 +25,12 @@
 
 */
 
-#include "stir/common.h"
+#include "stir/ArrayFwd.h"
 
 START_NAMESPACE_STIR
 
 template <class T>
 class NumericInfo;
-template <int num_dimensions, class elemT>
-class Array;
 
 /*!
   \ingroup Array

--- a/src/include/stir/multiply_crystal_factors.h
+++ b/src/include/stir/multiply_crystal_factors.h
@@ -45,6 +45,6 @@ class ProjData;
   the existing data with the efficiencies, but overwrites it.
 
 */
-void multiply_crystal_factors(ProjData& proj_data, const Array<2, float>& efficiencies, const float global_factor);
+void multiply_crystal_factors(ProjData& proj_data, const ArrayType<2, float>& efficiencies, const float global_factor);
 
 END_NAMESPACE_STIR

--- a/src/include/stir/multiply_crystal_factors.h
+++ b/src/include/stir/multiply_crystal_factors.h
@@ -17,13 +17,11 @@
   See STIR/LICENSE.txt for details
 */
 
-#include "stir/common.h"
+#include "stir/ArrayFwd.h"
 
 START_NAMESPACE_STIR
 
 class ProjData;
-template <int num_dimensions, typename elemT>
-class Array;
 
 /*!
   \ingroup projdata

--- a/src/include/stir/numerics/determinant.h
+++ b/src/include/stir/numerics/determinant.h
@@ -19,12 +19,9 @@
   \author Kris Thielemans
 
 */
-#include "stir/common.h"
+#include "stir/ArrayFwd.h"
 
 START_NAMESPACE_STIR
-
-template <int num_dimensions, class elemT>
-class Array;
 
 /*! \ingroup numerics
   \brief Compute the determinant of a matrix

--- a/src/include/stir/numerics/norm.h
+++ b/src/include/stir/numerics/norm.h
@@ -21,7 +21,7 @@
 
 */
 
-#include "stir/common.h"
+#include "stir/ArrayFwd.h"
 #include <complex>
 #include <cmath>
 #ifdef BOOST_NO_STDC_NAMESPACE
@@ -32,9 +32,6 @@ using ::fabs;
 #endif
 
 START_NAMESPACE_STIR
-
-template <int num_dimensions, class elemT>
-class Array;
 
 /*!
  \ingroup numerics

--- a/src/include/stir/recon_buildblock/BackProjectorByBinUsingInterpolation.h
+++ b/src/include/stir/recon_buildblock/BackProjectorByBinUsingInterpolation.h
@@ -26,6 +26,7 @@
 #include "stir/recon_buildblock/BackProjectorByBin.h"
 #include "stir/RegisteredParsingObject.h"
 #include "stir/shared_ptr.h"
+#include "stir/ArrayFwd.h"
 
 START_NAMESPACE_STIR
 
@@ -35,8 +36,6 @@ template <typename elemT>
 class RelatedViewgrams;
 template <typename elemT>
 class VoxelsOnCartesianGrid;
-template <int num_dimensions, typename elemT>
-class Array;
 class ProjDataInfo;
 class ProjDataInfoCylindricalArcCorr;
 class DataSymmetriesForBins_PET_CartesianGrid;

--- a/src/include/stir/recon_buildblock/ForwardProjectorByBinUsingRayTracing.h
+++ b/src/include/stir/recon_buildblock/ForwardProjectorByBinUsingRayTracing.h
@@ -28,7 +28,8 @@
 #include "stir/RegisteredParsingObject.h"
 #include "stir/shared_ptr.h"
 #include "stir/recon_buildblock/DataSymmetriesForBins_PET_CartesianGrid.h"
-#include "stir/shared_ptr.h"
+#include "stir/ArrayFwd.h"
+
 START_NAMESPACE_STIR
 
 template <typename elemT>
@@ -37,8 +38,6 @@ template <typename elemT>
 class RelatedViewgrams;
 template <typename elemT>
 class VoxelsOnCartesianGrid;
-template <int num_dimensions, typename elemT>
-class Array;
 class ProjDataInfo;
 class ProjDataInfoCylindrical;
 

--- a/src/include/stir/recon_buildblock/FourierRebinning.h
+++ b/src/include/stir/recon_buildblock/FourierRebinning.h
@@ -166,10 +166,10 @@ private:
 
 
   */
-  void rebinning(Array<3, std::complex<float>>& FT_rebinned_data,
-                 Array<3, float>& Weights_for_FT_rebinned_data,
+  void rebinning(ArrayType<3, std::complex<float>>& FT_rebinned_data,
+                 ArrayType<3, float>& Weights_for_FT_rebinned_data,
                  PETCount_rebinned& num_rebinned,
-                 const Array<2, std::complex<float>>& FT_current_sinogram,
+                 const ArrayType<2, std::complex<float>>& FT_current_sinogram,
                  const float z,
                  const float average_ring_difference_in_segment,
                  const int num_views_pow2,
@@ -192,8 +192,8 @@ private:
     Pm(w,k) = Pm(w,k) + Pij(w,k) (i=ring0 and j=ring1), and m is the nearest integer to (i+j) -k(i-j)/(Rw)).
   */
 
-  void do_rebinning(Array<3, std::complex<float>>& FT_rebinned_data,
-                    Array<3, float>& Weights_for_FT_rebinned_data,
+  void do_rebinning(ArrayType<3, std::complex<float>>& FT_rebinned_data,
+                    ArrayType<3, float>& Weights_for_FT_rebinned_data,
                     PETCount_rebinned& count_rebinned,
                     const SegmentBySinogram<float>& segment,
                     const int num_tang_poss_pow2,

--- a/src/include/stir/recon_buildblock/FourierRebinning.h
+++ b/src/include/stir/recon_buildblock/FourierRebinning.h
@@ -28,6 +28,7 @@
 
 #include "stir/recon_buildblock/ProjDataRebinning.h"
 #include "stir/RegisteredParsingObject.h"
+#include "stir/ArrayFwd.h"
 #include <complex>
 
 START_NAMESPACE_STIR
@@ -36,8 +37,6 @@ class SegmentByView;
 template <typename elemT>
 class SegmentBySinogram;
 // template <typename elemT> class Sinogram;
-template <int num_dimensions, typename elemT>
-class Array;
 class Succeeded;
 
 /*


### PR DESCRIPTION
prepare for possible changes in future to enable GPU array etc. This might mean `stir::Array` template arguments change in the future, or `DiscretisedDensity` is derived from a different class. It is now recommended to
- include `stir/ArrayFwd.h` when using forward declaration
- use the `ArrayType` template-alias in places where a rectangular array that might live on a GPU is intended.
