### PR TITLE
Reduce redundancy in PETSIRD reading code

### DIFF
--- a/src/include/stir/listmode/CListModeDataPETSIRD.h
+++ b/src/include/stir/listmode/CListModeDataPETSIRD.h
@@ -104,7 +104,10 @@ public:
 
   SavedPosition save_get_position() override;
 
-  Succeeded reopen_and_prime();
+  //! Reopens the underlying reader and primes it at the first event block.
+  /*! Calls error() (which throws) if the file cannot be opened, the header cannot be read,
+      or no event time blocks are found in the file. */
+  void reopen_and_prime();
 
   Succeeded seek_to_event_block_index(std::size_t target_event_block_index) const;
 

--- a/src/include/stir/listmode/CListModeDataPETSIRD.h
+++ b/src/include/stir/listmode/CListModeDataPETSIRD.h
@@ -133,8 +133,6 @@ private:
   mutable bool curr_is_prompt = true;
   //! Whether the PETSIRD data contains delayed events.
   mutable bool m_has_delayeds;
-  //! Storing header
-  petsird::Header m_last_header;
   //! Shared PETSIRD scanner and acquisition information.
   shared_ptr<const PETSIRDInfo> petsird_info_sptr;
   //! Cursor used to restore the most recently saved reader position

--- a/src/include/stir/listmode/CListModeDataPETSIRD.h
+++ b/src/include/stir/listmode/CListModeDataPETSIRD.h
@@ -133,6 +133,8 @@ private:
   mutable bool curr_is_prompt = true;
   //! Whether the PETSIRD data contains delayed events.
   mutable bool m_has_delayeds;
+  //! Storing header
+  petsird::Header m_last_header;
   //! Shared PETSIRD scanner and acquisition information.
   shared_ptr<const PETSIRDInfo> petsird_info_sptr;
   //! Cursor used to restore the most recently saved reader position

--- a/src/listmode_buildblock/CListModeDataPETSIRD.cxx
+++ b/src/listmode_buildblock/CListModeDataPETSIRD.cxx
@@ -38,7 +38,7 @@ CListModeDataPETSIRD::CListModeDataPETSIRD(const std::string& listmode_filename,
   m_has_delayeds = header.scanner.delayed_events_are_stored;
 
   if (reset() == Succeeded::no)
-    error("CListModeDataPETSIRD: Could not open/prime the reader. Abort.");
+    error(format("CListModeDataPETSIRD: Could not read the PETSIRD header from file {}.", listmode_filename));
 
   petsird_info_sptr = std::make_shared<PETSIRDInfo>(header);
   auto stir_scanner_sptr = petsird_info_sptr->get_scanner_sptr();

--- a/src/listmode_buildblock/CListModeDataPETSIRD.cxx
+++ b/src/listmode_buildblock/CListModeDataPETSIRD.cxx
@@ -27,28 +27,10 @@ CListModeDataPETSIRD::CListModeDataPETSIRD(const std::string& listmode_filename,
 {
   CListModeDataBasedOnCoordinateMap::listmode_filename = listmode_filename;
 
-  petsird::Header header;
-  if (use_hdf5)
-    current_lm_data_ptr.reset(new petsird::hdf5::PETSIRDReader(listmode_filename));
-  else
-    current_lm_data_ptr.reset(new petsird::binary::PETSIRDReader(listmode_filename));
+  if (reset() == Succeeded::no)
+    error("CListModeDataPETSIRD: Could not open/prime the reader. Abort.");
 
-  current_lm_data_ptr->ReadHeader(header);
-
-  m_has_delayeds = header.scanner.delayed_events_are_stored;
-
-  // Get the first TimeBlock
-  if (!current_lm_data_ptr->ReadTimeBlocks(curr_time_block))
-    error("CListModeDataPETSIRD: Could not read the first TimeBlock. Abort.");
-
-  ++m_time_block_index;
-
-  if (std::holds_alternative<petsird::EventTimeBlock>(curr_time_block))
-    curr_event_block = std::get<petsird::EventTimeBlock>(curr_time_block);
-  else
-    error("CListModeDataPETSIRD: holds_alternative not true. Abort.");
-
-  petsird_info_sptr = std::make_shared<PETSIRDInfo>(header);
+  petsird_info_sptr = std::make_shared<PETSIRDInfo>(m_last_header);
   auto stir_scanner_sptr = petsird_info_sptr->get_scanner_sptr();
 
   int tof_mash_factor = 1;
@@ -189,68 +171,44 @@ CListModeDataPETSIRD::save_get_position()
 Succeeded
 CListModeDataPETSIRD::reopen_and_prime()
 {
-  // ensure PETSIRD state machine is satisfied
-  if (current_lm_data_ptr)
-    {
-      try
-        {
-          current_lm_data_ptr->Close();
-        }
-      catch (...)
-        {}
-    }
-  // current_lm_data_ptr.reset();
   if (use_hdf5)
     current_lm_data_ptr.reset(new petsird::hdf5::PETSIRDReader(this->listmode_filename));
   else
     current_lm_data_ptr.reset(new petsird::binary::PETSIRDReader(this->listmode_filename));
 
-  petsird::Header header;
-  current_lm_data_ptr->ReadHeader(header);
-  // m_eof_reached = false;
+  current_lm_data_ptr->ReadHeader(m_last_header); // read directly into the member
+  m_has_delayeds = m_last_header.scanner.delayed_events_are_stored;
+
   curr_event_in_event_block = 0;
   curr_is_prompt = true;
   m_time_block_index = 0;
-  // read until first EventTimeBlock
-  while (true)
-    {
-      if (!current_lm_data_ptr->ReadTimeBlocks(this->curr_time_block))
-        {
-          // m_eof_reached = true;
-          current_lm_data_ptr->Close();
-          return Succeeded::no;
-        }
-      if (std::holds_alternative<petsird::EventTimeBlock>(this->curr_time_block))
-        {
-          this->curr_event_block = std::get<petsird::EventTimeBlock>(this->curr_time_block);
-          return Succeeded::yes;
-        }
-    }
+
+  return seek_to_event_block_index(0);
 }
 
 Succeeded
 CListModeDataPETSIRD::seek_to_event_block_index(std::size_t target_event_block_index) const
 {
-  // assumes we are primed at event_block_index = 0
-  std::size_t idx = 0;
-  while (idx < target_event_block_index)
+  try
     {
-      // read next until EventTimeBlock
-      while (true)
+      while (m_time_block_index <= target_event_block_index)
         {
-          if (!current_lm_data_ptr->ReadTimeBlocks(this->curr_time_block))
+          if (!current_lm_data_ptr->ReadTimeBlocks(curr_time_block))
+            return Succeeded::no;
+          ++m_time_block_index;
+          if (std::holds_alternative<petsird::EventTimeBlock>(curr_time_block))
             {
-              // m_eof_reached = true;
-              current_lm_data_ptr->Close();
-              return Succeeded::no;
+              curr_event_block = std::get<petsird::EventTimeBlock>(curr_time_block);
+              if (m_time_block_index > target_event_block_index)
+                return Succeeded::yes;
             }
-          if (std::holds_alternative<petsird::EventTimeBlock>(this->curr_time_block))
-            break;
         }
-      this->curr_event_block = std::get<petsird::EventTimeBlock>(this->curr_time_block);
-      ++idx;
+      return Succeeded::yes;
     }
-  return Succeeded::yes;
+  catch (...)
+    {
+      return Succeeded::no;
+    }
 }
 
 Succeeded
@@ -283,56 +241,6 @@ CListModeDataPETSIRD::set_get_position(const SavedPosition& pos)
 Succeeded
 CListModeDataPETSIRD::reset()
 {
-  /* \todo Not sure if this is the best way to reset the reader.
-  It ensures we are in a clean state, but it might be slow if the file is large and/or on a slow disk.
-  */
-  // if (current_lm_data_ptr)
-  //   {
-  //     try
-  //       {
-  //         current_lm_data_ptr->Close();
-  //       }
-  //     catch (...)
-  //       {
-  //         // If Close throws, treat as failure (or swallow if you must)
-  //         return Succeeded::no;
-  //       }
-  //   }
-
-  if (use_hdf5)
-    current_lm_data_ptr.reset(new petsird::hdf5::PETSIRDReader(this->listmode_filename));
-  else
-    current_lm_data_ptr.reset(new petsird::binary::PETSIRDReader(this->listmode_filename));
-
-  petsird::Header header;
-  current_lm_data_ptr->ReadHeader(header);
-
-  curr_event_in_event_block = 0;
-  curr_is_prompt = true;
-  m_time_block_index = 0;
-
-  try
-    {
-      while (true)
-        {
-          info(format("Reading TimeBlock index {}", m_time_block_index), 2);
-          if (!current_lm_data_ptr->ReadTimeBlocks(this->curr_time_block))
-            return Succeeded::no;
-
-          ++m_time_block_index;
-
-          if (std::holds_alternative<petsird::EventTimeBlock>(this->curr_time_block))
-            {
-              this->curr_event_block = std::get<petsird::EventTimeBlock>(this->curr_time_block);
-              break;
-            }
-        }
-    }
-  catch (...)
-    {
-      return Succeeded::no;
-    }
-
-  return Succeeded::yes;
+  return reopen_and_prime();
 }
 END_NAMESPACE_STIR

--- a/src/listmode_buildblock/CListModeDataPETSIRD.cxx
+++ b/src/listmode_buildblock/CListModeDataPETSIRD.cxx
@@ -178,25 +178,24 @@ CListModeDataPETSIRD::save_get_position()
   return static_cast<SavedPosition>(m_saved_positions.size() - 1);
 }
 
-Succeeded
+void
 CListModeDataPETSIRD::reopen_and_prime()
 {
-  // current_lm_data_ptr.reset();
   if (use_hdf5)
     current_lm_data_ptr.reset(new petsird::hdf5::PETSIRDReader(this->listmode_filename));
   else
     current_lm_data_ptr.reset(new petsird::binary::PETSIRDReader(this->listmode_filename));
 
   petsird::Header header;
-  current_lm_data_ptr->ReadHeader(header);
-  // m_eof_reached = false;
+  current_lm_data_ptr->ReadHeader(header); // let it throw naturally if it fails
   m_has_delayeds = header.scanner.delayed_events_are_stored;
 
   curr_event_in_event_block = 0;
   curr_is_prompt = true;
   m_time_block_index = 0;
-  // read until first EventTimeBlock
-  return seek_to_event_block_index(0);
+
+  if (seek_to_event_block_index(0) == Succeeded::no)
+    error(format("CListModeDataPETSIRD: No event time blocks found in file {}.", listmode_filename));
 }
 
 Succeeded
@@ -255,6 +254,7 @@ CListModeDataPETSIRD::set_get_position(const SavedPosition& pos)
 Succeeded
 CListModeDataPETSIRD::reset()
 {
-  return reopen_and_prime();
+  reopen_and_prime();
+  return Succeeded::yes;
 }
 END_NAMESPACE_STIR

--- a/src/listmode_buildblock/CListModeDataPETSIRD.cxx
+++ b/src/listmode_buildblock/CListModeDataPETSIRD.cxx
@@ -34,7 +34,9 @@ CListModeDataPETSIRD::CListModeDataPETSIRD(const std::string& listmode_filename,
     current_lm_data_ptr.reset(new petsird::binary::PETSIRDReader(listmode_filename));
 
   current_lm_data_ptr->ReadHeader(header);
+
   m_has_delayeds = header.scanner.delayed_events_are_stored;
+
   if (reset() == Succeeded::no)
     error("CListModeDataPETSIRD: Could not open/prime the reader. Abort.");
 
@@ -65,6 +67,10 @@ CListModeDataPETSIRD::CListModeDataPETSIRD(const std::string& listmode_filename,
 Succeeded
 CListModeDataPETSIRD::open_lm_file() const
 {
+  // current_lm_data_ptr.reset(new petsird::hdf5::PETSIRDReader(listmode_filename));
+  // if (!current_lm_data_ptr->ReadTimeBlocks(curr_time_block))
+  //  return Succeeded::no;
+
   curr_event_block = std::get<petsird::EventTimeBlock>(curr_time_block);
   return Succeeded::yes;
 }
@@ -175,6 +181,7 @@ CListModeDataPETSIRD::save_get_position()
 Succeeded
 CListModeDataPETSIRD::reopen_and_prime()
 {
+  // current_lm_data_ptr.reset();
   if (use_hdf5)
     current_lm_data_ptr.reset(new petsird::hdf5::PETSIRDReader(this->listmode_filename));
   else
@@ -182,18 +189,20 @@ CListModeDataPETSIRD::reopen_and_prime()
 
   petsird::Header header;
   current_lm_data_ptr->ReadHeader(header);
+  // m_eof_reached = false;
   m_has_delayeds = header.scanner.delayed_events_are_stored;
 
   curr_event_in_event_block = 0;
   curr_is_prompt = true;
   m_time_block_index = 0;
-
+  // read until first EventTimeBlock
   return seek_to_event_block_index(0);
 }
 
 Succeeded
 CListModeDataPETSIRD::seek_to_event_block_index(std::size_t target_event_block_index) const
 {
+  // assumes we are primed at event_block_index = 0
   std::size_t idx = 0;
   while (true)
     {
@@ -202,6 +211,7 @@ CListModeDataPETSIRD::seek_to_event_block_index(std::size_t target_event_block_i
         {
           if (!current_lm_data_ptr->ReadTimeBlocks(this->curr_time_block))
             {
+              // m_eof_reached = true;
               current_lm_data_ptr->Close();
               return Succeeded::no;
             }

--- a/src/listmode_buildblock/CListModeDataPETSIRD.cxx
+++ b/src/listmode_buildblock/CListModeDataPETSIRD.cxx
@@ -27,10 +27,12 @@ CListModeDataPETSIRD::CListModeDataPETSIRD(const std::string& listmode_filename,
 {
   CListModeDataBasedOnCoordinateMap::listmode_filename = listmode_filename;
 
+  petsird::Header header;
   if (reset() == Succeeded::no)
     error("CListModeDataPETSIRD: Could not open/prime the reader. Abort.");
 
-  petsird_info_sptr = std::make_shared<PETSIRDInfo>(m_last_header);
+  current_lm_data_ptr->ReadHeader(header);
+  petsird_info_sptr = std::make_shared<PETSIRDInfo>(header);
   auto stir_scanner_sptr = petsird_info_sptr->get_scanner_sptr();
 
   int tof_mash_factor = 1;
@@ -176,8 +178,9 @@ CListModeDataPETSIRD::reopen_and_prime()
   else
     current_lm_data_ptr.reset(new petsird::binary::PETSIRDReader(this->listmode_filename));
 
-  current_lm_data_ptr->ReadHeader(m_last_header); // read directly into the member
-  m_has_delayeds = m_last_header.scanner.delayed_events_are_stored;
+  petsird::Header header;
+  current_lm_data_ptr->ReadHeader(header);
+  m_has_delayeds = header.scanner.delayed_events_are_stored;
 
   curr_event_in_event_block = 0;
   curr_is_prompt = true;

--- a/src/listmode_buildblock/CListModeDataPETSIRD.cxx
+++ b/src/listmode_buildblock/CListModeDataPETSIRD.cxx
@@ -234,8 +234,7 @@ CListModeDataPETSIRD::set_get_position(const SavedPosition& pos)
   // If you cached the actual blocks, you STILL must ensure the reader state
   // will not be used incorrectly. Easiest: reopen+seek anyway (robust),
   // then overwrite curr_* with cached data.
-  if (reopen_and_prime() == Succeeded::no)
-    return Succeeded::no;
+  reopen_and_prime();
   if (seek_to_event_block_index(c.time_block_index) == Succeeded::no)
     return Succeeded::no;
 

--- a/src/listmode_buildblock/CListModeDataPETSIRD.cxx
+++ b/src/listmode_buildblock/CListModeDataPETSIRD.cxx
@@ -28,10 +28,16 @@ CListModeDataPETSIRD::CListModeDataPETSIRD(const std::string& listmode_filename,
   CListModeDataBasedOnCoordinateMap::listmode_filename = listmode_filename;
 
   petsird::Header header;
+  if (use_hdf5)
+    current_lm_data_ptr.reset(new petsird::hdf5::PETSIRDReader(listmode_filename));
+  else
+    current_lm_data_ptr.reset(new petsird::binary::PETSIRDReader(listmode_filename));
+
+  current_lm_data_ptr->ReadHeader(header);
+  m_has_delayeds = header.scanner.delayed_events_are_stored;
   if (reset() == Succeeded::no)
     error("CListModeDataPETSIRD: Could not open/prime the reader. Abort.");
 
-  current_lm_data_ptr->ReadHeader(header);
   petsird_info_sptr = std::make_shared<PETSIRDInfo>(header);
   auto stir_scanner_sptr = petsird_info_sptr->get_scanner_sptr();
 
@@ -59,10 +65,6 @@ CListModeDataPETSIRD::CListModeDataPETSIRD(const std::string& listmode_filename,
 Succeeded
 CListModeDataPETSIRD::open_lm_file() const
 {
-  // current_lm_data_ptr.reset(new petsird::hdf5::PETSIRDReader(listmode_filename));
-  // if (!current_lm_data_ptr->ReadTimeBlocks(curr_time_block))
-  //  return Succeeded::no;
-
   curr_event_block = std::get<petsird::EventTimeBlock>(curr_time_block);
   return Succeeded::yes;
 }
@@ -192,25 +194,24 @@ CListModeDataPETSIRD::reopen_and_prime()
 Succeeded
 CListModeDataPETSIRD::seek_to_event_block_index(std::size_t target_event_block_index) const
 {
-  try
+  std::size_t idx = 0;
+  while (true)
     {
-      while (m_time_block_index <= target_event_block_index)
+      // read next until EventTimeBlock
+      while (true)
         {
-          if (!current_lm_data_ptr->ReadTimeBlocks(curr_time_block))
-            return Succeeded::no;
-          ++m_time_block_index;
-          if (std::holds_alternative<petsird::EventTimeBlock>(curr_time_block))
+          if (!current_lm_data_ptr->ReadTimeBlocks(this->curr_time_block))
             {
-              curr_event_block = std::get<petsird::EventTimeBlock>(curr_time_block);
-              if (m_time_block_index > target_event_block_index)
-                return Succeeded::yes;
+              current_lm_data_ptr->Close();
+              return Succeeded::no;
             }
+          if (std::holds_alternative<petsird::EventTimeBlock>(this->curr_time_block))
+            break;
         }
-      return Succeeded::yes;
-    }
-  catch (...)
-    {
-      return Succeeded::no;
+      this->curr_event_block = std::get<petsird::EventTimeBlock>(this->curr_time_block);
+      if (idx == target_event_block_index)
+        return Succeeded::yes;
+      ++idx;
     }
 }
 


### PR DESCRIPTION
<!-- Fill in most of this text, and delete what is not appropriate.
Please read and adhere to the [contribution guidelines](https://github.com/UCL/STIR/blob/master/CONTRIBUTING.md).
Did you sign the STIR Contribution License Agreement?
-->

## Changes in this pull request
Cleaned code as requested by @KrisThielemans. Tried to remove redundancy with minimal changes.

## Testing performed
Ran the convertor->binning to sinogram->every step to full quantification and everything seemed to be in order.
Testing this with 'incorrect' data could be worthwhile to check if the errors are correct.

## Related issues
<!-- Use keywords such as "fixes", "closes", see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->


## Checklist before requesting a review
<!--Put an x between the [] when completed. Delete a line if not applicable. -->
  - [x] I have performed a self-review of my code
  - [] I have added docstrings/doxygen in line with the guidance in the developer guide
  - [x] The code builds and runs on my machine

## Contribution Notes

Please tick the following: 

 - [x] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in STIR (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License.
