### PR TITLE
This fixes an issue with calling multiply_crystal_factors in python.

### DIFF
--- a/src/swig/stir.i
+++ b/src/swig/stir.i
@@ -85,7 +85,6 @@
 #include "stir/IndexRange3D.h"
 #include "stir/IndexRange4D.h"
 #include "stir/Array.h"
-#include "stir/ArrayFwd.h"
 #include "stir/DiscretisedDensity.h"
 #include "stir/DiscretisedDensityOnCartesianGrid.h"
 #include "stir/PixelsOnCartesianGrid.h"

--- a/src/swig/stir.i
+++ b/src/swig/stir.i
@@ -85,6 +85,7 @@
 #include "stir/IndexRange3D.h"
 #include "stir/IndexRange4D.h"
 #include "stir/Array.h"
+#include "stir/ArrayFwd.h"
 #include "stir/DiscretisedDensity.h"
 #include "stir/DiscretisedDensityOnCartesianGrid.h"
 #include "stir/PixelsOnCartesianGrid.h"

--- a/src/swig/stir_array.i
+++ b/src/swig/stir_array.i
@@ -85,6 +85,7 @@
 #endif
 
 %include "stir/Array.h"
+%include "stir/ArrayFwd.h"
 
 namespace stir
 {
@@ -229,6 +230,10 @@ namespace stir
 %template (FloatNumericVectorWithOffset2D) stir::NumericVectorWithOffset<stir::Array<1,float>, float>;
 
   %template(FloatArray2D) stir::Array<2,float>;
+  %apply const stir::Array<2,float>& { const stir::ArrayType<2,float>& };
+  %apply stir::Array<2,float>& { stir::ArrayType<2,float>& };
+  %apply stir::Array<2,float>* { stir::ArrayType<2,float>* };
+
   // TODO name
   %template (FloatNumericVectorWithOffset3D) stir::NumericVectorWithOffset<stir::Array<2,float>, float>;
   %template(FloatArray3D) stir::Array<3,float>;

--- a/src/swig/test/python/test_buildblock.py
+++ b/src/swig/test/python/test_buildblock.py
@@ -339,7 +339,7 @@ def test_multiply_crystal_factors():
     projdata.fill(1)
 
     # Create array
-    efficiencies = FloatArray2D(IndexRange2D(Int2BasicCoordinate((0,0)), 
+    efficiencies = FloatArray2D(IndexRange2D(Int2BasicCoordinate((0,0)),
                                 Int2BasicCoordinate((s.get_num_rings() - 1, s.get_num_detectors_per_ring() - 1))))
     efficiencies.fill(1)
 

--- a/src/swig/test/python/test_buildblock.py
+++ b/src/swig/test/python/test_buildblock.py
@@ -347,5 +347,5 @@ def test_multiply_crystal_factors():
     multiply_crystal_factors(projdata, efficiencies, 1.0)
 
     assert projdata.find_max() == projdata.find_min()
-    view_mash_factor = s.get_num_detectors_per_ring() / 2 / projdatainfo.get_num_views()`
+    view_mash_factor = s.get_num_detectors_per_ring() / 2 / projdatainfo.get_num_views()
     assert projdata.find_max() == view_mash_factor  # only true for span=1, as in this test case

--- a/src/swig/test/python/test_buildblock.py
+++ b/src/swig/test/python/test_buildblock.py
@@ -330,3 +330,21 @@ def test_xapyb_and_sapyb():
     projdata.sapyb(3,projdata,2)
     assert projdata.to_array().find_max()==approx_val
     assert projdata.to_array().find_min()==approx_val
+
+def test_multiply_crystal_factors():
+    # Create proj data
+    s=Scanner.get_scanner_from_name("ECAT 962")
+    projdatainfo=ProjDataInfo.construct_proj_data_info(s,1,9,8,6,False)
+    projdata=ProjDataInMemory(ExamInfo(),projdatainfo)
+    projdata.fill(1)
+
+    # Create array
+    efficiencies = FloatArray2D(IndexRange2D(Int2BasicCoordinate((0,0)), 
+                                Int2BasicCoordinate((s.get_num_rings() - 1, s.get_num_detectors_per_ring() - 1))))
+    efficiencies.fill(1)
+
+    # Test multiply_crystal_factors()
+    multiply_crystal_factors(projdata, efficiencies, 1.0)
+
+    assert projdata.find_max() == projdata.find_min()
+    assert projdata.find_max() == 36.0 # this is an empirical value

--- a/src/swig/test/python/test_buildblock.py
+++ b/src/swig/test/python/test_buildblock.py
@@ -347,4 +347,5 @@ def test_multiply_crystal_factors():
     multiply_crystal_factors(projdata, efficiencies, 1.0)
 
     assert projdata.find_max() == projdata.find_min()
-    assert projdata.find_max() == 36.0 # this is an empirical value
+    view_mash_factor = s.get_num_detectors_per_ring() / 2 / projdatainfo.get_num_views()`
+    assert projdata.find_max() == view_mash_factor  # only true for span=1, as in this test case


### PR DESCRIPTION
With the introduction of ArrayType, the python binding of multiply_crystal_factors no longer works, because it expects ArrayType as a second argument, but swig doesn't know ArrayType is the same than Array.

## Changes in this pull request
Tell swig that ArrayType is the same than Array to fix existing python bindings.

## Testing performed
Built STIR with swig python, then created FloatArray2D object and used it to call multiply_crystal_factors. I no longer get an error and the output looks good.

## Related issues
fixes https://github.com/UCL/STIR/issues/1621


## Checklist before requesting a review
<!--Put an x between the [] when completed. Delete a line if not applicable. -->
  - [x] I have performed a self-review of my code
  - [] I have added docstrings/doxygen in line with the guidance in the developer guide
  - [] I have implemented unit tests that cover any new or modified functionality (if applicable)
  - [x] The code builds and runs on my machine
  - [] `documentation/release_XXX.md` has been updated with any functionality change (if applicable)

## Contribution Notes

Please tick the following: 

 - [x] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in STIR (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License.
 - [x] I (or my institution) have signed the STIR Contribution License Agreement (not required for small changes).
