### PR TITLE
Vision script bugfix: rotational shift between STIR and Siemens recons

### DIFF
--- a/examples/python/Vision_files_preprocess.py
+++ b/examples/python/Vision_files_preprocess.py
@@ -149,6 +149,10 @@ def process_files(prompts_header_filename,
     ## the crystal depth of interaction (DOI) from 7mm to 10mm to minimize the differences.
     if apply_DOI_adaption: DOI_adaption(prompts_from_e7, 10)
 
+    ###################### View Offset ADAPTION ############################
+
+    view_offset_adaption(prompts_from_e7, 0.0324)
+
     ## write to file so you can use it later
     prompts_from_e7.write_to_file(os.path.join(STIR_output_folder, prompts_filename_STIR_corr_DOI))
 
@@ -483,6 +487,15 @@ def DOI_adaption(projdata, DOI_new):
     proj_info.get_scanner().set_average_depth_of_interaction(DOI_new)
     DOI = proj_info.get_scanner().get_average_depth_of_interaction()
     print('New Depth of interaction:', DOI)
+
+def view_offset_adaption(projdata, view_offset):
+    proj_info = projdata.get_proj_data_info()
+
+    VO = proj_info.get_scanner().get_intrinsic_azimuthal_tilt()
+    print('Current view offset (rad):', VO)
+    proj_info.get_scanner().set_intrinsic_azimuthal_tilt(view_offset)
+    VO = proj_info.get_scanner().get_average_depth_of_interaction()
+    print('New Depth of interaction(rad):', VO)
 
 def check_if_compressed(header_filename):
     with open(header_filename) as f:


### PR DESCRIPTION
<!-- Fill in most of this text, and delete what is not appropriate.
Please read and adhere to the [contribution guidelines](https://github.com/UCL/STIR/blob/master/CONTRIBUTING.md).
Did you sign the STIR Contribution License Agreement?
-->

## Changes in this pull request
- Included a view offset in the projection data to make sure no rotational shifts occur between Siemens and STIR reconstructions for Vision 600 data. I'll update the Documentation after further testing.
- file-prefix can now be included
- uniform 1 image is now written out to ensure agreement with Siemens image dimensions

## Testing performed
Overlap of Images was tested. Screenshots are following.

## Related issues
<!-- Use keywords such as "fixes", "closes", see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->


## Checklist before requesting a review
<!--Put an x between the [] when completed. Delete a line if not applicable. -->
  - [] I have performed a self-review of my code
  - [] I have added docstrings/doxygen in line with the guidance in the developer guide
  - [] I have implemented unit tests that cover any new or modified functionality (if applicable)
  - [] The code builds and runs on my machine
  - [] `documentation/release_XXX.md` has been updated with any functionality change (if applicable)

## Contribution Notes

Please tick the following: 

 - [ x ] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in STIR (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License.
 - [ x ] I (or my institution) have signed the STIR Contribution License Agreement (not required for small changes).
