### PR TITLE
re-add recon_test to stir_dirs.cmake

### DIFF
--- a/src/cmake/stir_dirs.cmake
+++ b/src/cmake/stir_dirs.cmake
@@ -102,6 +102,7 @@ if (NOT MINI_STIR)
   list(APPEND STIR_TEST_DIRS
     test/numerics
     test/modelling
+    recon_test
     )
 
   if (STIR_WITH_NiftyPET_PROJECTOR)


### PR DESCRIPTION
It was inadvertently removed when implemented MINI_STIR

#Fixes #1606 