### PR TITLE
[CMake] Use hdf target as opposed to HDF5_CXX_LIBRARIES

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,8 @@ if(CCACHE_PROGRAM)
 endif()
 
 
+include(CMakePrintHelpers)
+
 PROJECT(STIR)
 
 SET_PROPERTY(GLOBAL PROPERTY USE_FOLDERS ON)
@@ -150,15 +152,17 @@ if(NOT DISABLE_CERN_ROOT)
   endif()
 endif()
 
-include(CMakePrintHelpers)
-
 if(NOT DISABLE_HDF5)
   find_package(HDF5 COMPONENTS CXX)
-  if (TARGET hdf5::hdf5_cpp)
-    cmake_print_properties(
-      TARGETS hdf5::hdf5_cpp hdf5::hdf5 HDF5::HDF5
-      PROPERTIES LOCATION INTERFACE_INCLUDE_DIRECTORIES IMPORTED_LINK_INTERFACE_LIBRARIES IMPORTED_LINK_DEPENDENT_LIBRARIES LINK_INTERFACE_LIBRARIES INTERFACE_LINK_LIBRARIES
-      )
+  if (TARGET HDF5::HDF5)
+    option(USE_HDF5_TARGET "Use HDF5::HDF5 CMake target for dependencies (recommended)" ON)
+    mark_as_advanced(USE_HDF5_TARGET)
+    if (HDF5_FIND_DEBUG) # debugging print (re-use name of FindHDF5 CMake variable)
+      cmake_print_properties(
+        TARGETS HDF5::HDF5
+        PROPERTIES LOCATION INTERFACE_INCLUDE_DIRECTORIES IMPORTED_LINK_INTERFACE_LIBRARIES IMPORTED_LINK_DEPENDENT_LIBRARIES INTERFACE_LINK_LIBRARIES
+        )
+    endif()
   endif()
 
 endif()

--- a/documentation/release_6.4.htm
+++ b/documentation/release_6.4.htm
@@ -12,7 +12,7 @@
   <h2>Overall summary</h2>
 
     <p>
-      This version is 100% backwards compatible with STIR 6.2, aside from three important bug fixes,
+      This version is 100% backwards compatible with STIR 6.3, aside from three important bug fixes,
       which will change results (see below).
     </p>
     <p>
@@ -76,7 +76,15 @@
       <br>
       <a href=https://github.com/UCL/STIR/pull/1658>PR #1658</a>
     </li>
-  </ul>
+    <li>
+      Use the CMake <code>HDF5::HDF5</code> target to specify dependencies on,
+      as opposed to <code>HDF5_CXX_LIBRARIES</code> etc. This should be more future proof
+      and avoids problems with the STIR conda-forge build. (This can be switched of
+      with the CMake option <code>USE_HDF5_TARGET=OFF</code>.)
+      <br>
+      <a href=https://github.com/UCL/STIR/pull/1665>PR #1665</a>
+    </li>
+</ul>
 
   <h3>Known problems</h3>
   <p>See <a href=https://github.com/UCL/STIR/labels/bug>our issue tracker</a>.<br>

--- a/src/IO/CMakeLists.txt
+++ b/src/IO/CMakeLists.txt
@@ -103,7 +103,7 @@ if (CERN_ROOT_FOUND)
 endif()
 
 if (HAVE_HDF5)
-  if (TARGET HDF5::HDF5)
+  if (USE_HDF5_TARGET)
     target_link_libraries(${TARGET} PUBLIC HDF5::HDF5)
   else()
     target_include_directories(${TARGET} PUBLIC ${HDF5_INCLUDE_DIRS})

--- a/src/buildblock/CMakeLists.txt
+++ b/src/buildblock/CMakeLists.txt
@@ -143,7 +143,7 @@ if (LLN_FOUND)
 endif()
 
 if (HAVE_HDF5)
-  if (TARGET HDF5::HDF5)
+  if (USE_HDF5_TARGET)
     target_link_libraries(${TARGET} PUBLIC HDF5::HDF5)
   else()
     # for GEHDF5, TODO remove once IO dependency added or GEHDF5Wrapper no longer includes H5Cpp.h

--- a/src/data_buildblock/CMakeLists.txt
+++ b/src/data_buildblock/CMakeLists.txt
@@ -38,7 +38,7 @@ target_sources(${STIR_BUILDBLOCK_LIB} PRIVATE ${${dir_LIB_SOURCES}})
 set(TARGET ${STIR_BUILDBLOCK_LIB})
 
 if (HAVE_HDF5)
-  if (TARGET HDF5::HDF5)
+  if (USE_HDF5_TARGET)
     target_link_libraries(${TARGET} PUBLIC HDF5::HDF5)
   else()
     # for GEHDF5, TODO remove once IO dependency added or GEHDF5Wrapper no longer includes H5Cpp.h

--- a/src/listmode_buildblock/CMakeLists.txt
+++ b/src/listmode_buildblock/CMakeLists.txt
@@ -60,7 +60,7 @@ target_sources(${STIR_BUILDBLOCK_LIB} PRIVATE ${${dir_LIB_SOURCES}})
 set(TARGET ${STIR_BUILDBLOCK_LIB})
 
 if (HAVE_HDF5)
-  if (TARGET HDF5::HDF5)
+  if (USE_HDF5_TARGET)
     target_link_libraries(${TARGET} PUBLIC HDF5::HDF5)
   else()
     # for GEHDF5, TODO remove once IO dependency added or GEHDF5Wrapper no longer includes H5Cpp.h

--- a/src/recon_buildblock/CMakeLists.txt
+++ b/src/recon_buildblock/CMakeLists.txt
@@ -174,7 +174,7 @@ if (STIR_WITH_Parallelproj_PROJECTOR)
 endif()
 
 if (HAVE_HDF5)
-  if (TARGET HDF5::HDF5)
+  if (USE_HDF5_TARGET)
     target_link_libraries(${TARGET} PUBLIC HDF5::HDF5)
   else()
     # for GEHDF5, TODO remove once IO dependency added or GEHDF5Wrapper no longer includes H5Cpp.h


### PR DESCRIPTION
Using targets is recommended, as it will add compiler flags etc as needed. It might also resolve
https://github.com/conda-forge/stir-feedstock/issues/149, as with this update, `STIRTargets.cmake` contains `hdf5::hdf5_cpp` as opposed to explicit filenames.

This fix was recommended by @traversaro at [#general > dependency on $BUILD_PREFIX/...libpthread.so problem @ 💬](https://conda-forge.zulipchat.com/#narrow/channel/457337-general/topic/dependency.20on.20.24BUILD_PREFIX.2F.2E.2E.2Elibpthread.2Eso.20problem/near/554656050)