### PR TITLE
examples/python/Quadra_files_preprocess.py

### DIFF
--- a/documentation/release_6.4.htm
+++ b/documentation/release_6.4.htm
@@ -103,6 +103,10 @@
 
   <h3>New functionality</h3>
   <ul>
+    <li>
+      Added a Python script to convert e7tools generated Siemens Biograph Vision 600 sinograms to STIR compatible format.
+      <a href=https://github.com/UCL/STIR/pull/1675>PR #1675</a>
+    </li>
   </ul>
 
   <h3>Changed functionality</h3>

--- a/examples/python/Quadra_files_preprocess.py
+++ b/examples/python/Quadra_files_preprocess.py
@@ -101,7 +101,7 @@ def remove_scan_data_lines_from_interfile_header(header_filename_new, header_fil
     data_type_string = r'scan data type description[^\n]*\s*:=\s*[^\n]*\n'
     data = re.sub(data_type_string, '', data)
 
-    num_data_types_string = 'number of scan data types[^\n]*\s*:=\s*[^\n]*\n'
+    num_data_types_string = r'number of scan data types[^\n]*\s*:=\s*[^\n]*\n'
     data = re.sub(num_data_types_string, '', data)
 
     with open(header_filename_new, 'w') as f2:
@@ -239,7 +239,7 @@ try:
     os.mkdir(STIR_output_folder)
 except FileExistsError:
     print("STIR output folder exists, files are overwritten")
-    
+
 #%%
 ###################### PROMPTS FILE ############################
 ##### first, we check if the prompts file is compressed
@@ -454,7 +454,7 @@ TOF_bin = 6
 
 fig, ax = plt.subplots(figsize = (8,6))
 
-ax.plot(np.mean(prompts_precorr[TOF_bin, central_slice-thickness_half:central_slice+thickness_half, 0, :], axis=(0)), label='Prompts, pre-corrected multfactors')
+ax.plot(np.mean(prompts_precorr[TOF_bin, central_slice-thickness_half:central_slice+thickness_half, 0, :], axis=(0)), label='Prompts, corr-multfactors')
 ax.plot(np.mean(add_sino_arr[TOF_bin, central_slice-thickness_half:central_slice+thickness_half, 0, :], axis=(0)), label='additive term')
 
 ax.set_xlabel('Radial distance (bin)')


### PR DESCRIPTION
<!-- Fill in most of this text, and delete what is not appropriate.
Please read and adhere to the [contribution guidelines](https://github.com/UCL/STIR/blob/master/CONTRIBUTING.md).
Did you sign the STIR Contribution License Agreement?
-->

## Changes in this pull request
Added python script to convert e7tools generated sinograms from the Siemens Biograph Vision Quadra to STIR-compatible format. (Based on Nicole Jurjew's Vision_files_preprocess.py).
This python file uses jupyter notebook style to allow execution in separate code blocks and to avoid RAM usage issues.

## Testing performed


## Related issues
<!-- Use keywords such as "fixes", "closes", see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->


## Checklist before requesting a review
<!--Put an x between the [] when completed. Delete a line if not applicable. -->
  - [x] I have performed a self-review of my code
  - [] I have added docstrings/doxygen in line with the guidance in the developer guide
  - [] I have implemented unit tests that cover any new or modified functionality (if applicable)
  - [x] The code builds and runs on my machine
  - [] `documentation/release_XXX.md` has been updated with any functionality change (if applicable)

## Contribution Notes

Please tick the following: 

 - [x] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in STIR (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License.
 - [ ] I (or my institution) have signed the STIR Contribution License Agreement (not required for small changes).
