### PR TITLE
Fix sprintf deprecation warnings

### DIFF
--- a/documentation/release_6.4.htm
+++ b/documentation/release_6.4.htm
@@ -95,6 +95,10 @@
     The object is now cloned once and ownership is transferred safely after type checking.<br>
     <a href=https://github.com/UCL/STIR/pull/1673>PR #1673</a>
        </li>
+    <li>
+      Minor fix to replace a deprecated <code>atd::sprintf()</code> with <code>std::snprintf()</code>, see <a href=https://github.com/UCL/STIR/issues/1586># 1586</a>.<br>
+      <a href=https://github.com/UCL/STIR/pull/1697>PR #1697</a>
+    </li>
     <br>
   </ul>
 

--- a/documentation/release_6.4.htm
+++ b/documentation/release_6.4.htm
@@ -96,8 +96,8 @@
     <a href=https://github.com/UCL/STIR/pull/1673>PR #1673</a>
        </li>
     <li>
-      Minor fix to replace a deprecated <code>atd::sprintf()</code> with <code>std::snprintf()</code>, see <a href=https://github.com/UCL/STIR/issues/1586># 1586</a>.<br>
-      <a href=https://github.com/UCL/STIR/pull/1697>PR #1697</a>
+      Minor fix to replace a deprecated <code>std::sprintf()</code> with <code>std::snprintf()</code>, see <a href="https://github.com/UCL/STIR/issues/1586">#1586</a>.<br>
+      <a href="https://github.com/UCL/STIR/pull/1697">PR #1697</a>
     </li>
     <br>
   </ul>

--- a/src/IO/stir_ecat7.cxx
+++ b/src/IO/stir_ecat7.cxx
@@ -95,7 +95,7 @@ print_debug(char const* const fname, char const* const format, ...)
       len = strlen(fname) + strlen(format) + 5;
       if ((fmt = (char*)calloc((long)len, sizeof(char))) == NULL)
         return (1);
-      sprintf(fmt, "%s%s%s", fname, " :: ", format);
+      snprintf(fmt, len, "%s%s%s", fname, " :: ", format);
 
       va_start(ap, format);
       vfprintf(stderr, fmt, ap);
@@ -1657,7 +1657,13 @@ write_basic_interfile_header_for_ECAT7(string& interfile_header_filename,
     if (dot_ptr != NULL)
       header_filename[dot_ptr - header_filename] = '_';
     // now add stuff to say which frame, gate, bed, data this was
-    sprintf(header_filename + strlen(header_filename), "_f%dg%dd%db%d", frame_num, gate_num, data_num, bed_num);
+    snprintf(header_filename + strlen(header_filename),
+             ECAT7_filename.size() + 100 - strlen(header_filename),
+             "_f%dg%dd%db%d",
+             frame_num,
+             gate_num,
+             data_num,
+             bed_num);
   }
 
   switch (mptr->mhptr->file_type)

--- a/src/IO/stir_ecat7.cxx
+++ b/src/IO/stir_ecat7.cxx
@@ -1648,7 +1648,8 @@ write_basic_interfile_header_for_ECAT7(string& interfile_header_filename,
       return Succeeded::no;
     }
 
-  char* header_filename = new char[ECAT7_filename.size() + 100];
+  const size_t max_filename_length = ECAT7_filename.size() + 100;
+  char* header_filename = new char[max_filename_length];
   {
     strcpy(header_filename, ECAT7_filename.c_str());
     // keep extension, just in case we would have conflicts otherwise
@@ -1657,13 +1658,8 @@ write_basic_interfile_header_for_ECAT7(string& interfile_header_filename,
     if (dot_ptr != NULL)
       header_filename[dot_ptr - header_filename] = '_';
     // now add stuff to say which frame, gate, bed, data this was
-    snprintf(header_filename + strlen(header_filename),
-             ECAT7_filename.size() + 100 - strlen(header_filename),
-             "_f%dg%dd%db%d",
-             frame_num,
-             gate_num,
-             data_num,
-             bed_num);
+    const size_t used = strnlen(header_filename, max_filename_length);
+    snprintf(header_filename + used, max_filename_length - used, "_f%dg%dd%db%d", frame_num, gate_num, data_num, bed_num);
   }
 
   switch (mptr->mhptr->file_type)

--- a/src/analytic/FBP3DRP/ColsherFilter.cxx
+++ b/src/analytic/FBP3DRP/ColsherFilter.cxx
@@ -197,7 +197,7 @@ ColsherFilter::set_up(int target_height, int target_width, float theta, float d_
     Array<2, float> real_filter(IndexRange2D(target_height, target_width / 2 + 1));
     std::transform(filter.begin_all(), filter.end_all(), real_filter.begin_all(), real_part /*std::real<std::complex<float> >*/);
     char file[200];
-    sprintf(file, "%s_%d_%d_%g.dat", "new_colsher", target_width, target_height, theta);
+    snprintf(file, sizeof(file), "%s_%d_%d_%g.dat", "new_colsher", target_width, target_height, theta);
     std::cout << "Saving filter : " << file << std::endl;
     std::ofstream s(file);
     write_data(s, real_filter);
@@ -365,7 +365,7 @@ ColsherFilter::ColsherFilter(int height_v,
 #  ifdef __DEBUG_COLSHER
   {
     char file[200];
-    sprintf(file, "%s_%d_%d_%g.dat", "old_colsher", width, height, _PI / 2 - gamma);
+    snprintf(file, sizeof(file), "%s_%d_%d_%g.dat", "old_colsher", width, height, _PI / 2 - gamma);
     std::cout << "Saving filter : " << file << std::endl;
     std::ofstream s(file);
     write_data(s, filter);

--- a/src/analytic/FBP3DRP/FBP3DRPReconstruction.cxx
+++ b/src/analytic/FBP3DRP/FBP3DRPReconstruction.cxx
@@ -565,7 +565,7 @@ FBP3DRPReconstruction::do_2D_reconstruction()
   if (save_intermediate_files && !_disable_output)
     {
       char file[max_filename_length];
-      sprintf(file, "%s_estimated", output_filename_prefix.c_str());
+      snprintf(file, sizeof(file), "%s_estimated", output_filename_prefix.c_str());
       do_save_img(file, estimated_image());
     }
 }
@@ -656,7 +656,7 @@ FBP3DRPReconstruction::do_3D_Reconstruction(VoxelsOnCartesianGrid<float>& image)
           if (save_intermediate_files && !_disable_output)
             {
               char* file = new char[output_filename_prefix.size() + 20];
-              sprintf(file, "%s_afterseg%d", output_filename_prefix.c_str(), seg_num);
+              snprintf(file, output_filename_prefix.size() + 20, "%s_afterseg%d", output_filename_prefix.c_str(), seg_num);
               back_projector_sptr->get_output(image);
               do_save_img(file, image);
               delete[] file;
@@ -897,7 +897,7 @@ void
 FBP3DRPReconstruction::do_log_file(const VoxelsOnCartesianGrid<float>& image)
 {
   char file[max_filename_length];
-  sprintf(file, "%s.log", output_filename_prefix.c_str());
+  snprintf(file, sizeof(file), "%s.log", output_filename_prefix.c_str());
 
   full_log << endl << "- WRITE LOGFILE (" << file << ")" << endl;
 

--- a/src/analytic/FBP3DRP/FBP3DRPReconstruction.cxx
+++ b/src/analytic/FBP3DRP/FBP3DRPReconstruction.cxx
@@ -82,8 +82,8 @@
 
 #include "stir/analytic/FBP3DRP/ColsherFilter.h"
 #include "stir/display.h"
-//#include "stir/recon_buildblock/distributable.h"
-//#include "stir/FBP3DRP/process_viewgrams.h"
+// #include "stir/recon_buildblock/distributable.h"
+// #include "stir/FBP3DRP/process_viewgrams.h"
 
 #include "stir/analytic/FBP3DRP/FBP3DRPReconstruction.h"
 #include "stir/analytic/FBP2D/FBP2DReconstruction.h"
@@ -92,7 +92,7 @@
 #include "stir/recon_buildblock/BackProjectorByBinUsingInterpolation.h"
 #include "stir/recon_buildblock/ForwardProjectorByBinUsingRayTracing.h"
 #include "stir/IO/read_from_file.h"
-//#include "stir/mash_views.h"
+// #include "stir/mash_views.h"
 
 #include <algorithm>
 #include <fstream>
@@ -370,7 +370,7 @@ FBP3DRPReconstruction::actual_reconstruct(shared_ptr<DiscretisedDensity<3, float
 
   {
     // char file[max_filename_length];
-    // sprintf(file,"%s.full_log",output_filename_prefix.c_str());
+    // snprintf(file, sizeof(file), "%s.full_log",output_filename_prefix.c_str());
     std::string file = output_filename_prefix;
     file += ".full_log";
     full_log.open(file.c_str(), ios::out);

--- a/src/analytic/FBP3DRP/FBP3DRPReconstruction.cxx
+++ b/src/analytic/FBP3DRP/FBP3DRPReconstruction.cxx
@@ -655,8 +655,9 @@ FBP3DRPReconstruction::do_3D_Reconstruction(VoxelsOnCartesianGrid<float>& image)
 #ifndef PARALLEL
           if (save_intermediate_files && !_disable_output)
             {
-              char* file = new char[output_filename_prefix.size() + 20];
-              snprintf(file, output_filename_prefix.size() + 20, "%s_afterseg%d", output_filename_prefix.c_str(), seg_num);
+              const size_t filename_size = output_filename_prefix.size() + 20;
+              char* file = new char[filename_size];
+              snprintf(file, filename_size, "%s_afterseg%d", output_filename_prefix.c_str(), seg_num);
               back_projector_sptr->get_output(image);
               do_save_img(file, image);
               delete[] file;

--- a/src/buildblock/ML_norm.cxx
+++ b/src/buildblock/ML_norm.cxx
@@ -1709,7 +1709,7 @@ iterate_efficiencies(DetectorEfficiencies& efficiencies,
 #ifdef WRITE_ALL
         {
           char out_filename[100];
-          sprintf(out_filename, "MLresult_subiter_eff_1_%d.out", sub_iter_num++);
+          snprintf(out_filename, sizeof(out_filename), "MLresult_subiter_eff_1_%d.out", sub_iter_num++);
           ofstream out(out_filename);
           if (!out)
             {

--- a/src/display/display_array.cxx
+++ b/src/display/display_array.cxx
@@ -494,7 +494,7 @@ display(const RelatedViewgrams<elemT>& vs, double maxi, const char* const title,
   VectorWithOffset<char*>::iterator text_iter = text.begin();
   typename RelatedViewgrams<elemT>::const_iterator vs_iter = vs.begin();
 
-  const std::size_t label_size = 100;
+  constexpr std::size_t label_size = 100;
   while (vs_iter != vs.end())
     {
       *text_iter = new char[label_size];

--- a/src/display/display_array.cxx
+++ b/src/display/display_array.cxx
@@ -494,10 +494,11 @@ display(const RelatedViewgrams<elemT>& vs, double maxi, const char* const title,
   VectorWithOffset<char*>::iterator text_iter = text.begin();
   typename RelatedViewgrams<elemT>::const_iterator vs_iter = vs.begin();
 
+  const std::size_t label_size = 100;
   while (vs_iter != vs.end())
     {
-      *text_iter = new char[100];
-      sprintf(*text_iter, "v %d, s %d", vs_iter->get_view_num(), vs_iter->get_segment_num());
+      *text_iter = new char[label_size];
+      snprintf(*text_iter, label_size, "v %d, s %d", vs_iter->get_view_num(), vs_iter->get_segment_num());
       ++text_iter;
       ++vs_iter;
     }

--- a/src/experimental/buildblock/NonseparableSpatiallyVaryingFilters3D.cxx
+++ b/src/experimental/buildblock/NonseparableSpatiallyVaryingFilters3D.cxx
@@ -967,7 +967,7 @@ NonseparableSpatiallyVaryingFilters3D<elemT>::virtual_apply(DiscretisedDensity<3
 #      if 0
 		  {
 		    char filename[1000];
-		    sprintf(filename, "filter%g.hv",tmp);
+		    snprintf(filename, sizeof(filename), "filter%g.hv",tmp);
 		    filename[7]='_';
 		    write_basic_interfile(filename, new_coeffs);
 		  }

--- a/src/experimental/listmode_utilities/change_lm_time_tags.cxx
+++ b/src/experimental/listmode_utilities/change_lm_time_tags.cxx
@@ -32,7 +32,7 @@ open_next(std::fstream& s, const std::string& filename_prefix, int& num)
     s.close();
 
   char txt[50];
-  sprintf(txt, "_%d.lm", num);
+  snprintf(txt, sizeof(txt), "_%d.lm", num);
   string filename = filename_prefix;
   filename += txt;
   s.open(filename.c_str(), std::ios::out | std::ios::binary);

--- a/src/experimental/motion/MatchTrackerAndScanner.cxx
+++ b/src/experimental/motion/MatchTrackerAndScanner.cxx
@@ -150,7 +150,7 @@ MatchTrackerAndScanner::run()
       CartesianCoordinate3D<float> location_of_image_max_in_mm;
       {
         char rest[50];
-        sprintf(rest, "_f%ug1d0b0.hv", current_frame_num);
+        snprintf(rest, sizeof(rest), "_f%ug1d0b0.hv", current_frame_num);
         const string input_filename = this->get_image_filename_prefix() + rest;
 
         shared_ptr<DiscretisedDensity<3, float>> input_image_sptr(read_from_file<DiscretisedDensity<3, float>>(input_filename));

--- a/src/experimental/motion_utilities/find_motion_corrected_norm_factors.cxx
+++ b/src/experimental/motion_utilities/find_motion_corrected_norm_factors.cxx
@@ -380,7 +380,7 @@ FindMCNormFactors::process_data()
 
       {
         char rest[50];
-        sprintf(rest, "_f%ug1d0b0", current_frame_num);
+        snprintf(rest, sizeof(rest), "_f%ug1d0b0", current_frame_num);
         const string output_filename = output_filename_prefix + rest;
 
         out_proj_data_ptr = construct_proj_data(output, output_filename, template_proj_data_info_ptr);

--- a/src/experimental/motion_utilities/move_image.cxx
+++ b/src/experimental/motion_utilities/move_image.cxx
@@ -161,7 +161,7 @@ MoveImage::process_data()
 
       {
         char rest[50];
-        sprintf(rest, "_f%ug1d0b0", current_frame_num);
+        snprintf(rest, sizeof(rest), "_f%ug1d0b0", current_frame_num);
         const string output_filename = output_filename_prefix + rest;
         if (output_file_format_sptr->write_to_file(output_filename, *out_density_sptr) == Succeeded::no)
           {

--- a/src/experimental/motion_utilities/move_projdata.cxx
+++ b/src/experimental/motion_utilities/move_projdata.cxx
@@ -23,7 +23,7 @@
 
 */
 #include "stir/ProjDataInterfile.h"
-//#include "stir/IO/DefaultOutputFileFormat.h"
+// #include "stir/IO/DefaultOutputFileFormat.h"
 #include "stir_experimental/motion/TimeFrameMotion.h"
 #include "stir_experimental/motion/transform_3d_object.h"
 #include "stir/Succeeded.h"
@@ -176,7 +176,7 @@ MoveProjData::process_data()
       set_frame_num_to_process(current_frame_num);
       {
         char rest[50];
-        sprintf(rest, "_f%ug1d0b0", current_frame_num);
+        snprintf(rest, sizeof(rest), "_f%ug1d0b0", current_frame_num);
         const string output_filename = output_filename_prefix + rest;
         out_proj_data_sptr.reset(
             new ProjDataInterfile(in_proj_data_sptr->get_exam_info_sptr(), proj_data_info_ptr, output_filename, ios::out));

--- a/src/experimental/recon_buildblock/BinNormalisationFromML2D.cxx
+++ b/src/experimental/recon_buildblock/BinNormalisationFromML2D.cxx
@@ -91,13 +91,14 @@ BinNormalisationFromML2D::set_up(const shared_ptr<const ProjDataInfo>& proj_data
       if (do_eff)
         {
           char* normalisation_filename = new char[normalisation_filename_prefix.size() + 30];
-          sprintf(normalisation_filename,
-                  "%s_%s_%d_%d_%d.out",
-                  normalisation_filename_prefix.c_str(),
-                  "eff",
-                  ax_pos_num,
-                  iter_num,
-                  eff_iter_num);
+          snprintf(normalisation_filename,
+                   normalisation_filename_prefix.size() + 30,
+                   "%s_%s_%d_%d_%d.out",
+                   normalisation_filename_prefix.c_str(),
+                   "eff",
+                   ax_pos_num,
+                   iter_num,
+                   eff_iter_num);
           ifstream in(normalisation_filename);
           in >> efficiencies;
           if (!in)
@@ -114,8 +115,13 @@ BinNormalisationFromML2D::set_up(const shared_ptr<const ProjDataInfo>& proj_data
         {
           {
             char* normalisation_filename = new char[normalisation_filename_prefix.size() + 30];
-            sprintf(
-                normalisation_filename, "%s_%s_%d_%d.out", normalisation_filename_prefix.c_str(), "geo", ax_pos_num, iter_num);
+            snprintf(normalisation_filename,
+                     normalisation_filename_prefix.size() + 30,
+                     "%s_%s_%d_%d.out",
+                     normalisation_filename_prefix.c_str(),
+                     "geo",
+                     ax_pos_num,
+                     iter_num);
             ifstream in(normalisation_filename);
             in >> norm_geo_data;
             if (!in)
@@ -132,8 +138,13 @@ BinNormalisationFromML2D::set_up(const shared_ptr<const ProjDataInfo>& proj_data
         {
           {
             char* normalisation_filename = new char[normalisation_filename_prefix.size() + 30];
-            sprintf(
-                normalisation_filename, "%s_%s_%d_%d.out", normalisation_filename_prefix.c_str(), "block", ax_pos_num, iter_num);
+            snprintf(normalisation_filename,
+                     normalisation_filename_prefix.size() + 30,
+                     "%s_%s_%d_%d.out",
+                     normalisation_filename_prefix.c_str(),
+                     "block",
+                     ax_pos_num,
+                     iter_num);
             ifstream in(normalisation_filename);
             in >> norm_block_data;
             if (!in)

--- a/src/experimental/recon_buildblock/BinNormalisationFromML2D.cxx
+++ b/src/experimental/recon_buildblock/BinNormalisationFromML2D.cxx
@@ -90,9 +90,10 @@ BinNormalisationFromML2D::set_up(const shared_ptr<const ProjDataInfo>& proj_data
       // efficiencies
       if (do_eff)
         {
-          char* normalisation_filename = new char[normalisation_filename_prefix.size() + 30];
+          const size_t filename_size = normalisation_filename_prefix.size() + 30;
+          char* normalisation_filename = new char[filename_size];
           snprintf(normalisation_filename,
-                   normalisation_filename_prefix.size() + 30,
+                   filename_size,
                    "%s_%s_%d_%d_%d.out",
                    normalisation_filename_prefix.c_str(),
                    "eff",
@@ -114,9 +115,10 @@ BinNormalisationFromML2D::set_up(const shared_ptr<const ProjDataInfo>& proj_data
       if (do_geo)
         {
           {
-            char* normalisation_filename = new char[normalisation_filename_prefix.size() + 30];
+            const size_t filename_size = normalisation_filename_prefix.size() + 30;
+            char* normalisation_filename = new char[filename_size];
             snprintf(normalisation_filename,
-                     normalisation_filename_prefix.size() + 30,
+                     filename_size,
                      "%s_%s_%d_%d.out",
                      normalisation_filename_prefix.c_str(),
                      "geo",
@@ -137,9 +139,10 @@ BinNormalisationFromML2D::set_up(const shared_ptr<const ProjDataInfo>& proj_data
       if (do_block)
         {
           {
-            char* normalisation_filename = new char[normalisation_filename_prefix.size() + 30];
+            const size_t filename_size = normalisation_filename_prefix.size() + 30;
+            char* normalisation_filename = new char[filename_size];
             snprintf(normalisation_filename,
-                     normalisation_filename_prefix.size() + 30,
+                     filename_size,
                      "%s_%s_%d_%d.out",
                      normalisation_filename_prefix.c_str(),
                      "block",

--- a/src/experimental/recon_buildblock/ParametricQuadraticPrior.cxx
+++ b/src/experimental/recon_buildblock/ParametricQuadraticPrior.cxx
@@ -183,8 +183,9 @@ ParametricQuadraticPrior<TargetT>::compute_gradient(TargetT& prior_gradient, con
       static int count = 0;
       ++count; // Maybe it will be usefult to add here a writing step, intialised by the parameter file, otherwise we will run out
                // of space!
-      char* filename = new char[gradient_filename_prefix.size() + 100];
-      snprintf(filename, gradient_filename_prefix.size() + 100, "%s%d.img", gradient_filename_prefix.c_str(), count);
+      const size_t filename_size = gradient_filename_prefix.size() + 100;
+      char* filename = new char[filename_size];
+      snprintf(filename, filename_size, "%s%d.img", gradient_filename_prefix.c_str(), count);
       // This works only for ParametricVoxelsOnCartesianGrid and maybe for other ecat7 format files.
       write_to_file(filename, prior_gradient);
       delete[] filename;

--- a/src/experimental/recon_buildblock/ParametricQuadraticPrior.cxx
+++ b/src/experimental/recon_buildblock/ParametricQuadraticPrior.cxx
@@ -184,7 +184,7 @@ ParametricQuadraticPrior<TargetT>::compute_gradient(TargetT& prior_gradient, con
       ++count; // Maybe it will be usefult to add here a writing step, intialised by the parameter file, otherwise we will run out
                // of space!
       char* filename = new char[gradient_filename_prefix.size() + 100];
-      sprintf(filename, "%s%d.img", gradient_filename_prefix.c_str(), count);
+      snprintf(filename, gradient_filename_prefix.size() + 100, "%s%d.img", gradient_filename_prefix.c_str(), count);
       // This works only for ParametricVoxelsOnCartesianGrid and maybe for other ecat7 format files.
       write_to_file(filename, prior_gradient);
       delete[] filename;

--- a/src/experimental/recon_buildblock/ProjMatrixByDensel.cxx
+++ b/src/experimental/recon_buildblock/ProjMatrixByDensel.cxx
@@ -65,9 +65,9 @@ void ProjMatrixByDensel::write_to_file_by_densel(
                                       const char * const file_name_without_extension)
 { 
   char h_interfile[256];
-  sprintf (h_interfile, "%s.hp", file_name_without_extension );
+  snprintf (h_interfile, sizeof(h_interfile), "%s.hp", file_name_without_extension );
   FILE * prob_file = fopen (h_interfile , "wb");
-  sprintf (h_interfile, "%s.p", file_name_without_extension );
+  snprintf (h_interfile, sizeof(h_interfile), "%s.p", file_name_without_extension );
   fstream pout;
   open_write_denselary(pout, h_interfile);
   

--- a/src/experimental/utilities/create_normfactors.cxx
+++ b/src/experimental/utilities/create_normfactors.cxx
@@ -73,7 +73,14 @@ main(int argc, char** argv)
           efficiencies[b] = exp(noise * ((2.F * rand()) / RAND_MAX - 1));
         {
           char* out_filename = new char[out_filename_prefix.size() + 30];
-          sprintf(out_filename, "%s_%s_%d_%d_%d.out", out_filename_prefix.c_str(), "eff", ax_pos_num, iter_num, eff_iter_num);
+          snprintf(out_filename,
+                   out_filename_prefix.size() + 30,
+                   "%s_%s_%d_%d_%d.out",
+                   out_filename_prefix.c_str(),
+                   "eff",
+                   ax_pos_num,
+                   iter_num,
+                   eff_iter_num);
           ofstream out(out_filename);
           out << efficiencies;
           delete[] out_filename;
@@ -106,7 +113,13 @@ main(int argc, char** argv)
           }
           {
             char* out_filename = new char[out_filename_prefix.size() + 30];
-            sprintf(out_filename, "%s_%s_%d_%d.out", out_filename_prefix.c_str(), "geo", ax_pos_num, iter_num);
+            snprintf(out_filename,
+                     out_filename_prefix.size() + 30,
+                     "%s_%s_%d_%d.out",
+                     out_filename_prefix.c_str(),
+                     "geo",
+                     ax_pos_num,
+                     iter_num);
             ofstream out(out_filename);
             out << norm_geo_data;
             delete[] out_filename;
@@ -124,7 +137,13 @@ main(int argc, char** argv)
 
           {
             char* out_filename = new char[out_filename_prefix.size() + 30];
-            sprintf(out_filename, "%s_%s_%d_%d.out", out_filename_prefix.c_str(), "block", ax_pos_num, iter_num);
+            snprintf(out_filename,
+                     out_filename_prefix.size() + 30,
+                     "%s_%s_%d_%d.out",
+                     out_filename_prefix.c_str(),
+                     "block",
+                     ax_pos_num,
+                     iter_num);
             ofstream out(out_filename);
             out << norm_block_data;
             delete[] out_filename;

--- a/src/experimental/utilities/create_normfactors.cxx
+++ b/src/experimental/utilities/create_normfactors.cxx
@@ -72,9 +72,10 @@ main(int argc, char** argv)
         for (int b = 0; b < num_detectors; ++b)
           efficiencies[b] = exp(noise * ((2.F * rand()) / RAND_MAX - 1));
         {
-          char* out_filename = new char[out_filename_prefix.size() + 30];
+          const size_t filename_size = out_filename_prefix.size() + 30;
+          char* out_filename = new char[filename_size];
           snprintf(out_filename,
-                   out_filename_prefix.size() + 30,
+                   filename_size,
                    "%s_%s_%d_%d_%d.out",
                    out_filename_prefix.c_str(),
                    "eff",
@@ -112,14 +113,9 @@ main(int argc, char** argv)
                 }
           }
           {
-            char* out_filename = new char[out_filename_prefix.size() + 30];
-            snprintf(out_filename,
-                     out_filename_prefix.size() + 30,
-                     "%s_%s_%d_%d.out",
-                     out_filename_prefix.c_str(),
-                     "geo",
-                     ax_pos_num,
-                     iter_num);
+            const size_t filename_size = out_filename_prefix.size() + 30;
+            char* out_filename = new char[filename_size];
+            snprintf(out_filename, filename_size, "%s_%s_%d_%d.out", out_filename_prefix.c_str(), "geo", ax_pos_num, iter_num);
             ofstream out(out_filename);
             out << norm_geo_data;
             delete[] out_filename;
@@ -136,14 +132,9 @@ main(int argc, char** argv)
               }
 
           {
-            char* out_filename = new char[out_filename_prefix.size() + 30];
-            snprintf(out_filename,
-                     out_filename_prefix.size() + 30,
-                     "%s_%s_%d_%d.out",
-                     out_filename_prefix.c_str(),
-                     "block",
-                     ax_pos_num,
-                     iter_num);
+            const size_t filename_size = out_filename_prefix.size() + 30;
+            char* out_filename = new char[filename_size];
+            snprintf(out_filename, filename_size, "%s_%s_%d_%d.out", out_filename_prefix.c_str(), "block", ax_pos_num, iter_num);
             ofstream out(out_filename);
             out << norm_block_data;
             delete[] out_filename;

--- a/src/experimental/utilities/create_normfactors3D.cxx
+++ b/src/experimental/utilities/create_normfactors3D.cxx
@@ -74,7 +74,13 @@ main(int argc, char** argv)
                                                    * exp(noise * ((2.F * rand()) / RAND_MAX - 1)));
       {
         char* out_filename = new char[out_filename_prefix.size() + 30];
-        sprintf(out_filename, "%s_%s_%d_%d.out", out_filename_prefix.c_str(), "eff", iter_num, eff_iter_num);
+        snprintf(out_filename,
+                 out_filename_prefix.size() + 30,
+                 "%s_%s_%d_%d.out",
+                 out_filename_prefix.c_str(),
+                 "eff",
+                 iter_num,
+                 eff_iter_num);
         ofstream out(out_filename);
         out << efficiencies;
         delete[] out_filename;
@@ -95,7 +101,7 @@ main(int argc, char** argv)
 
       {
         char* out_filename = new char[out_filename_prefix.size() + 30];
-        sprintf(out_filename, "%s_%s_%d.out", out_filename_prefix.c_str(), "block", iter_num);
+        snprintf(out_filename, out_filename_prefix.size() + 30, "%s_%s_%d.out", out_filename_prefix.c_str(), "block", iter_num);
         ofstream out(out_filename);
         out << norm_block_data;
         delete[] out_filename;

--- a/src/experimental/utilities/create_normfactors3D.cxx
+++ b/src/experimental/utilities/create_normfactors3D.cxx
@@ -73,14 +73,9 @@ main(int argc, char** argv)
           efficiencies[ra][a] = static_cast<float>((2 + sin(2 * _PI * a / num_detectors_per_ring))
                                                    * exp(noise * ((2.F * rand()) / RAND_MAX - 1)));
       {
-        char* out_filename = new char[out_filename_prefix.size() + 30];
-        snprintf(out_filename,
-                 out_filename_prefix.size() + 30,
-                 "%s_%s_%d_%d.out",
-                 out_filename_prefix.c_str(),
-                 "eff",
-                 iter_num,
-                 eff_iter_num);
+        const size_t filename_size = out_filename_prefix.size() + 30;
+        char* out_filename = new char[filename_size];
+        snprintf(out_filename, filename_size, "%s_%s_%d_%d.out", out_filename_prefix.c_str(), "eff", iter_num, eff_iter_num);
         ofstream out(out_filename);
         out << efficiencies;
         delete[] out_filename;
@@ -100,8 +95,9 @@ main(int argc, char** argv)
               }
 
       {
-        char* out_filename = new char[out_filename_prefix.size() + 30];
-        snprintf(out_filename, out_filename_prefix.size() + 30, "%s_%s_%d.out", out_filename_prefix.c_str(), "block", iter_num);
+        const size_t filename_size = out_filename_prefix.size() + 30;
+        char* out_filename = new char[filename_size];
+        snprintf(out_filename, filename_size, "%s_%s_%d.out", out_filename_prefix.c_str(), "block", iter_num);
         ofstream out(out_filename);
         out << norm_block_data;
         delete[] out_filename;

--- a/src/include/stir/display.inl
+++ b/src/include/stir/display.inl
@@ -43,7 +43,7 @@ display(const Array<3, elemT>& plane_stack, double maxi, const char* const title
   scale_factors.fill(1.);
   VectorWithOffset<char*> text(plane_stack.get_min_index(), plane_stack.get_max_index());
 
-  const std::size_t label_size = 10;
+  constexpr std::size_t label_size = 10;
   for (int i = plane_stack.get_min_index(); i <= plane_stack.get_max_index(); i++)
     {
       text[i] = new char[label_size];

--- a/src/include/stir/display.inl
+++ b/src/include/stir/display.inl
@@ -43,10 +43,11 @@ display(const Array<3, elemT>& plane_stack, double maxi, const char* const title
   scale_factors.fill(1.);
   VectorWithOffset<char*> text(plane_stack.get_min_index(), plane_stack.get_max_index());
 
+  const std::size_t label_size = 10;
   for (int i = plane_stack.get_min_index(); i <= plane_stack.get_max_index(); i++)
     {
-      text[i] = new char[10];
-      sprintf(text[i], "%d", i);
+      text[i] = new char[label_size];
+      snprintf(text[i], label_size, "%d", i);
     }
 
   display(plane_stack, scale_factors, text, maxi, title, zoom);

--- a/src/iterative/KOSMAPOSL/KOSMAPOSLReconstruction.cxx
+++ b/src/iterative/KOSMAPOSL/KOSMAPOSLReconstruction.cxx
@@ -30,7 +30,7 @@
 #include "stir/OSMAPOSL/OSMAPOSLReconstruction.h"
 #include "stir/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMean.h"
 #include "stir/DiscretisedDensity.h"
-//#include "stir/LogLikBased/common.h"
+// #include "stir/LogLikBased/common.h"
 #include "stir/ThresholdMinToSmallPositiveValueDataProcessor.h"
 #include "stir/ChainedDataProcessor.h"
 #include "stir/Succeeded.h"
@@ -49,8 +49,8 @@
 #include "stir/format.h"
 #include "stir/VoxelsOnCartesianGrid.h"
 
-//#include "stir/modelling/ParametricDiscretisedDensity.h"
-//#include "stir/modelling/KineticParameters.h"
+// #include "stir/modelling/ParametricDiscretisedDensity.h"
+// #include "stir/modelling/KineticParameters.h"
 
 #include <memory>
 #include <iostream>
@@ -1094,7 +1094,11 @@ KOSMAPOSLReconstruction<TargetT>::update_estimate(TargetT& current_alpha_coeffic
       // allocate space for the filename assuming that
       // we never have more than 10^49 subiterations ...
       char* fname = new char[this->output_filename_prefix.size() + 60];
-      snprintf(fname, this->output_filename_prefix.size() + 60, "%s_update_%d", this->output_filename_prefix.c_str(), this->subiteration_num);
+      snprintf(fname,
+               this->output_filename_prefix.size() + 60,
+               "%s_update_%d",
+               this->output_filename_prefix.c_str(),
+               this->subiteration_num);
 
       // Write it to file
       this->output_file_format_ptr->write_to_file(fname, *kmultiplicative_update_ptr);

--- a/src/iterative/KOSMAPOSL/KOSMAPOSLReconstruction.cxx
+++ b/src/iterative/KOSMAPOSL/KOSMAPOSLReconstruction.cxx
@@ -1093,12 +1093,9 @@ KOSMAPOSLReconstruction<TargetT>::update_estimate(TargetT& current_alpha_coeffic
     {
       // allocate space for the filename assuming that
       // we never have more than 10^49 subiterations ...
-      char* fname = new char[this->output_filename_prefix.size() + 60];
-      snprintf(fname,
-               this->output_filename_prefix.size() + 60,
-               "%s_update_%d",
-               this->output_filename_prefix.c_str(),
-               this->subiteration_num);
+      const size_t filename_length = this->output_filename_prefix.size() + 60;
+      char* fname = new char[filename_length];
+      snprintf(fname, filename_length, "%s_update_%d", this->output_filename_prefix.c_str(), this->subiteration_num);
 
       // Write it to file
       this->output_file_format_ptr->write_to_file(fname, *kmultiplicative_update_ptr);

--- a/src/iterative/KOSMAPOSL/KOSMAPOSLReconstruction.cxx
+++ b/src/iterative/KOSMAPOSL/KOSMAPOSLReconstruction.cxx
@@ -1094,7 +1094,7 @@ KOSMAPOSLReconstruction<TargetT>::update_estimate(TargetT& current_alpha_coeffic
       // allocate space for the filename assuming that
       // we never have more than 10^49 subiterations ...
       char* fname = new char[this->output_filename_prefix.size() + 60];
-      sprintf(fname, "%s_update_%d", this->output_filename_prefix.c_str(), this->subiteration_num);
+      snprintf(fname, this->output_filename_prefix.size() + 60, "%s_update_%d", this->output_filename_prefix.c_str(), this->subiteration_num);
 
       // Write it to file
       this->output_file_format_ptr->write_to_file(fname, *kmultiplicative_update_ptr);

--- a/src/iterative/OSMAPOSL/OSMAPOSLReconstruction.cxx
+++ b/src/iterative/OSMAPOSL/OSMAPOSLReconstruction.cxx
@@ -480,7 +480,7 @@ OSMAPOSLReconstruction<TargetT>::update_estimate(TargetT& current_image_estimate
       // allocate space for the filename assuming that
       // we never have more than 10^49 subiterations ...
       char* fname = new char[this->output_filename_prefix.size() + 60];
-      sprintf(fname, "%s_update_%d", this->output_filename_prefix.c_str(), this->subiteration_num);
+      snprintf(fname, this->output_filename_prefix.size() + 60, "%s_update_%d", this->output_filename_prefix.c_str(), this->subiteration_num);
 
       // Write it to file
       this->output_file_format_ptr->write_to_file(fname, *multiplicative_update_image_ptr);

--- a/src/iterative/OSMAPOSL/OSMAPOSLReconstruction.cxx
+++ b/src/iterative/OSMAPOSL/OSMAPOSLReconstruction.cxx
@@ -479,12 +479,9 @@ OSMAPOSLReconstruction<TargetT>::update_estimate(TargetT& current_image_estimate
     {
       // allocate space for the filename assuming that
       // we never have more than 10^49 subiterations ...
-      char* fname = new char[this->output_filename_prefix.size() + 60];
-      snprintf(fname,
-               this->output_filename_prefix.size() + 60,
-               "%s_update_%d",
-               this->output_filename_prefix.c_str(),
-               this->subiteration_num);
+      const size_t filename_length = this->output_filename_prefix.size() + 60;
+      char* fname = new char[filename_length];
+      snprintf(fname, filename_length, "%s_update_%d", this->output_filename_prefix.c_str(), this->subiteration_num);
 
       // Write it to file
       this->output_file_format_ptr->write_to_file(fname, *multiplicative_update_image_ptr);

--- a/src/iterative/OSMAPOSL/OSMAPOSLReconstruction.cxx
+++ b/src/iterative/OSMAPOSL/OSMAPOSLReconstruction.cxx
@@ -30,7 +30,7 @@
 #include "stir/OSMAPOSL/OSMAPOSLReconstruction.h"
 #include "stir/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMean.h"
 #include "stir/DiscretisedDensity.h"
-//#include "stir/LogLikBased/common.h"
+// #include "stir/LogLikBased/common.h"
 #include "stir/ThresholdMinToSmallPositiveValueDataProcessor.h"
 #include "stir/ChainedDataProcessor.h"
 #include "stir/Succeeded.h"
@@ -480,7 +480,11 @@ OSMAPOSLReconstruction<TargetT>::update_estimate(TargetT& current_image_estimate
       // allocate space for the filename assuming that
       // we never have more than 10^49 subiterations ...
       char* fname = new char[this->output_filename_prefix.size() + 60];
-      snprintf(fname, this->output_filename_prefix.size() + 60, "%s_update_%d", this->output_filename_prefix.c_str(), this->subiteration_num);
+      snprintf(fname,
+               this->output_filename_prefix.size() + 60,
+               "%s_update_%d",
+               this->output_filename_prefix.c_str(),
+               this->subiteration_num);
 
       // Write it to file
       this->output_file_format_ptr->write_to_file(fname, *multiplicative_update_image_ptr);

--- a/src/listmode_buildblock/CListModeDataECAT.cxx
+++ b/src/listmode_buildblock/CListModeDataECAT.cxx
@@ -176,7 +176,7 @@ CListModeDataECAT<CListRecordT>::open_lm_file(unsigned int new_lm_file) const
       // now open new file
       std::string filename = listmode_filename_prefix;
       char rest[50];
-      sprintf(rest, "_%d.lm", new_lm_file);
+      snprintf(rest, sizeof(rest), "_%d.lm", new_lm_file);
       filename += rest;
       info(format("CListModeDataECAT: opening file {}", filename));
       shared_ptr<istream> stream_ptr(new fstream(filename.c_str(), ios::in | ios::binary));

--- a/src/listmode_buildblock/LmToProjData.cxx
+++ b/src/listmode_buildblock/LmToProjData.cxx
@@ -38,7 +38,7 @@ FRAME_BASED_DT_CORR:
 // (Note: can currently NOT be disabled)
 #define USE_SegmentByView
 
-//#define FRAME_BASED_DT_CORR
+// #define FRAME_BASED_DT_CORR
 
 // set elem_type to what you want to use for the sinogram elements
 // we need a signed type, as randoms can be subtracted. However, signed char could do.
@@ -510,13 +510,13 @@ LmToProjData::get_bin_from_event(Bin& bin, const ListEvent& event) const
         return; // rejected for some strange reason
 
       // do_normalisation
-      //#ifndef FRAME_BASED_DT_CORR
+      // #ifndef FRAME_BASED_DT_CORR
       //     const double start_time = current_time;
       //     const double end_time = current_time;
-      //#else
+      // #else
       //     const double start_time = frame_defs.get_start_time(current_frame_num);
       //     const double end_time =frame_defs.get_end_time(current_frame_num);
-      //#endif
+      // #endif
 
       const float bin_efficiency = normalisation_ptr->get_bin_efficiency(uncompressed_bin);
       // TODO remove arbitrary number. Supposes that these bin_efficiencies are around 1
@@ -566,13 +566,13 @@ LmToProjData::do_post_normalisation(Bin& bin) const
         }
       else
         {
-          //#ifndef FRAME_BASED_DT_CORR
+          // #ifndef FRAME_BASED_DT_CORR
           //	  const double start_time = current_time;
           //	  const double end_time = current_time;
-          //#else
+          // #else
           //	  const double start_time = frame_defs.get_start_time(current_frame_num);
           //	  const double end_time =frame_defs.get_end_time(current_frame_num);
-          //#endif
+          // #endif
           const float bin_efficiency = post_normalisation_ptr->get_bin_efficiency(bin);
           // TODO remove arbitrary number. Supposes that these bin_efficiencies are around 1
           if (bin_efficiency < 1.E-10)
@@ -884,7 +884,7 @@ LmToProjData::process_data()
                                      current_time);
                           }
                       } // end of spatial event processing
-                  }     // end of while loop over all events
+                  } // end of while loop over all events
 
                 time_of_last_stored_event = max(time_of_last_stored_event, current_time);
               }
@@ -951,7 +951,7 @@ LmToProjData::run_tof_test_function()
 
     {
         char rest[50];
-        sprintf(rest, "_f%dg1d0b0", current_frame_num);
+        snprintf(rest, sizeof(rest), "_f%dg1d0b0", current_frame_num);
         const string output_filename = output_filename_prefix + rest;
 
         proj_data_sptr =

--- a/src/listmode_buildblock/LmToProjData.cxx
+++ b/src/listmode_buildblock/LmToProjData.cxx
@@ -694,7 +694,7 @@ LmToProjData::process_data()
         {
           writing_to_file = true;
           char rest[50];
-          sprintf(rest, "_f%dg1d0b0", current_frame_num);
+          snprintf(rest, sizeof(rest), "_f%dg1d0b0", current_frame_num);
           const string output_filename = output_filename_prefix + rest;
 
           output_proj_data_sptr = construct_proj_data(output, output_filename, this_frame_exam_info, template_proj_data_info_ptr);

--- a/src/listmode_buildblock/LmToProjData.cxx
+++ b/src/listmode_buildblock/LmToProjData.cxx
@@ -884,7 +884,7 @@ LmToProjData::process_data()
                                      current_time);
                           }
                       } // end of spatial event processing
-                  } // end of while loop over all events
+                  }     // end of while loop over all events
 
                 time_of_last_stored_event = max(time_of_last_stored_event, current_time);
               }

--- a/src/listmode_utilities/lm_fansums.cxx
+++ b/src/listmode_utilities/lm_fansums.cxx
@@ -248,7 +248,7 @@ void
 LmFansums::write_fan_sums(const Array<2, float>& data_fan_sums, const unsigned current_frame_num) const
 {
   char txt[50];
-  sprintf(txt, "_f%u.dat", current_frame_num);
+  snprintf(txt, sizeof(txt), "_f%u.dat", current_frame_num);
   std::string filename = output_filename_prefix;
   filename += txt;
   ofstream out(filename.c_str());

--- a/src/recon_buildblock/FourierRebinning.cxx
+++ b/src/recon_buildblock/FourierRebinning.cxx
@@ -227,7 +227,7 @@ FourierRebinning::rebin()
       if (fore_debug_level >= 2)
         {
           char s[100];
-          sprintf(s, "(extended) segment by sinogram %d", segment.get_segment_num());
+          snprintf(s, sizeof(s), "(extended) segment by sinogram %d", segment.get_segment_num());
           display(segment, segment.find_max(), s);
         }
 
@@ -303,12 +303,12 @@ FourierRebinning::rebin()
           for (int i = 0; i < num_views_pow2; i++)
             for (int j = 0; j <= num_tang_poss_pow2 / 2; j++)
               real[i][j] = FT_rebinned_sinogram[i][j].real();
-          sprintf(s, "real part of FT of rebinned (extended) sinogram %d", plane);
+          snprintf(s, sizeof(s), "real part of FT of rebinned (extended) sinogram %d", plane);
           display(real, s, real.find_max());
           for (int i = 0; i < num_views_pow2; i++)
             for (int j = 0; j <= num_tang_poss_pow2 / 2; j++)
               real[i][j] = FT_rebinned_sinogram[i][j].imag();
-          sprintf(s, "imag part of FT of rebinned (extended) sinogram %d", plane);
+          snprintf(s, sizeof(s), "imag part of FT of rebinned (extended) sinogram %d", plane);
           display(real, s, real.find_max());
         }
 
@@ -596,7 +596,7 @@ void
 FourierRebinning::do_log_file()
 { // CL Saving time details and write them to log file
   char file[200];
-  sprintf(file, "%s.log", output_filename_prefix.c_str());
+  snprintf(file, sizeof(file), "%s.log", output_filename_prefix.c_str());
 
   std::ofstream logfile(file);
 

--- a/src/recon_buildblock/IterativeReconstruction.cxx
+++ b/src/recon_buildblock/IterativeReconstruction.cxx
@@ -335,7 +335,7 @@ std::string
 IterativeReconstruction<TargetT>::make_filename_prefix_subiteration_num(const std::string& filename_prefix) const
 {
   char num[50];
-  sprintf(num, "_%d", subiteration_num);
+  snprintf(num, sizeof(num), "_%d", subiteration_num);
   return filename_prefix + num;
 }
 

--- a/src/recon_buildblock/LogcoshPrior.cxx
+++ b/src/recon_buildblock/LogcoshPrior.cxx
@@ -386,7 +386,7 @@ LogcoshPrior<elemT>::compute_gradient(DiscretisedDensity<3, elemT>& prior_gradie
   if (gradient_filename_prefix.size() > 0)
     {
       char* filename = new char[gradient_filename_prefix.size() + 100];
-      sprintf(filename, "%s%d.v", gradient_filename_prefix.c_str(), count);
+      snprintf(filename, gradient_filename_prefix.size() + 100, "%s%d.v", gradient_filename_prefix.c_str(), count);
       OutputFileFormat<DiscretisedDensity<3, elemT>>::default_sptr()->write_to_file(filename, prior_gradient);
       delete[] filename;
     }

--- a/src/recon_buildblock/LogcoshPrior.cxx
+++ b/src/recon_buildblock/LogcoshPrior.cxx
@@ -385,8 +385,9 @@ LogcoshPrior<elemT>::compute_gradient(DiscretisedDensity<3, elemT>& prior_gradie
   ++count;
   if (gradient_filename_prefix.size() > 0)
     {
-      char* filename = new char[gradient_filename_prefix.size() + 100];
-      snprintf(filename, gradient_filename_prefix.size() + 100, "%s%d.v", gradient_filename_prefix.c_str(), count);
+      const size_t filename_size = gradient_filename_prefix.size() + 100;
+      char* filename = new char[filename_size];
+      snprintf(filename, filename_size, "%s%d.v", gradient_filename_prefix.c_str(), count);
       OutputFileFormat<DiscretisedDensity<3, elemT>>::default_sptr()->write_to_file(filename, prior_gradient);
       delete[] filename;
     }

--- a/src/recon_buildblock/ML_estimate_component_based_normalisation.cxx
+++ b/src/recon_buildblock/ML_estimate_component_based_normalisation.cxx
@@ -135,7 +135,7 @@ ML_estimate_component_based_normalisation(const std::string& out_filename_prefix
 
       /* {
         char *out_filename = new char[20];
-        sprintf(out_filename, "%s_%d.out",
+        snprintf(out_filename, 20, "%s_%d.out",
         "fan", ax_pos_num);
         std::ofstream out(out_filename);
         out << data_fan_sums;
@@ -177,7 +177,7 @@ ML_estimate_component_based_normalisation(const std::string& out_filename_prefix
               iterate_efficiencies(efficiencies, data_fan_sums, fan_data);
               {
                 char* out_filename = new char[out_filename_prefix.size() + 30];
-                sprintf(out_filename, "%s_%s_%d_%d.out", out_filename_prefix.c_str(), "eff", iter_num, eff_iter_num);
+                snprintf(out_filename, out_filename_prefix.size() + 30, "%s_%s_%d_%d.out", out_filename_prefix.c_str(), "eff", iter_num, eff_iter_num);
                 std::ofstream out(out_filename);
                 out << efficiencies;
                 delete[] out_filename;
@@ -231,7 +231,7 @@ ML_estimate_component_based_normalisation(const std::string& out_filename_prefix
 
         {
           char* out_filename = new char[out_filename_prefix.size() + 30];
-          sprintf(out_filename, "%s_%s_%d.out", out_filename_prefix.c_str(), "geo", iter_num);
+          snprintf(out_filename, out_filename_prefix.size() + 30, "%s_%s_%d.out", out_filename_prefix.c_str(), "geo", iter_num);
           std::ofstream out(out_filename);
           out << norm_geo_data;
           delete[] out_filename;
@@ -266,7 +266,7 @@ ML_estimate_component_based_normalisation(const std::string& out_filename_prefix
 #endif
           {
             char* out_filename = new char[out_filename_prefix.size() + 30];
-            sprintf(out_filename, "%s_%s_%d.out", out_filename_prefix.c_str(), "block", iter_num);
+            snprintf(out_filename, out_filename_prefix.size() + 30, "%s_%s_%d.out", out_filename_prefix.c_str(), "block", iter_num);
             std::ofstream out(out_filename);
             out << norm_block_data;
             delete[] out_filename;

--- a/src/recon_buildblock/ML_estimate_component_based_normalisation.cxx
+++ b/src/recon_buildblock/ML_estimate_component_based_normalisation.cxx
@@ -177,7 +177,13 @@ ML_estimate_component_based_normalisation(const std::string& out_filename_prefix
               iterate_efficiencies(efficiencies, data_fan_sums, fan_data);
               {
                 char* out_filename = new char[out_filename_prefix.size() + 30];
-                snprintf(out_filename, out_filename_prefix.size() + 30, "%s_%s_%d_%d.out", out_filename_prefix.c_str(), "eff", iter_num, eff_iter_num);
+                snprintf(out_filename,
+                         out_filename_prefix.size() + 30,
+                         "%s_%s_%d_%d.out",
+                         out_filename_prefix.c_str(),
+                         "eff",
+                         iter_num,
+                         eff_iter_num);
                 std::ofstream out(out_filename);
                 out << efficiencies;
                 delete[] out_filename;
@@ -266,7 +272,8 @@ ML_estimate_component_based_normalisation(const std::string& out_filename_prefix
 #endif
           {
             char* out_filename = new char[out_filename_prefix.size() + 30];
-            snprintf(out_filename, out_filename_prefix.size() + 30, "%s_%s_%d.out", out_filename_prefix.c_str(), "block", iter_num);
+            snprintf(
+                out_filename, out_filename_prefix.size() + 30, "%s_%s_%d.out", out_filename_prefix.c_str(), "block", iter_num);
             std::ofstream out(out_filename);
             out << norm_block_data;
             delete[] out_filename;

--- a/src/recon_buildblock/ML_estimate_component_based_normalisation.cxx
+++ b/src/recon_buildblock/ML_estimate_component_based_normalisation.cxx
@@ -176,14 +176,10 @@ ML_estimate_component_based_normalisation(const std::string& out_filename_prefix
             {
               iterate_efficiencies(efficiencies, data_fan_sums, fan_data);
               {
-                char* out_filename = new char[out_filename_prefix.size() + 30];
-                snprintf(out_filename,
-                         out_filename_prefix.size() + 30,
-                         "%s_%s_%d_%d.out",
-                         out_filename_prefix.c_str(),
-                         "eff",
-                         iter_num,
-                         eff_iter_num);
+                const size_t filename_size = out_filename_prefix.size() + 30;
+                char* out_filename = new char[filename_size];
+                snprintf(
+                    out_filename, filename_size, "%s_%s_%d_%d.out", out_filename_prefix.c_str(), "eff", iter_num, eff_iter_num);
                 std::ofstream out(out_filename);
                 out << efficiencies;
                 delete[] out_filename;
@@ -236,8 +232,9 @@ ML_estimate_component_based_normalisation(const std::string& out_filename_prefix
 #endif
 
         {
-          char* out_filename = new char[out_filename_prefix.size() + 30];
-          snprintf(out_filename, out_filename_prefix.size() + 30, "%s_%s_%d.out", out_filename_prefix.c_str(), "geo", iter_num);
+          const size_t filename_size = out_filename_prefix.size() + 30;
+          char* out_filename = new char[filename_size];
+          snprintf(out_filename, filename_size, "%s_%s_%d.out", out_filename_prefix.c_str(), "geo", iter_num);
           std::ofstream out(out_filename);
           out << norm_geo_data;
           delete[] out_filename;
@@ -271,9 +268,9 @@ ML_estimate_component_based_normalisation(const std::string& out_filename_prefix
                  }
 #endif
           {
-            char* out_filename = new char[out_filename_prefix.size() + 30];
-            snprintf(
-                out_filename, out_filename_prefix.size() + 30, "%s_%s_%d.out", out_filename_prefix.c_str(), "block", iter_num);
+            const size_t filename_size = out_filename_prefix.size() + 30;
+            char* out_filename = new char[filename_size];
+            snprintf(out_filename, filename_size, "%s_%s_%d.out", out_filename_prefix.c_str(), "block", iter_num);
             std::ofstream out(out_filename);
             out << norm_block_data;
             delete[] out_filename;

--- a/src/recon_buildblock/PLSPrior.cxx
+++ b/src/recon_buildblock/PLSPrior.cxx
@@ -673,8 +673,9 @@ PLSPrior<elemT>::compute_gradient(DiscretisedDensity<3, elemT>& prior_gradient,
   ++count;
   if (gradient_filename_prefix.size() > 0)
     {
-      char* filename = new char[gradient_filename_prefix.size() + 100];
-      snprintf(filename, gradient_filename_prefix.size() + 100, "%s%d.v", gradient_filename_prefix.c_str(), count);
+      const size_t filename_size = gradient_filename_prefix.size() + 100;
+      char* filename = new char[filename_size];
+      snprintf(filename, filename_size, "%s%d.v", gradient_filename_prefix.c_str(), count);
       write_to_file(filename, prior_gradient);
       delete[] filename;
     }

--- a/src/recon_buildblock/PLSPrior.cxx
+++ b/src/recon_buildblock/PLSPrior.cxx
@@ -674,7 +674,7 @@ PLSPrior<elemT>::compute_gradient(DiscretisedDensity<3, elemT>& prior_gradient,
   if (gradient_filename_prefix.size() > 0)
     {
       char* filename = new char[gradient_filename_prefix.size() + 100];
-      sprintf(filename, "%s%d.v", gradient_filename_prefix.c_str(), count);
+      snprintf(filename, gradient_filename_prefix.size() + 100, "%s%d.v", gradient_filename_prefix.c_str(), count);
       write_to_file(filename, prior_gradient);
       delete[] filename;
     }

--- a/src/recon_buildblock/ProjMatrixByBin.cxx
+++ b/src/recon_buildblock/ProjMatrixByBin.cxx
@@ -273,9 +273,9 @@ void ProjMatrixByBin::write_to_file_by_bin(
                                       const char * const file_name_without_extension)
 { 
   char h_interfile[256];
-  sprintf (h_interfile, "%s.hp", file_name_without_extension );
+  snprintf (h_interfile, sizeof(h_interfile), "%s.hp", file_name_without_extension );
   FILE * prob_file = fopen (h_interfile , "wb");
-  sprintf (h_interfile, "%s.p", file_name_without_extension );
+  snprintf (h_interfile, sizeof(h_interfile), "%s.p", file_name_without_extension );
   fstream pout;
   open_write_binary(pout, h_interfile);
   

--- a/src/recon_buildblock/QuadraticPrior.cxx
+++ b/src/recon_buildblock/QuadraticPrior.cxx
@@ -376,7 +376,7 @@ QuadraticPrior<elemT>::compute_gradient(DiscretisedDensity<3, elemT>& prior_grad
   if (gradient_filename_prefix.size() > 0)
     {
       char* filename = new char[gradient_filename_prefix.size() + 100];
-      sprintf(filename, "%s%d.v", gradient_filename_prefix.c_str(), count);
+      snprintf(filename, gradient_filename_prefix.size() + 100, "%s%d.v", gradient_filename_prefix.c_str(), count);
       write_to_file(filename, prior_gradient);
       delete[] filename;
     }

--- a/src/recon_buildblock/QuadraticPrior.cxx
+++ b/src/recon_buildblock/QuadraticPrior.cxx
@@ -375,8 +375,9 @@ QuadraticPrior<elemT>::compute_gradient(DiscretisedDensity<3, elemT>& prior_grad
   ++count;
   if (gradient_filename_prefix.size() > 0)
     {
-      char* filename = new char[gradient_filename_prefix.size() + 100];
-      snprintf(filename, gradient_filename_prefix.size() + 100, "%s%d.v", gradient_filename_prefix.c_str(), count);
+      const size_t filename_size = gradient_filename_prefix.size() + 100;
+      char* filename = new char[filename_size];
+      snprintf(filename, filename_size, "%s%d.v", gradient_filename_prefix.c_str(), count);
       write_to_file(filename, prior_gradient);
       delete[] filename;
     }

--- a/src/recon_buildblock/QuadraticPrior.cxx
+++ b/src/recon_buildblock/QuadraticPrior.cxx
@@ -527,7 +527,7 @@ QuadraticPrior<elemT>::parabolic_surrogate_curvature(DiscretisedDensity<3, elemT
     static int count = 0;
     ++count;
     char filename[20];
-    sprintf(filename, "normalised_gradient%d.v",count);
+    snprintf(filename, sizeof(filename), "normalised_gradient%d.v",count);
     write_basic_interfile(filename, parabolic_surrogate_curvature);
   }*/
 }

--- a/src/recon_buildblock/RelativeDifferencePrior.cxx
+++ b/src/recon_buildblock/RelativeDifferencePrior.cxx
@@ -443,8 +443,9 @@ RelativeDifferencePrior<elemT>::compute_gradient(DiscretisedDensity<3, elemT>& p
   ++count;
   if (gradient_filename_prefix.size() > 0)
     {
-      char* filename = new char[gradient_filename_prefix.size() + 100];
-      snprintf(filename, gradient_filename_prefix.size() + 100, "%s%d.v", gradient_filename_prefix.c_str(), count);
+      const size_t filename_size = gradient_filename_prefix.size() + 100;
+      char* filename = new char[filename_size];
+      snprintf(filename, filename_size, "%s%d.v", gradient_filename_prefix.c_str(), count);
       write_to_file(filename, prior_gradient);
       delete[] filename;
     }

--- a/src/recon_buildblock/RelativeDifferencePrior.cxx
+++ b/src/recon_buildblock/RelativeDifferencePrior.cxx
@@ -444,7 +444,7 @@ RelativeDifferencePrior<elemT>::compute_gradient(DiscretisedDensity<3, elemT>& p
   if (gradient_filename_prefix.size() > 0)
     {
       char* filename = new char[gradient_filename_prefix.size() + 100];
-      sprintf(filename, "%s%d.v", gradient_filename_prefix.c_str(), count);
+      snprintf(filename, gradient_filename_prefix.size() + 100, "%s%d.v", gradient_filename_prefix.c_str(), count);
       write_to_file(filename, prior_gradient);
       delete[] filename;
     }

--- a/src/test/numerics/test_overlap_interpolate.cxx
+++ b/src/test/numerics/test_overlap_interpolate.cxx
@@ -116,18 +116,18 @@ private:
     for (int i = inboundaries.get_min_index(); i <= inboundaries.get_max_index(); ++i)
       inboundaries[i] = i - .5F;
     outvalues.set_min_index(outstartindex);
-    sprintf(out, "%s: inconsistent index sizes. Check test program", description);
+    snprintf(out, sizeof(out), "%s: inconsistent index sizes. Check test program", description);
     if (!check_if_equal(outvalues.get_max_index(), outendindex - 1, out))
       return Succeeded::no;
     VectorWithOffset<float> outboundaries(outstartindex, outendindex);
     for (int i = outboundaries.get_min_index(); i <= outboundaries.get_max_index(); ++i)
       outboundaries[i] = (i - .5F) / zoom + offset;
 
-    sprintf(out, "%s: test general overlap_interpolate", description);
+    snprintf(out, sizeof(out), "%s: test general overlap_interpolate", description);
     if (test_case(invalues, inboundaries, outvalues, outboundaries, out) == Succeeded::no)
       return Succeeded::no;
 
-    sprintf(out, "%s: test uniform overlap_interpolate", description);
+    snprintf(out, sizeof(out), "%s: test uniform overlap_interpolate", description);
     if (uniform_test_case(invalues, zoom, offset, outvalues, out) == Succeeded::no)
       return Succeeded::no;
     return Succeeded::yes;

--- a/src/test/test_display.cxx
+++ b/src/test/test_display.cxx
@@ -84,7 +84,7 @@ main()
         }
     }
   VectorWithOffset<char*> text(t.get_min_index(), t.get_max_index());
-  const std::size_t label_size = 15;
+  constexpr std::size_t label_size = 15;
   for (int i = t.get_min_index(); i <= t.get_max_index(); i++)
     {
       text[i] = new char[label_size];

--- a/src/test/test_display.cxx
+++ b/src/test/test_display.cxx
@@ -84,10 +84,11 @@ main()
         }
     }
   VectorWithOffset<char*> text(t.get_min_index(), t.get_max_index());
+  const std::size_t label_size = 15;
   for (int i = t.get_min_index(); i <= t.get_max_index(); i++)
     {
-      text[i] = new char[15];
-      sprintf(text[i], "image %d", i);
+      text[i] = new char[label_size];
+      snprintf(text[i], label_size, "image %d", i);
     }
 
   display(t, scale_factors, text, maxi, "Test display 3D all args", scale);

--- a/src/test/test_stir_math.cxx
+++ b/src/test/test_stir_math.cxx
@@ -139,11 +139,11 @@ stir_mathTests::run_tests()
     {
       char cmd_args[1000];
       snprintf(cmd_args,
-              sizeof(cmd_args),
-              "--add-scalar 3.1 --power 2 --times-scalar 3.2 --min-threshold %g --max-threshold %g "
-              "STIRtmpout.v STIRtmp1.hv STIRtmp2.hv STIRtmp3.hv",
-              min_threshold,
-              max_threshold);
+               sizeof(cmd_args),
+               "--add-scalar 3.1 --power 2 --times-scalar 3.2 --min-threshold %g --max-threshold %g "
+               "STIRtmpout.v STIRtmp1.hv STIRtmp2.hv STIRtmp3.hv",
+               min_threshold,
+               max_threshold);
       if (run_stir_math(cmd_args))
         {
           out_data_ptr = read_from_file<DiscretisedDensity<3, float>>("STIRtmpout.hv");
@@ -270,11 +270,11 @@ stir_mathTests::run_tests()
     {
       char cmd_args[1000];
       snprintf(cmd_args,
-              sizeof(cmd_args),
-              "-s --add-scalar 3.1 --power 2 --times-scalar 3.2 --min-threshold %g --max-threshold %g "
-              "STIRtmpout.hs STIRtmp1.hs STIRtmp2.hs STIRtmp3.hs",
-              min_threshold,
-              max_threshold);
+               sizeof(cmd_args),
+               "-s --add-scalar 3.1 --power 2 --times-scalar 3.2 --min-threshold %g --max-threshold %g "
+               "STIRtmpout.hs STIRtmp1.hs STIRtmp2.hs STIRtmp3.hs",
+               min_threshold,
+               max_threshold);
       if (run_stir_math(cmd_args))
         {
           out_data_ptr = ProjData::read_from_file("STIRtmpout.hs");

--- a/src/test/test_stir_math.cxx
+++ b/src/test/test_stir_math.cxx
@@ -138,7 +138,8 @@ stir_mathTests::run_tests()
     const float max_threshold = RAND_MAX / 2.F;
     {
       char cmd_args[1000];
-      sprintf(cmd_args,
+      snprintf(cmd_args,
+              sizeof(cmd_args),
               "--add-scalar 3.1 --power 2 --times-scalar 3.2 --min-threshold %g --max-threshold %g "
               "STIRtmpout.v STIRtmp1.hv STIRtmp2.hv STIRtmp3.hv",
               min_threshold,
@@ -268,7 +269,8 @@ stir_mathTests::run_tests()
     const float max_threshold = RAND_MAX / 2.F;
     {
       char cmd_args[1000];
-      sprintf(cmd_args,
+      snprintf(cmd_args,
+              sizeof(cmd_args),
               "-s --add-scalar 3.1 --power 2 --times-scalar 3.2 --min-threshold %g --max-threshold %g "
               "STIRtmpout.hs STIRtmp1.hs STIRtmp2.hs STIRtmp3.hs",
               min_threshold,

--- a/src/utilities/apply_normfactors.cxx
+++ b/src/utilities/apply_normfactors.cxx
@@ -83,7 +83,14 @@ main(int argc, char** argv)
       if (do_eff)
         {
           char* in_filename = new char[in_filename_prefix.size() + 30];
-          snprintf(in_filename, in_filename_prefix.size() + 30, "%s_%s_%d_%d_%d.out", in_filename_prefix.c_str(), "eff", ax_pos_num, iter_num, eff_iter_num);
+          snprintf(in_filename,
+                   in_filename_prefix.size() + 30,
+                   "%s_%s_%d_%d_%d.out",
+                   in_filename_prefix.c_str(),
+                   "eff",
+                   ax_pos_num,
+                   iter_num,
+                   eff_iter_num);
           std::ifstream in(in_filename);
           in >> efficiencies;
           if (!in)
@@ -100,7 +107,13 @@ main(int argc, char** argv)
         {
           {
             char* in_filename = new char[in_filename_prefix.size() + 30];
-            snprintf(in_filename, in_filename_prefix.size() + 30, "%s_%s_%d_%d.out", in_filename_prefix.c_str(), "geo", ax_pos_num, iter_num);
+            snprintf(in_filename,
+                     in_filename_prefix.size() + 30,
+                     "%s_%s_%d_%d.out",
+                     in_filename_prefix.c_str(),
+                     "geo",
+                     ax_pos_num,
+                     iter_num);
             std::ifstream in(in_filename);
             in >> norm_geo_data;
             if (!in)
@@ -117,7 +130,13 @@ main(int argc, char** argv)
         {
           {
             char* in_filename = new char[in_filename_prefix.size() + 30];
-            snprintf(in_filename, in_filename_prefix.size() + 30, "%s_%s_%d_%d.out", in_filename_prefix.c_str(), "block", ax_pos_num, iter_num);
+            snprintf(in_filename,
+                     in_filename_prefix.size() + 30,
+                     "%s_%s_%d_%d.out",
+                     in_filename_prefix.c_str(),
+                     "block",
+                     ax_pos_num,
+                     iter_num);
             std::ifstream in(in_filename);
             in >> norm_block_data;
             if (!in)

--- a/src/utilities/apply_normfactors.cxx
+++ b/src/utilities/apply_normfactors.cxx
@@ -83,7 +83,7 @@ main(int argc, char** argv)
       if (do_eff)
         {
           char* in_filename = new char[in_filename_prefix.size() + 30];
-          sprintf(in_filename, "%s_%s_%d_%d_%d.out", in_filename_prefix.c_str(), "eff", ax_pos_num, iter_num, eff_iter_num);
+          snprintf(in_filename, in_filename_prefix.size() + 30, "%s_%s_%d_%d_%d.out", in_filename_prefix.c_str(), "eff", ax_pos_num, iter_num, eff_iter_num);
           std::ifstream in(in_filename);
           in >> efficiencies;
           if (!in)
@@ -100,7 +100,7 @@ main(int argc, char** argv)
         {
           {
             char* in_filename = new char[in_filename_prefix.size() + 30];
-            sprintf(in_filename, "%s_%s_%d_%d.out", in_filename_prefix.c_str(), "geo", ax_pos_num, iter_num);
+            snprintf(in_filename, in_filename_prefix.size() + 30, "%s_%s_%d_%d.out", in_filename_prefix.c_str(), "geo", ax_pos_num, iter_num);
             std::ifstream in(in_filename);
             in >> norm_geo_data;
             if (!in)
@@ -117,7 +117,7 @@ main(int argc, char** argv)
         {
           {
             char* in_filename = new char[in_filename_prefix.size() + 30];
-            sprintf(in_filename, "%s_%s_%d_%d.out", in_filename_prefix.c_str(), "block", ax_pos_num, iter_num);
+            snprintf(in_filename, in_filename_prefix.size() + 30, "%s_%s_%d_%d.out", in_filename_prefix.c_str(), "block", ax_pos_num, iter_num);
             std::ifstream in(in_filename);
             in >> norm_block_data;
             if (!in)

--- a/src/utilities/apply_normfactors.cxx
+++ b/src/utilities/apply_normfactors.cxx
@@ -82,9 +82,10 @@ main(int argc, char** argv)
       // efficiencies
       if (do_eff)
         {
-          char* in_filename = new char[in_filename_prefix.size() + 30];
+          const size_t filename_size = in_filename_prefix.size() + 30;
+          char* in_filename = new char[filename_size];
           snprintf(in_filename,
-                   in_filename_prefix.size() + 30,
+                   filename_size,
                    "%s_%s_%d_%d_%d.out",
                    in_filename_prefix.c_str(),
                    "eff",
@@ -106,14 +107,9 @@ main(int argc, char** argv)
       if (do_geo)
         {
           {
-            char* in_filename = new char[in_filename_prefix.size() + 30];
-            snprintf(in_filename,
-                     in_filename_prefix.size() + 30,
-                     "%s_%s_%d_%d.out",
-                     in_filename_prefix.c_str(),
-                     "geo",
-                     ax_pos_num,
-                     iter_num);
+            const size_t filename_size = in_filename_prefix.size() + 30;
+            char* in_filename = new char[filename_size];
+            snprintf(in_filename, filename_size, "%s_%s_%d_%d.out", in_filename_prefix.c_str(), "geo", ax_pos_num, iter_num);
             std::ifstream in(in_filename);
             in >> norm_geo_data;
             if (!in)
@@ -129,14 +125,9 @@ main(int argc, char** argv)
       if (do_block)
         {
           {
-            char* in_filename = new char[in_filename_prefix.size() + 30];
-            snprintf(in_filename,
-                     in_filename_prefix.size() + 30,
-                     "%s_%s_%d_%d.out",
-                     in_filename_prefix.c_str(),
-                     "block",
-                     ax_pos_num,
-                     iter_num);
+            const size_t filename_size = in_filename_prefix.size() + 30;
+            char* in_filename = new char[filename_size];
+            snprintf(in_filename, filename_size, "%s_%s_%d_%d.out", in_filename_prefix.c_str(), "block", ax_pos_num, iter_num);
             std::ifstream in(in_filename);
             in >> norm_block_data;
             if (!in)

--- a/src/utilities/apply_normfactors3D.cxx
+++ b/src/utilities/apply_normfactors3D.cxx
@@ -70,14 +70,9 @@ main(int argc, char** argv)
     // efficiencies
     if (do_eff)
       {
-        char* in_filename = new char[in_filename_prefix.size() + 30];
-        snprintf(in_filename,
-                 in_filename_prefix.size() + 30,
-                 "%s_%s_%d_%d.out",
-                 in_filename_prefix.c_str(),
-                 "eff",
-                 iter_num,
-                 eff_iter_num);
+        const size_t filename_size = in_filename_prefix.size() + 30;
+        char* in_filename = new char[filename_size];
+        snprintf(in_filename, filename_size, "%s_%s_%d_%d.out", in_filename_prefix.c_str(), "eff", iter_num, eff_iter_num);
         std::ifstream in(in_filename);
         in >> norm.crystal_efficiencies();
         if (!in)
@@ -92,8 +87,9 @@ main(int argc, char** argv)
     if (do_geo)
       {
         {
-          char* in_filename = new char[in_filename_prefix.size() + 30];
-          snprintf(in_filename, in_filename_prefix.size() + 30, "%s_%s_%d.out", in_filename_prefix.c_str(), "geo", iter_num);
+          const size_t filename_size = in_filename_prefix.size() + 30;
+          char* in_filename = new char[filename_size];
+          snprintf(in_filename, filename_size, "%s_%s_%d.out", in_filename_prefix.c_str(), "geo", iter_num);
           std::ifstream in(in_filename);
           in >> norm.geometric_factors();
           if (!in)
@@ -109,8 +105,9 @@ main(int argc, char** argv)
     if (do_block)
       {
         {
-          char* in_filename = new char[in_filename_prefix.size() + 30];
-          snprintf(in_filename, in_filename_prefix.size() + 30, "%s_%s_%d.out", in_filename_prefix.c_str(), "block", iter_num);
+          const size_t filename_size = in_filename_prefix.size() + 30;
+          char* in_filename = new char[filename_size];
+          snprintf(in_filename, filename_size, "%s_%s_%d.out", in_filename_prefix.c_str(), "block", iter_num);
           std::ifstream in(in_filename);
           in >> norm.block_factors();
           if (!in)

--- a/src/utilities/apply_normfactors3D.cxx
+++ b/src/utilities/apply_normfactors3D.cxx
@@ -71,7 +71,7 @@ main(int argc, char** argv)
     if (do_eff)
       {
         char* in_filename = new char[in_filename_prefix.size() + 30];
-        sprintf(in_filename, "%s_%s_%d_%d.out", in_filename_prefix.c_str(), "eff", iter_num, eff_iter_num);
+        snprintf(in_filename, in_filename_prefix.size() + 30, "%s_%s_%d_%d.out", in_filename_prefix.c_str(), "eff", iter_num, eff_iter_num);
         std::ifstream in(in_filename);
         in >> norm.crystal_efficiencies();
         if (!in)
@@ -87,7 +87,7 @@ main(int argc, char** argv)
       {
         {
           char* in_filename = new char[in_filename_prefix.size() + 30];
-          sprintf(in_filename, "%s_%s_%d.out", in_filename_prefix.c_str(), "geo", iter_num);
+          snprintf(in_filename, in_filename_prefix.size() + 30, "%s_%s_%d.out", in_filename_prefix.c_str(), "geo", iter_num);
           std::ifstream in(in_filename);
           in >> norm.geometric_factors();
           if (!in)
@@ -104,7 +104,7 @@ main(int argc, char** argv)
       {
         {
           char* in_filename = new char[in_filename_prefix.size() + 30];
-          sprintf(in_filename, "%s_%s_%d.out", in_filename_prefix.c_str(), "block", iter_num);
+          snprintf(in_filename, in_filename_prefix.size() + 30, "%s_%s_%d.out", in_filename_prefix.c_str(), "block", iter_num);
           std::ifstream in(in_filename);
           in >> norm.block_factors();
           if (!in)

--- a/src/utilities/apply_normfactors3D.cxx
+++ b/src/utilities/apply_normfactors3D.cxx
@@ -71,7 +71,13 @@ main(int argc, char** argv)
     if (do_eff)
       {
         char* in_filename = new char[in_filename_prefix.size() + 30];
-        snprintf(in_filename, in_filename_prefix.size() + 30, "%s_%s_%d_%d.out", in_filename_prefix.c_str(), "eff", iter_num, eff_iter_num);
+        snprintf(in_filename,
+                 in_filename_prefix.size() + 30,
+                 "%s_%s_%d_%d.out",
+                 in_filename_prefix.c_str(),
+                 "eff",
+                 iter_num,
+                 eff_iter_num);
         std::ifstream in(in_filename);
         in >> norm.crystal_efficiencies();
         if (!in)

--- a/src/utilities/construct_randoms_from_singles.cxx
+++ b/src/utilities/construct_randoms_from_singles.cxx
@@ -65,14 +65,9 @@ main(int argc, char** argv)
 
     // efficiencies
     {
-      char* in_filename = new char[in_filename_prefix.size() + 30];
-      snprintf(in_filename,
-               in_filename_prefix.size() + 30,
-               "%s_%s_%d_%d.out",
-               in_filename_prefix.c_str(),
-               "eff",
-               iter_num,
-               eff_iter_num);
+      const size_t filename_size = in_filename_prefix.size() + 30;
+      char* in_filename = new char[filename_size];
+      snprintf(in_filename, filename_size, "%s_%s_%d_%d.out", in_filename_prefix.c_str(), "eff", iter_num, eff_iter_num);
       ifstream in(in_filename);
       in >> efficiencies;
       if (!in)

--- a/src/utilities/construct_randoms_from_singles.cxx
+++ b/src/utilities/construct_randoms_from_singles.cxx
@@ -66,7 +66,7 @@ main(int argc, char** argv)
     // efficiencies
     {
       char* in_filename = new char[in_filename_prefix.size() + 30];
-      sprintf(in_filename, "%s_%s_%d_%d.out", in_filename_prefix.c_str(), "eff", iter_num, eff_iter_num);
+      snprintf(in_filename, in_filename_prefix.size() + 30, "%s_%s_%d_%d.out", in_filename_prefix.c_str(), "eff", iter_num, eff_iter_num);
       ifstream in(in_filename);
       in >> efficiencies;
       if (!in)

--- a/src/utilities/construct_randoms_from_singles.cxx
+++ b/src/utilities/construct_randoms_from_singles.cxx
@@ -27,7 +27,7 @@
 #include <iostream>
 #include <fstream>
 #include <string>
-//#include <algorithm>
+// #include <algorithm>
 
 using std::cerr;
 using std::endl;
@@ -66,7 +66,13 @@ main(int argc, char** argv)
     // efficiencies
     {
       char* in_filename = new char[in_filename_prefix.size() + 30];
-      snprintf(in_filename, in_filename_prefix.size() + 30, "%s_%s_%d_%d.out", in_filename_prefix.c_str(), "eff", iter_num, eff_iter_num);
+      snprintf(in_filename,
+               in_filename_prefix.size() + 30,
+               "%s_%s_%d_%d.out",
+               in_filename_prefix.c_str(),
+               "eff",
+               iter_num,
+               eff_iter_num);
       ifstream in(in_filename);
       in >> efficiencies;
       if (!in)

--- a/src/utilities/correct_projdata.cxx
+++ b/src/utilities/correct_projdata.cxx
@@ -464,7 +464,7 @@ CorrectProjDataApplication::set_up()
       for ( int current_frame = 1; current_frame <= num_frames; current_frame++)
         {
           char ext[50];
-          sprintf(ext, "_f%dg1b0d0", current_frame);
+          snprintf(ext, sizeof(ext), "_f%dg1b0d0", current_frame);
           const string output_filename_with_ext = output_filename + ext;	
           output_projdata_ptr = new ProjDataInterfile(input_projdata_ptr->get_exam_info_sptr(), 
                   output_proj_data_info_sptr,output_filename_with_ext);
@@ -478,7 +478,7 @@ CorrectProjDataApplication::set_up()
       if (frame_definition_filename.size()!=0)
         {
           char ext[50];
-          sprintf(ext, "_f%dg1b0d0", frame_num);
+          snprintf(ext, sizeof(ext), "_f%dg1b0d0", frame_num);
           output_filename_with_ext += ext;
         }
 #endif

--- a/src/utilities/ecat/convecat6_if.cxx
+++ b/src/utilities/ecat/convecat6_if.cxx
@@ -162,15 +162,17 @@ main(int argc, char* argv[])
   switch (mhead.file_type)
     {
       case matImageFile: {
-        char* new_out_filename = new char[out_name.size() + 100];
+        const size_t max_filename_length = out_name.size() + 100;
+        char* new_out_filename = new char[max_filename_length];
         for (int frame_num = min_frame_num; frame_num <= max_frame_num; ++frame_num)
           for (int bed_num = min_bed_num; bed_num <= max_bed_num; ++bed_num)
             for (int gate_num = min_gate_num; gate_num <= max_gate_num; ++gate_num)
               {
                 strcpy(new_out_filename, out_name.c_str());
+                const size_t used = strnlen(new_out_filename, max_filename_length);
                 if (do_all)
-                  snprintf(new_out_filename + strlen(new_out_filename),
-                           out_name.size() + 100 - strlen(new_out_filename),
+                  snprintf(new_out_filename + used,
+                           max_filename_length - used,
                            "_f%dg%db%dd%d",
                            frame_num,
                            gate_num,
@@ -191,21 +193,24 @@ main(int argc, char* argv[])
         const int max_ring_diff = ask_num("Max ring diff to store (-1 == num_rings-1)", -1, 100, -1);
 
         const bool arccorrected = ask("Consider the data to be arc-corrected?", false);
-
-        char* new_out_filename = new char[out_name.size() + 100];
+        const size_t max_filename_length = out_name.size() + 100;
+        char* new_out_filename = new char[max_filename_length];
         for (int frame_num = min_frame_num; frame_num <= max_frame_num; ++frame_num)
           for (int bed_num = min_bed_num; bed_num <= max_bed_num; ++bed_num)
             for (int gate_num = min_gate_num; gate_num <= max_gate_num; ++gate_num)
               {
                 strcpy(new_out_filename, out_name.c_str());
                 if (do_all)
-                  snprintf(new_out_filename + strlen(new_out_filename),
-                           out_name.size() + 100 - strlen(new_out_filename),
-                           "_f%dg%db%dd%d",
-                           frame_num,
-                           gate_num,
-                           bed_num,
-                           data_num);
+                  {
+                    const size_t used = strnlen(new_out_filename, max_filename_length);
+                    snprintf(new_out_filename + used,
+                             max_filename_length - used,
+                             "_f%dg%db%dd%d",
+                             frame_num,
+                             gate_num,
+                             bed_num,
+                             data_num);
+                  }
                 cout << "Writing " << new_out_filename << endl;
                 ECAT6_to_PDFS(
                     frame_num, gate_num, data_num, bed_num, max_ring_diff, arccorrected, new_out_filename, cti_fptr, mhead);

--- a/src/utilities/ecat/convecat6_if.cxx
+++ b/src/utilities/ecat/convecat6_if.cxx
@@ -169,7 +169,13 @@ main(int argc, char* argv[])
               {
                 strcpy(new_out_filename, out_name.c_str());
                 if (do_all)
-                  sprintf(new_out_filename + strlen(new_out_filename), "_f%dg%db%dd%d", frame_num, gate_num, bed_num, data_num);
+                  snprintf(new_out_filename + strlen(new_out_filename),
+                           out_name.size() + 100 - strlen(new_out_filename),
+                           "_f%dg%db%dd%d",
+                           frame_num,
+                           gate_num,
+                           bed_num,
+                           data_num);
                 cout << "Writing " << new_out_filename << endl;
                 shared_ptr<VoxelsOnCartesianGrid<float>> image_ptr(
                     ECAT6_to_VoxelsOnCartesianGrid(frame_num, gate_num, data_num, bed_num, cti_fptr, mhead));
@@ -193,7 +199,13 @@ main(int argc, char* argv[])
               {
                 strcpy(new_out_filename, out_name.c_str());
                 if (do_all)
-                  sprintf(new_out_filename + strlen(new_out_filename), "_f%dg%db%dd%d", frame_num, gate_num, bed_num, data_num);
+                  snprintf(new_out_filename + strlen(new_out_filename),
+                           out_name.size() + 100 - strlen(new_out_filename),
+                           "_f%dg%db%dd%d",
+                           frame_num,
+                           gate_num,
+                           bed_num,
+                           data_num);
                 cout << "Writing " << new_out_filename << endl;
                 ECAT6_to_PDFS(
                     frame_num, gate_num, data_num, bed_num, max_ring_diff, arccorrected, new_out_filename, cti_fptr, mhead);

--- a/src/utilities/find_ML_normfactors.cxx
+++ b/src/utilities/find_ML_normfactors.cxx
@@ -232,9 +232,10 @@ main(int argc, char** argv)
               {
                 iterate_efficiencies(efficiencies, data_fan_sums, det_pair_data);
                 {
-                  char* out_filename = new char[out_filename_prefix.size() + 30];
+                  const size_t filename_size = out_filename_prefix.size() + 30;
+                  char* out_filename = new char[filename_size];
                   snprintf(out_filename,
-                           out_filename_prefix.size() + 30,
+                           filename_size,
                            "%s_%s_%d_%d_%d.out",
                            out_filename_prefix.c_str(),
                            "eff",
@@ -280,14 +281,9 @@ main(int argc, char** argv)
                     warning("norm geo 0 at a=%d b=%d measured value=%g\n", a, b, measured_geo_data[a][b]);
             }
             {
-              char* out_filename = new char[out_filename_prefix.size() + 30];
-              snprintf(out_filename,
-                       out_filename_prefix.size() + 30,
-                       "%s_%s_%d_%d.out",
-                       out_filename_prefix.c_str(),
-                       "geo",
-                       ax_pos_num,
-                       iter_num);
+              const size_t filename_size = out_filename_prefix.size() + 30;
+              char* out_filename = new char[filename_size];
+              snprintf(out_filename, filename_size, "%s_%s_%d_%d.out", out_filename_prefix.c_str(), "geo", ax_pos_num, iter_num);
               std::ofstream out(out_filename);
               out << norm_geo_data;
               delete[] out_filename;
@@ -325,14 +321,10 @@ main(int argc, char** argv)
                 }
               }
             {
-              char* out_filename = new char[out_filename_prefix.size() + 30];
-              snprintf(out_filename,
-                       out_filename_prefix.size() + 30,
-                       "%s_%s_%d_%d.out",
-                       out_filename_prefix.c_str(),
-                       "block",
-                       ax_pos_num,
-                       iter_num);
+              const size_t filename_size = out_filename_prefix.size() + 30;
+              char* out_filename = new char[filename_size];
+              snprintf(
+                  out_filename, filename_size, "%s_%s_%d_%d.out", out_filename_prefix.c_str(), "block", ax_pos_num, iter_num);
               std::ofstream out(out_filename);
               out << norm_block_data;
               delete[] out_filename;

--- a/src/utilities/find_ML_normfactors.cxx
+++ b/src/utilities/find_ML_normfactors.cxx
@@ -233,8 +233,14 @@ main(int argc, char** argv)
                 iterate_efficiencies(efficiencies, data_fan_sums, det_pair_data);
                 {
                   char* out_filename = new char[out_filename_prefix.size() + 30];
-                  snprintf(
-                      out_filename, out_filename_prefix.size() + 30, "%s_%s_%d_%d_%d.out", out_filename_prefix.c_str(), "eff", ax_pos_num, iter_num, eff_iter_num);
+                  snprintf(out_filename,
+                           out_filename_prefix.size() + 30,
+                           "%s_%s_%d_%d_%d.out",
+                           out_filename_prefix.c_str(),
+                           "eff",
+                           ax_pos_num,
+                           iter_num,
+                           eff_iter_num);
                   std::ofstream out(out_filename);
                   out << efficiencies;
                   delete[] out_filename;
@@ -275,7 +281,13 @@ main(int argc, char** argv)
             }
             {
               char* out_filename = new char[out_filename_prefix.size() + 30];
-              snprintf(out_filename, out_filename_prefix.size() + 30, "%s_%s_%d_%d.out", out_filename_prefix.c_str(), "geo", ax_pos_num, iter_num);
+              snprintf(out_filename,
+                       out_filename_prefix.size() + 30,
+                       "%s_%s_%d_%d.out",
+                       out_filename_prefix.c_str(),
+                       "geo",
+                       ax_pos_num,
+                       iter_num);
               std::ofstream out(out_filename);
               out << norm_geo_data;
               delete[] out_filename;
@@ -314,7 +326,13 @@ main(int argc, char** argv)
               }
             {
               char* out_filename = new char[out_filename_prefix.size() + 30];
-              snprintf(out_filename, out_filename_prefix.size() + 30, "%s_%s_%d_%d.out", out_filename_prefix.c_str(), "block", ax_pos_num, iter_num);
+              snprintf(out_filename,
+                       out_filename_prefix.size() + 30,
+                       "%s_%s_%d_%d.out",
+                       out_filename_prefix.c_str(),
+                       "block",
+                       ax_pos_num,
+                       iter_num);
               std::ofstream out(out_filename);
               out << norm_block_data;
               delete[] out_filename;

--- a/src/utilities/find_ML_normfactors.cxx
+++ b/src/utilities/find_ML_normfactors.cxx
@@ -201,7 +201,7 @@ main(int argc, char** argv)
           display(measured_block_data, "raw block data from measurements");
         /*{
           char *out_filename = new char[20];
-          sprintf(out_filename, "%s_%d.out",
+          snprintf(out_filename, 20, "%s_%d.out",
           "fan", ax_pos_num);
           std::ofstream out(out_filename);
           out << data_fan_sums;
@@ -233,8 +233,8 @@ main(int argc, char** argv)
                 iterate_efficiencies(efficiencies, data_fan_sums, det_pair_data);
                 {
                   char* out_filename = new char[out_filename_prefix.size() + 30];
-                  sprintf(
-                      out_filename, "%s_%s_%d_%d_%d.out", out_filename_prefix.c_str(), "eff", ax_pos_num, iter_num, eff_iter_num);
+                  snprintf(
+                      out_filename, out_filename_prefix.size() + 30, "%s_%s_%d_%d_%d.out", out_filename_prefix.c_str(), "eff", ax_pos_num, iter_num, eff_iter_num);
                   std::ofstream out(out_filename);
                   out << efficiencies;
                   delete[] out_filename;
@@ -275,7 +275,7 @@ main(int argc, char** argv)
             }
             {
               char* out_filename = new char[out_filename_prefix.size() + 30];
-              sprintf(out_filename, "%s_%s_%d_%d.out", out_filename_prefix.c_str(), "geo", ax_pos_num, iter_num);
+              snprintf(out_filename, out_filename_prefix.size() + 30, "%s_%s_%d_%d.out", out_filename_prefix.c_str(), "geo", ax_pos_num, iter_num);
               std::ofstream out(out_filename);
               out << norm_geo_data;
               delete[] out_filename;
@@ -314,7 +314,7 @@ main(int argc, char** argv)
               }
             {
               char* out_filename = new char[out_filename_prefix.size() + 30];
-              sprintf(out_filename, "%s_%s_%d_%d.out", out_filename_prefix.c_str(), "block", ax_pos_num, iter_num);
+              snprintf(out_filename, out_filename_prefix.size() + 30, "%s_%s_%d_%d.out", out_filename_prefix.c_str(), "block", ax_pos_num, iter_num);
               std::ofstream out(out_filename);
               out << norm_block_data;
               delete[] out_filename;

--- a/src/utilities/find_ML_singles_from_delayed.cxx
+++ b/src/utilities/find_ML_singles_from_delayed.cxx
@@ -178,7 +178,7 @@ main(int argc, char** argv)
             if (eff_iter_num == num_eff_iterations || (do_save_interval > 0 && eff_iter_num % do_save_interval == 0))
               {
                 char* out_filename = new char[out_filename_prefix.size() + 30];
-                sprintf(out_filename, "%s_%s_%d_%d.out", out_filename_prefix.c_str(), "eff", iter_num, eff_iter_num);
+                snprintf(out_filename, out_filename_prefix.size() + 30, "%s_%s_%d_%d.out", out_filename_prefix.c_str(), "eff", iter_num, eff_iter_num);
                 std::ofstream out(out_filename);
                 if (!out)
                   {

--- a/src/utilities/find_ML_singles_from_delayed.cxx
+++ b/src/utilities/find_ML_singles_from_delayed.cxx
@@ -178,7 +178,13 @@ main(int argc, char** argv)
             if (eff_iter_num == num_eff_iterations || (do_save_interval > 0 && eff_iter_num % do_save_interval == 0))
               {
                 char* out_filename = new char[out_filename_prefix.size() + 30];
-                snprintf(out_filename, out_filename_prefix.size() + 30, "%s_%s_%d_%d.out", out_filename_prefix.c_str(), "eff", iter_num, eff_iter_num);
+                snprintf(out_filename,
+                         out_filename_prefix.size() + 30,
+                         "%s_%s_%d_%d.out",
+                         out_filename_prefix.c_str(),
+                         "eff",
+                         iter_num,
+                         eff_iter_num);
                 std::ofstream out(out_filename);
                 if (!out)
                   {

--- a/src/utilities/find_ML_singles_from_delayed.cxx
+++ b/src/utilities/find_ML_singles_from_delayed.cxx
@@ -177,14 +177,10 @@ main(int argc, char** argv)
             iterate_efficiencies(efficiencies, data_fan_sums, max_ring_diff, half_fan_size);
             if (eff_iter_num == num_eff_iterations || (do_save_interval > 0 && eff_iter_num % do_save_interval == 0))
               {
-                char* out_filename = new char[out_filename_prefix.size() + 30];
-                snprintf(out_filename,
-                         out_filename_prefix.size() + 30,
-                         "%s_%s_%d_%d.out",
-                         out_filename_prefix.c_str(),
-                         "eff",
-                         iter_num,
-                         eff_iter_num);
+                const size_t filename_size = out_filename_prefix.size() + 30;
+                char* out_filename = new char[filename_size];
+                snprintf(
+                    out_filename, filename_size, "%s_%s_%d_%d.out", out_filename_prefix.c_str(), "eff", iter_num, eff_iter_num);
                 std::ofstream out(out_filename);
                 if (!out)
                   {

--- a/src/utilities/manip_projdata.cxx
+++ b/src/utilities/manip_projdata.cxx
@@ -189,7 +189,7 @@ do_math(enum options operation,
 
       case _display_view: { // display math buffer by View
         char title[100];
-        sprintf(title, "Segment %d", sino1.get_segment_num());
+        snprintf(title, sizeof(title), "Segment %d", sino1.get_segment_num());
         display(sino1, sino1.find_max(), title);
         if (ask("Display single viewgram?", false))
           {
@@ -205,7 +205,7 @@ do_math(enum options operation,
 
       case _display_sino: { // display math buffer by sinogram
         char title[100];
-        sprintf(title, "Segment %d", sino1.get_segment_num());
+        snprintf(title, sizeof(title), "Segment %d", sino1.get_segment_num());
         display(seg_sinogram, seg_sinogram.find_max());
         break;
       }
@@ -399,9 +399,9 @@ main(int argc, char* argv[])
               char output_buffer_filename[max_filename_length];
 
               ask_filename_with_extension(output_buffer_root, "Output to which file (without extension)?", "");
-              sprintf(output_buffer_filename, "%s.%s", output_buffer_root, "s");
+              snprintf(output_buffer_filename, max_filename_length, "%s.%s", output_buffer_root, "s");
               // TODO relies on write_basic_interfile_PDFS_header using .hs extension
-              sprintf(output_buffer_header, "%s.%s", output_buffer_root, "hs");
+              snprintf(output_buffer_header, max_filename_length, "%s.%s", output_buffer_root, "hs");
               shared_ptr<fstream> new_sino_ptr(new fstream);
               open_write_binary(*new_sino_ptr, output_buffer_filename);
               shared_ptr<ProjDataInfo> pdi_ptr = first_operand->get_proj_data_info_sptr()->create_shared_clone();


### PR DESCRIPTION
## Changes in this pull request
Current PR updates deprecated `sprintf` usage with `snprintf` and addresses #1586.

## Testing performed
Tested on MacOS (Apple Silicon) and CUDA-enabled Linux PCs.

## Related issues
Fixes #1586 


## Checklist before requesting a review
<!--Put an x between the [] when completed. Delete a line if not applicable. -->
  - [x] I have performed a self-review of my code
  - [x] The code builds and runs on my machine

## Contribution Notes

Please tick the following: 

 - [x] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in STIR (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License.
 - [ ] I (or my institution) have signed the STIR Contribution License Agreement (not required for small changes).
