### PR TITLE
KOSMAPOSL warning fix

### DIFF
--- a/src/iterative/KOSMAPOSL/KOSMAPOSLReconstruction.cxx
+++ b/src/iterative/KOSMAPOSL/KOSMAPOSLReconstruction.cxx
@@ -701,9 +701,9 @@ KOSMAPOSLReconstruction<TargetT>::estimate_stand_dev_for_anatomical_image(std::v
 
 #ifdef STIR_OPENMP
 #  if _OPENMP < 201107
-#    pragma omp parallel for reduction(+:kmean,nv)
+#    pragma omp parallel for reduction(+ : kmean, nv)
 #  else
-#    pragma omp parallel for collapse(3) reduction(+:kmean,nv) reduction(||:warning_nan_inf)
+#    pragma omp parallel for collapse(3) reduction(+ : kmean, nv) reduction(|| : warning_nan_inf)
 #  endif
 #endif
       for (int z = min_z; z <= max_z; z++)
@@ -713,9 +713,9 @@ KOSMAPOSLReconstruction<TargetT>::estimate_stand_dev_for_anatomical_image(std::v
               for (int x = min_x; x <= max_x; x++)
                 {
                   if (!((*anatomical_prior_sptrs[i])[z][y][x] >= -1000000 && (*anatomical_prior_sptrs[i])[z][y][x] <= 1000000))
-                  {
+                    {
                       warning_nan_inf = true;
-                  }
+                    }
                   kmean += (*anatomical_prior_sptrs[i])[z][y][x];
                   nv += 1;
                 }
@@ -724,9 +724,9 @@ KOSMAPOSLReconstruction<TargetT>::estimate_stand_dev_for_anatomical_image(std::v
 
       // The warning is now outside the loop.
       if (warning_nan_inf)
-      {
+        {
           warning("The anatomical image might contain nan or infinitive. You might get all-zero image!");
-      }
+        }
 
       kmean = kmean / nv;
 


### PR DESCRIPTION
<!-- Fill in most of this text, and delete what is not appropriate.
Please read and adhere to the [contribution guidelines](https://github.com/UCL/STIR/blob/master/CONTRIBUTING.md).
Did you sign the STIR Contribution License Agreement?
-->

## Changes in this pull request
1. Only check if the anatomical image contains NaN or Inf values. Do not check negative values.
2. Print the warning once outside the loop to avoid repeated messages.

## Testing performed


## Related issues
<!-- Use keywords such as "fixes", "closes", see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->


## Checklist before requesting a review
<!--Put an x between the [] when completed. Delete a line if not applicable. -->
  - [x] I have performed a self-review of my code
  - [] I have added docstrings/doxygen in line with the guidance in the developer guide
  - [] I have implemented unit tests that cover any new or modified functionality (if applicable)
  - [x] The code builds and runs on my machine
  - [] `documentation/release_XXX.md` has been updated with any functionality change (if applicable)
