### PR TITLE
TOF bin fix for RayTracingMatrix

### DIFF
--- a/src/include/stir/recon_buildblock/ProjMatrixByBin.inl
+++ b/src/include/stir/recon_buildblock/ProjMatrixByBin.inl
@@ -121,7 +121,7 @@ ProjMatrixByBin::apply_tof_kernel(ProjMatrixElemsForOneBin& probabilities) const
   const CartesianCoordinate3D<float> point1 = lor2.p1();
   const CartesianCoordinate3D<float> point2 = lor2.p2();
 
-  // Coordinate system correction:
+  // Coordinate system correction: TODO remove in future with ORIGIN shift PR
   // LOR coordinates have origin at scanner center (z=0 at center of all rings)
   // Image coordinates have origin at first ring (z=0 at ring 0)
   // Calculate the offset: distance from first ring to scanner center


### PR DESCRIPTION
## Changes in this pull request
<strike>Project LOR to mean z-plane for maintaining the concentric-circle model for TOF bins.</strike> Edit: fix mismatch in image/projdata coordinate system affecting TOF calculation

## Testing performed
Tested the same as issue 1537 and got consistent results with paralleproj.

## Related issues
<!-- Use keywords such as "fixes", "closes", see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
Fixes issue #1537 

## Checklist before requesting a review
<!--Put an x between the [] when completed. Delete a line if not applicable. -->
  - [x] I have performed a self-review of my code
  - [] I have added docstrings/doxygen in line with the guidance in the developer guide
  - [] I have implemented unit tests that cover any new or modified functionality (if applicable)
  - [x] The code builds and runs on my machine
  - [] `documentation/release_XXX.md` has been updated with any functionality change (if applicable)

## Contribution Notes

Please tick the following: 

 - [x] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in STIR (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License.
 - [ ] I (or my institution) have signed the STIR Contribution License Agreement (not required for small changes).
