### PR TITLE
Replace deprecated istrstream with istringstream

### DIFF
--- a/documentation/release_6.4.htm
+++ b/documentation/release_6.4.htm
@@ -99,6 +99,10 @@
       Minor fix to replace a deprecated <code>std::sprintf()</code> with <code>std::snprintf()</code>, see <a href="https://github.com/UCL/STIR/issues/1586">#1586</a>.<br>
       <a href="https://github.com/UCL/STIR/pull/1697">PR #1697</a>
     </li>
+    <li>
+      Minor fix to replace a deprecated <code>std::istrstream()</code> with <code>std::istringstream()</code>, see <a href="https://github.com/UCL/STIR/issues/1637">#1637</a>.<br>
+      <a href="https://github.com/UCL/STIR/pull/1698">PR #1698</a>
+    </li>
     <br>
   </ul>
 

--- a/src/buildblock/KeyParser.cxx
+++ b/src/buildblock/KeyParser.cxx
@@ -34,16 +34,13 @@
 #include <cstring>
 #include <cstdlib>
 #include "stir/warning.h"
-#include <strstream>
-#include <sstream>
 
 using std::ifstream;
 using std::cerr;
 using std::cout;
 using std::cin;
 using std::endl;
-using std::istrstream;
-using std::ostrstream;
+using std::istringstream;
 using std::vector;
 using std::string;
 // using std::map;
@@ -674,7 +671,7 @@ get_param_from_string(T& param, const string& s)
   if (cp == string::npos)
     return Succeeded::no;
 
-  istrstream str(s.c_str() + cp + 1);
+  istringstream str(s.c_str() + cp + 1);
   str >> param;
   return str.fail() ? Succeeded::no : Succeeded::yes;
 }
@@ -713,7 +710,7 @@ get_vparam_from_string(vector<T>& param, const string& s)
       const string::size_type start = s.find_first_not_of(" \t", cp + 1); // KT 07/10/2002 now also skips tabs
       if (start != string::npos)
         {
-          istrstream str(s.c_str() + start);
+          istringstream str(s.c_str() + start);
 
           if (s[start] == '{')
             str >> param;
@@ -739,7 +736,7 @@ get_vparam_from_string(VectorWithOffset<T>& param, const string& s)
       const string::size_type start = s.find_first_not_of(" \t", cp + 1); // KT 07/10/2002 now also skips tabs
       if (start != string::npos)
         {
-          istrstream str(s.c_str() + start);
+          istringstream str(s.c_str() + start);
 
           if (s[start] == '{')
             str >> param;

--- a/src/experimental/utilities/mode.cxx
+++ b/src/experimental/utilities/mode.cxx
@@ -12,7 +12,7 @@
     See STIR/LICENSE.txt for details
 */
 #include <fstream>
-#include <strstream>
+#include <sstream>
 #include <vector>
 #include <stdlib.h>
 
@@ -187,7 +187,7 @@ main(int argc, char** argv)
   while (argc > 0)
     {
       --argc;
-      istrstream s(*argv);
+      istringstream s(*argv);
       s >> (v[argc]);
       argv++;
     }


### PR DESCRIPTION
## Changes in this pull request

This pull request addresses the deprecation of `std::istrstream` described in #1637 by replacing the function with the recommended `std::istringstream` in `KeyParser.cxx` and  `mode.cxx`. This update improves compatibility with newer C++ standards and ensures better maintainability.

## Testing performed
Tested on MacOS (Apple Silicon) and CUDA-enabled Linux PCs.

## Related issues
Fixes #1637 


## Checklist before requesting a review
<!--Put an x between the [] when completed. Delete a line if not applicable. -->
  - [x] I have performed a self-review of my code
  - [x] The code builds and runs on my machine
  - [x] `documentation/release_XXX.md` has been updated with any functionality change (if applicable)

## Contribution Notes

Please tick the following: 

 - [x] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in STIR (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License.
 - [ ] I (or my institution) have signed the STIR Contribution License Agreement (not required for small changes).
