### PR TITLE
Fix buffer size issue

### DIFF
--- a/documentation/release_6.4.htm
+++ b/documentation/release_6.4.htm
@@ -103,6 +103,10 @@
       Minor fix to replace a deprecated <code>std::istrstream()</code> with <code>std::istringstream()</code>, see <a href="https://github.com/UCL/STIR/issues/1637">#1637</a>.<br>
       <a href="https://github.com/UCL/STIR/pull/1698">PR #1698</a>
     </li>
+    <li>
+      Fix to adjust buffer size in `manip_projdata.cxx` to account for appended extensions for file names.<br>
+      <a href="https://github.com/UCL/STIR/pull/1699">PR #1699</a>
+    </li>
     <br>
   </ul>
 

--- a/src/swig/numpy.i
+++ b/src/swig/numpy.i
@@ -40,6 +40,7 @@
 #define NO_IMPORT_ARRAY
 #endif
 #include "stdio.h"
+#include <string.h>
 #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 #include <numpy/arrayobject.h>
 %}
@@ -458,10 +459,10 @@
       for (i = 0; i < n-1; i++)
       {
         snprintf(s, sizeof(s), "%d, ", exact_dimensions[i]);
-        strcat(dims_str,s);
+        strncat(dims_str, s, sizeof(dims_str) - strlen(dims_str) - 1);
       }
       snprintf(s, sizeof(s), " or %d", exact_dimensions[n-1]);
-      strcat(dims_str,s);
+      strncat(dims_str, s, sizeof(dims_str) - strlen(dims_str) - 1);
       PyErr_Format(PyExc_TypeError,
                    "Array must have %s dimensions.  Given array has %d dimensions",
                    dims_str,
@@ -503,14 +504,14 @@
         {
           snprintf(s, sizeof(s), "%ld,", (long int)size[i]);
         }
-        strcat(desired_dims,s);
+        strncat(desired_dims, s, sizeof(desired_dims) - strlen(desired_dims) - 1);
       }
       len = strlen(desired_dims);
       desired_dims[len-1] = ']';
       for (i = 0; i < n; i++)
       {
         snprintf(s, sizeof(s), "%ld,", (long int)array_size(ary,i));
-        strcat(actual_dims,s);
+        strncat(actual_dims, s, sizeof(actual_dims) - strlen(actual_dims) - 1);
       }
       len = strlen(actual_dims);
       actual_dims[len-1] = ']';

--- a/src/swig/numpy.i
+++ b/src/swig/numpy.i
@@ -457,10 +457,10 @@
     {
       for (i = 0; i < n-1; i++)
       {
-        sprintf(s, "%d, ", exact_dimensions[i]);
+        snprintf(s, sizeof(s), "%d, ", exact_dimensions[i]);
         strcat(dims_str,s);
       }
-      sprintf(s, " or %d", exact_dimensions[n-1]);
+      snprintf(s, sizeof(s), " or %d", exact_dimensions[n-1]);
       strcat(dims_str,s);
       PyErr_Format(PyExc_TypeError,
                    "Array must have %s dimensions.  Given array has %d dimensions",
@@ -497,11 +497,11 @@
       {
         if (size[i] == -1)
         {
-          sprintf(s, "*,");
+          snprintf(s, sizeof(s), "*,");
         }
         else
         {
-          sprintf(s, "%ld,", (long int)size[i]);
+          snprintf(s, sizeof(s), "%ld,", (long int)size[i]);
         }
         strcat(desired_dims,s);
       }
@@ -509,7 +509,7 @@
       desired_dims[len-1] = ']';
       for (i = 0; i < n; i++)
       {
-        sprintf(s, "%ld,", (long int)array_size(ary,i));
+        snprintf(s, sizeof(s), "%ld,", (long int)array_size(ary,i));
         strcat(actual_dims,s);
       }
       len = strlen(actual_dims);

--- a/src/utilities/manip_projdata.cxx
+++ b/src/utilities/manip_projdata.cxx
@@ -35,7 +35,7 @@ This utility programme processes (interfile) sinogram data
 #include "stir/Sinogram.h"
 #include "stir/Viewgram.h"
 
-//#include "stir/Scanner.h"
+// #include "stir/Scanner.h"
 #include "stir/ArrayFunction.h"
 #include "stir/recon_array_functions.h"
 #include "stir/display.h"
@@ -395,7 +395,7 @@ main(int argc, char* argv[])
             {
               // operation result is a sinogram
 
-              char output_buffer_root[max_filename_length];
+              char output_buffer_root[max_filename_length - 3]; // to allow for extension
               char output_buffer_filename[max_filename_length];
 
               ask_filename_with_extension(output_buffer_root, "Output to which file (without extension)?", "");


### PR DESCRIPTION
## Changes in this pull request
1. Fixed the sizes of buffers used for filenames in `manip_projdata.cxx` to account for added extension characters. The warning can be observed in [gh actions ubuntu gcc](https://github.com/UCL/STIR/actions/runs/23426446407/job/68142253082) for `manip_projdata.cxx`.
2. Updated  one more use of `sprintf` to `snprintf` in `src/swig/numpy.i` following #1697. The warnings can be found in [gh actions macos clang21](https://github.com/UCL/STIR/actions/runs/23426446407/job/68142253086).

## Testing performed
Tested on local MacOS (Apple Silicon) and CUDA-enabled Linux PCs.
Tested using [github actions at denproc/STIR-1:master](https://github.com/denproc/STIR-1/actions/runs/23452107844) .

## Related issues
Follow up for #1586 


## Checklist before requesting a review
<!--Put an x between the [] when completed. Delete a line if not applicable. -->
  - [x] I have performed a self-review of my code
  - [x] I have implemented unit tests that cover any new or modified functionality (if applicable)
  - [x] The code builds and runs on my machine
  - [x] `documentation/release_XXX.md` has been updated with any functionality change (if applicable)

## Contribution Notes

Please tick the following: 

 - [x] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in STIR (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License.
 - [ ] I (or my institution) have signed the STIR Contribution License Agreement (not required for small changes).
