### PR TITLE
Add ORCiD for Matthew Strugari in CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -48,6 +48,7 @@ authors:
       affiliation:  ETH Zuerich
     - family-names: Strugari
       given-names:  Matthew
+      orcid:        'https://orcid.org/0000-0001-8045-9126'
       affiliation:  Dalhousie University (Canada)
     - family-names: Colombo
       given-names:  Matteo Neel


### PR DESCRIPTION
## Changes in this pull request
Added ORCID identifier for Matthew Strugari in CITATION.cff to enable proper metadata propagation to Zenodo/DataCite and ORCID auto-linking in future releases. This is a minimal metadata-only change affecting citation and DOI/ORCID linkage.

## Testing performed
Validated CITATION.cff syntax locally and confirmed ORCID URL format is correct.

## Related issues
N/A


## Checklist before requesting a review
  - [x] I have performed a self-review of my code
  - [ ] I have added docstrings/doxygen in line with the guidance in the developer guide
  - [ ] I have implemented unit tests that cover any new or modified functionality (if applicable)
  - [ ] The code builds and runs on my machine
  - [ ] `documentation/release_XXX.md` has been updated with any functionality change (if applicable)

## Contribution Notes

Please tick the following: 

 - [X] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in STIR (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License.
 - [ ] I (or my institution) have signed the STIR Contribution License Agreement (not required for small changes).
