### PR TITLE
explicitly instantiate fourier_1d

### DIFF
--- a/src/numerics_buildblock/fourier.cxx
+++ b/src/numerics_buildblock/fourier.cxx
@@ -387,6 +387,7 @@ template void fourier<>(Array<1, std::complex<float>>& c, const int sign);
 template void fourier<>(VectorWithOffset<std::complex<float>>& c, const int sign);
 
 #define INSTANTIATE(d, type)                                                                                                     \
+  template void fourier_1d<>(Array<d, std::complex<type>> & v, const int sign);                                                  \
   template Array<d, std::complex<type>> fourier_for_real_data<>(const Array<d, type>& v, const int sign);                        \
   template Array<d, type> inverse_fourier_for_real_data_corrupting_input<>(Array<d, std::complex<type>> & c, const int sign);    \
   template Array<d, type> inverse_fourier_for_real_data<>(const Array<d, std::complex<type>>& c, const int sign);                \


### PR DESCRIPTION
For certain compilers/linkers, including on conda-forge, we are missing fourier_1d<Array<...>> in the library, so instantiate them explicitly.

This was also necessary in #7 when building with shared libraries, but this PR only commits that change.

Fixes #1657 